### PR TITLE
fix: incorrect loss evaluation

### DIFF
--- a/deepinv/training_utils.py
+++ b/deepinv/training_utils.py
@@ -114,9 +114,8 @@ def train(
     loss_history = []
 
     for epoch in range(epochs):
-        if eval_dataloader:
-            eval_psnr_net.reset()
-        train_psnr_net.reset()
+        for meter in meters:
+            meter.reset()
         iterators = [iter(loader) for loader in train_dataloader]
         batches = len(train_dataloader[G - 1])
         for i in range(batches):


### PR DESCRIPTION
**Introduction**

The function `deepinv.train` takes a list of losses `losses` and when executed, during each epoch, it evaluates the losses and their total sum `loss_total`. All those quantities are written to the standard output, and the list of total sums `loss_history` is saved both into the checkpoint files and to wandb.

Currently, the function incorrectly computes the evaluated losses and their total sum, which affects the three outputs previously mentioned. That is shown in the illustration section. Moreover, this PR solves the bug as explained in the solution section.

**Illustrating the Bug**

Below is written a code snippet that illustrates the bug. The snippet consists in calling the function `deepinv.train` with a list of losses comprised of two instances of the class `DummyLoss`, allowing to show both the error in the evaluated losses and in their sum.

The dataset used for creating the training dataloader given to the function `deepinv.train` consists of a single entry. This implies that each loss is evaluated exactly once per epoch.

The class `DummyLoss` implements a loss that evaluates to 1 the first time it is called, to 2 the second time, to 3 the third time, and so on.

We executed the snippet using the current version of deepinv and obtained what follows. Among what is written to the standard output are the two evaluated losses corresponding to the first epochs: 1, 1.5, 2, 2.5, etc.; along with their sum: 2, 3, 4, 5, etc. Instead of these values, we expected to obtain those: 1, 2, 3, 4, etc. for the two evaluated losses and 2, 4, 6, 8, etc. for their sum. A raw portion of the standard output we obtained is written under the code snippet.

```python
import torch
import wandb
import deepinv
from deepinv.models import DnCNN
from deepinv.physics import Inpainting
from torch.nn import Module
from torch.utils.data import Dataset, DataLoader

wandb.init(project= "experiments")


class DummyDataset(Dataset):
    """A dataset with one random entry."""

    def __init__(self):
        super().__init__()
        self.x = torch.rand(1, 32, 32)
        self.y = torch.rand(1, 32, 32)

    def __len__(self):
        return 1

    def __getitem__(self, idx):
        return self.x, self.y


class DummyLoss(Module):
    """A loss whose value is equal to the number of times it got called."""

    def __init__(self):
        super().__init__()
        self.name = "dummy_loss"
        self.stack = []
        self.stack.append(torch.tensor(.0, requires_grad=True))

    def forward(self, x, y, *args, **kwargs):
        loss_val = self.stack[-1] + torch.tensor(1., requires_grad=True)
        self.stack.append(loss_val)
        return loss_val


device = "cpu"

dataset = DummyDataset()
model = DnCNN(in_channels=1, out_channels=1, depth=3, device="cpu", pretrained=None, train=True)
loss1 = DummyLoss()
loss2 = DummyLoss()
losses = [loss1, loss2]
physics = Inpainting((1, 32, 32))

dataloader = DataLoader(dataset, batch_size=1)
epochs = 9

optimizer = torch.optim.SGD(model.parameters(), lr=1)

deepinv.train(model=model,
      train_dataloader=dataloader,
      epochs=epochs,
      losses=losses,
      eval_dataloader=None,
      physics=physics,
      optimizer=optimizer,
      scheduler=None,
      device=device,
      ckp_interval=epochs,
      eval_interval=1,
      log_interval=1,
      save_path=".",
      verbose=False,
      unsupervised=False,
      plot_images=False,
      save_images=False,
      plot_metrics=False,
      wandb_vis=True,
      n_plot_max_wandb=8)

```

```
23-06-26-18:05:04       [1/9]   loss=2.00e+00   Loss_dummy_loss=1.00e+00        Loss_dummy_loss=1.00e+00        Train_psnr_model=0.00
23-06-26-18:05:04       [2/9]   loss=3.00e+00   Loss_dummy_loss=1.50e+00        Loss_dummy_loss=1.50e+00        Train_psnr_model=0.00
23-06-26-18:05:04       [3/9]   loss=4.00e+00   Loss_dummy_loss=2.00e+00        Loss_dummy_loss=2.00e+00        Train_psnr_model=0.00
23-06-26-18:05:04       [4/9]   loss=5.00e+00   Loss_dummy_loss=2.50e+00        Loss_dummy_loss=2.50e+00        Train_psnr_model=0.00
23-06-26-18:05:04       [5/9]   loss=6.00e+00   Loss_dummy_loss=3.00e+00        Loss_dummy_loss=3.00e+00        Train_psnr_model=0.00
23-06-26-18:05:04       [6/9]   loss=7.00e+00   Loss_dummy_loss=3.50e+00        Loss_dummy_loss=3.50e+00        Train_psnr_model=0.00
23-06-26-18:05:04       [7/9]   loss=8.00e+00   Loss_dummy_loss=4.00e+00        Loss_dummy_loss=4.00e+00        Train_psnr_model=0.00
23-06-26-18:05:04       [8/9]   loss=9.00e+00   Loss_dummy_loss=4.50e+00        Loss_dummy_loss=4.50e+00        Train_psnr_model=0.00
23-06-26-18:05:04       [9/9]   loss=1.00e+01   Loss_dummy_loss=5.00e+00        Loss_dummy_loss=5.00e+00        Train_psnr_model=0.00
```

**Solving the Bug**

Currently, the evaluated losses and their sum are computed using various instances of the class `deepinv.utils.AverageMeter`. Those instances are created at the beginning of the function but are mistakenly not reset at the beginning of new epochs. We tried adding the missing reset statements, then ran the code snippet a second time, and we finally obtained the expected results. Below is a raw portion of the standard output we got.

This PR consists in adding the currently missing reset statements, and in merging them with the present ones, by iterating over the list `meters`.

```
23-06-26-18:42:06       [1/9]   loss=2.00e+00   Loss_dummy_loss=1.00e+00        Loss_dummy_loss=1.00e+00    Train_psnr_model=0.00
23-06-26-18:42:06       [2/9]   loss=4.00e+00   Loss_dummy_loss=2.00e+00        Loss_dummy_loss=2.00e+00    Train_psnr_model=0.00
23-06-26-18:42:06       [3/9]   loss=6.00e+00   Loss_dummy_loss=3.00e+00        Loss_dummy_loss=3.00e+00    Train_psnr_model=0.00
23-06-26-18:42:06       [4/9]   loss=8.00e+00   Loss_dummy_loss=4.00e+00        Loss_dummy_loss=4.00e+00    Train_psnr_model=0.00
23-06-26-18:42:06       [5/9]   loss=1.00e+01   Loss_dummy_loss=5.00e+00        Loss_dummy_loss=5.00e+00    Train_psnr_model=0.00
23-06-26-18:42:06       [6/9]   loss=1.20e+01   Loss_dummy_loss=6.00e+00        Loss_dummy_loss=6.00e+00    Train_psnr_model=0.00
23-06-26-18:42:06       [7/9]   loss=1.40e+01   Loss_dummy_loss=7.00e+00        Loss_dummy_loss=7.00e+00    Train_psnr_model=0.00
23-06-26-18:42:06       [8/9]   loss=1.60e+01   Loss_dummy_loss=8.00e+00        Loss_dummy_loss=8.00e+00    Train_psnr_model=0.00
23-06-26-18:42:06       [9/9]   loss=1.80e+01   Loss_dummy_loss=9.00e+00        Loss_dummy_loss=9.00e+00    Train_psnr_model=0.00
```

**Checks to be done before submitting your PR**
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.md](../../CHANGELOG.md) (as applicable) (to come).
