### PR TITLE
DOC formatting and commentting one example

### DIFF
--- a/deepinv/datasets/datagenerator.py
+++ b/deepinv/datasets/datagenerator.py
@@ -77,13 +77,16 @@ def generate_dataset(train_dataset, physics, save_dir, test_dataset=None, device
 
     n_train = min(len(train_dataset), max_datapoints)
     n_train_g = int(n_train/G)
-    
+
     if test_dataset is not None:
         n_test = min(len(test_dataset), max_datapoints)
         n_test_g = int(n_test/G)
 
+    datasets = []
     for g in range(G):
-        hf = h5py.File(f"{save_dir}/{dataset_filename}{g}.h5", 'w')
+        dataset_name = f"{save_dir}/{dataset_filename}{g}.h5"
+        hf = h5py.File(dataset_name, 'w')
+        datasets.append(dataset_name)
 
         hf.attrs['operator'] = physics[g].__class__.__name__
 
@@ -101,7 +104,7 @@ def generate_dataset(train_dataset, physics, save_dir, test_dataset=None, device
         for i, x in enumerate(tqdm(train_dataloader)):
             x = x[0] if isinstance(x, list) else x
             x = x.to(device)
-            
+
             # choose operator and generate measurement
             y = physics[g](x)
 
@@ -146,7 +149,7 @@ def generate_dataset(train_dataset, physics, save_dir, test_dataset=None, device
                 index = index + bsize
         hf.close()
 
-    print('Dataset has been saved in ' + str(save_dir))
+    print(f"Dataset has been saved in {save_dir}")
 
-    return
+    return datasets
 

--- a/examples/demo_dpir_deblur.py
+++ b/examples/demo_dpir_deblur.py
@@ -1,78 +1,128 @@
-import sys
-import numpy as np
-import deepinv as dinv
-import hdf5storage
+from pathlib import Path
+
 import torch
+import hdf5storage
+import numpy as np
 from torch.utils.data import DataLoader
-from deepinv.models.denoiser import Denoiser
-from deepinv.optim.data_fidelity import *
-from deepinv.optim.optimizers import *
-from deepinv.training_utils import test
 from torchvision import datasets, transforms
+
+import deepinv as dinv
+from deepinv.models.denoiser import Denoiser
+from deepinv.optim.data_fidelity import L2
+from deepinv.optim.optimizers import Optim
+from deepinv.training_utils import test
 from deepinv.utils.parameters import get_DPIR_params
 
+
+# Setup paths for data loading, results and checkpoints.
+ORIGINAL_DATA_DIR = Path("../datasets")
+DATA_DIR = Path("../measurments")
+RESULTS_DIR = Path("../results")
+CKPT_DIR = Path("../checkpoints")
+
+
+# Set the global random seed from pytorch to ensure
+# reproducibility of the example.
 torch.manual_seed(0)
 
-num_workers = 4 if torch.cuda.is_available() else 0  # set to 0 if using small cpu, else 4
-problem = 'deblur'
-G = 1
-ckpt_path = '../checkpoints/drunet_color.pth'
+
+# Setup the variable to fetch dataset and operators.
 denoiser_name = 'drunet'
-batch_size = 1
 dataset = 'set3c'
-dataset_path = f'../../datasets/{dataset}'
-dir = f'../datasets/{dataset}/{problem}/'
+ckpt_path = CKPT_DIR / 'drunet_color.pth'
+dataset_path = ORIGINAL_DATA_DIR / dataset
+measurment_dir = DATA_DIR / dataset / 'deblur'
+
+# Use parallel dataloader if using a GPU to fasten training, otherwise, as
+# all computes are on CPU, use synchronous dataloading.
+num_workers = 4 if torch.cuda.is_available() else 0
+
+# Parameters of the algorithm to solve the inverse problem
+batch_size = 1
 noise_level_img = 0.03
 max_iter = 8
 verbose = True
-early_stop = False 
+early_stop = False
 n_channels = 3
 train = False
 crit_conv = 'residual'
 thres_conv = 1e-4
 img_size = 256
 
+lamb, sigma_denoiser, stepsize, max_iter = get_DPIR_params(noise_level_img)
+params_algo = {'stepsize': stepsize, 'g_param': sigma_denoiser, 'lambda': lamb}
+
+# Generate a motion blur operator.
 kernels = hdf5storage.loadmat('../kernels/Levin09.mat')['kernels']
-filter_np = kernels[0,1].astype(np.float64)
+filter_np = kernels[0, 1].astype(np.float64)
 filter_torch = torch.from_numpy(filter_np).unsqueeze(0).unsqueeze(0)
-p = dinv.physics.BlurFFT(img_size = (3,img_size,img_size), filter=filter_torch, device=dinv.device, noise_model = dinv.physics.GaussianNoise(sigma=noise_level_img))
+p = dinv.physics.BlurFFT(
+    img_size=(3, img_size, img_size),
+    filter=filter_torch,
+    device=dinv.device,
+    noise_model=dinv.physics.GaussianNoise(sigma=noise_level_img)
+)
+
+# Select the data fidelity term
 data_fidelity = L2()
 
-val_transform = transforms.Compose([
-            transforms.ToTensor(),
- ])
-dataset = datasets.ImageFolder(root=dataset_path, transform=val_transform)
-dinv.datasets.generate_dataset(train_dataset=dataset, test_dataset=None,
-                               physics=p, device=dinv.device, save_dir=dir, max_datapoints=3,
-                               num_workers=num_workers)
-dataset = dinv.datasets.HDF5Dataset(path=f'{dir}/dinv_dataset0.h5', train=True)
-dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=num_workers, shuffle=False)
 
-
-model_spec = {'name': denoiser_name,
-              'args': {
-                    'in_channels':n_channels+1, 
-                    'out_channels':n_channels,
-                    'pretrained':ckpt_path, 
-                    'train': False, 
-                    'device':dinv.device
-                    }}
-
-
-lamb, sigma_denoiser, stepsize, max_iter = get_DPIR_params(noise_level_img)
-params_algo={'stepsize': stepsize, 'g_param': sigma_denoiser, 'lambda' : lamb}
-
+# Specify the prior
+model_spec = {
+    'name': denoiser_name,
+    'args': {
+        'in_channels': n_channels+1,
+        'out_channels': n_channels,
+        'pretrained': ckpt_path,
+        'train': False,
+        'device': dinv.device
+    }
+}
 prior = {'prox_g': Denoiser(model_spec)}
-model = Optim(algo_name = 'HQS', prior=prior, data_fidelity=data_fidelity, early_stop=early_stop,
-              max_iter=max_iter, crit_conv=crit_conv, thres_conv=thres_conv, backtracking=False, F_fn=None,
-              verbose=True, params_algo=params_algo)
 
-test(model=model,  # Safe because it has forward
+
+# Generate a dataset in a HDF5 folder in "{dir}/dinv_dataset0.h5'" and load it.
+val_transform = transforms.Compose([transforms.ToTensor()])
+dataset = datasets.ImageFolder(root=dataset_path, transform=val_transform)
+generated_datasets = dinv.datasets.generate_dataset(
+    train_dataset=dataset,
+    test_dataset=None,
+    physics=p,
+    device=dinv.device,
+    save_dir=measurment_dir,
+    max_datapoints=3,
+    num_workers=num_workers
+)
+dataset = dinv.datasets.HDF5Dataset(path=generated_datasets[0], train=True)
+dataloader = DataLoader(
+    dataset, batch_size=batch_size, num_workers=num_workers, shuffle=False
+)
+
+# isntanciate the algorithm class to solve the IP problem.
+model = Optim(
+    algo_name='HQS',
+    prior=prior,
+    data_fidelity=data_fidelity,
+    early_stop=early_stop,
+    max_iter=max_iter,
+    crit_conv=crit_conv,
+    thres_conv=thres_conv,
+    backtracking=False,
+    F_fn=None,
+    verbose=True,
+    params_algo=params_algo
+)
+
+# Evaluate the model on the problem. this will generate a figure saved in
+# '../results/results_pnp.png'
+test(
+    model=model,
     test_dataloader=dataloader,
     physics=p,
     device=dinv.device,
     plot=True,
     plot_input=True,
-    save_folder='../results/',
-    save_plot_path='../results/results_pnp.png',
-    verbose=verbose)
+    save_folder=str(RESULTS_DIR),
+    save_plot_path=str(RESULTS_DIR / 'results_pnp.png'),
+    verbose=verbose
+)


### PR DESCRIPTION
While talking with @matthieutrs, we did a pass on one example to try and improve the formatting:

- Add more comments to explain what is going on.
- Reorganize a bit, to have consistent blocks.
- Follow the pep8 standard for Python. Another option would be black (which can easily be automated). This makes the code more consistent and readable.

This example should not be merged as is, as it can probably be improved but I put it here so we can start discussing it.
Particular pain points were on getting the data/kernels and setting up the directory structure, but this can easily be improved with some automated loader that I think you are already discussing.
I would also recommend avoiding using `..` as a root for the data, as this might not go well when running this from `$HOME` or random locations. I would suggest using a default in `$HOME/deepinv_data`, that can be tweaked with a `DEEP_INV_DATA` env variable, and maybe with `XDG_DATA_HOME` which is a classical env variable for data storage on Unix system.

Note that for examples, a nice library is [`sphinx-gallery`](https://sphinx-gallery.github.io/stable/index.html) that automatize running example in a `sphinx`-based documentation. I can help you set this up next week in Lyon if you'd like.