### PR TITLE
grayscale drunet

### DIFF
--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -135,7 +135,10 @@ class DRUNet(nn.Module):
 
         if pretrained is not None:
             if pretrained == "download":
-                name = "drunet_color.pth"
+                if in_channels == 4:
+                    name = "drunet_color.pth"
+                elif in_channels == 2:
+                    name = "drunet_gray.pth"
                 url = online_weights_path() + name
                 ckpt_drunet = torch.hub.load_state_dict_from_url(
                     url, map_location=lambda storage, loc: storage, file_name=name

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -17,7 +17,7 @@ def imsize():
 
 
 @pytest.fixture
-def imsize_1d():
+def imsize_1_channel():
     h = 37
     w = 31
     c = 1
@@ -98,7 +98,7 @@ def test_denoiser(imsize, device, denoiser):
     assert x_hat.shape == x.shape
 
 
-model_list_1d = [
+model_list_1_channel = [
     "drunet",
     "dncnn",
     "waveletprior",
@@ -109,8 +109,8 @@ model_list_1d = [
 ]
 
 
-@pytest.mark.parametrize("denoiser", model_list_1d)
-def test_denoiser_1d(imsize_1d, device, denoiser):
+@pytest.mark.parametrize("denoiser", model_list_1_channel)
+def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
     if denoiser in ("waveletprior", "waveletdict"):
         try:
             import pytorch_wavelets
@@ -123,10 +123,10 @@ def test_denoiser_1d(imsize_1d, device, denoiser):
     torch.manual_seed(0)
     sigma = 0.2
     physics = dinv.physics.Denoising(dinv.physics.GaussianNoise(sigma))
-    x = torch.ones(imsize_1d, device=device).unsqueeze(0)
+    x = torch.ones(imsize_1_channel, device=device).unsqueeze(0)
     y = physics(x)
 
-    f = choose_denoiser(denoiser, imsize_1d).to(device)
+    f = choose_denoiser(denoiser, imsize_1_channel).to(device)
 
     x_hat = f(y, sigma)
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -16,6 +16,14 @@ def imsize():
     return c, h, w
 
 
+@pytest.fixture
+def imsize_1d():
+    h = 37
+    w = 31
+    c = 1
+    return c, h, w
+
+
 model_list = [
     "unet",
     "drunet",
@@ -84,6 +92,41 @@ def test_denoiser(imsize, device, denoiser):
     y = physics(x)
 
     f = choose_denoiser(denoiser, imsize).to(device)
+
+    x_hat = f(y, sigma)
+
+    assert x_hat.shape == x.shape
+
+
+model_list_1d = [
+    "drunet",
+    "dncnn",
+    "waveletprior",
+    "waveletdict",
+    "tgv",
+    "median",
+    "autoencoder",
+]
+
+
+@pytest.mark.parametrize("denoiser", model_list_1d)
+def test_denoiser_1d(imsize_1d, device, denoiser):
+    if denoiser in ("waveletprior", "waveletdict"):
+        try:
+            import pytorch_wavelets
+        except ImportError:
+            pytest.xfail(
+                "This test requires pytorch_wavelets. "
+                "It should be installed with `pip install"
+                "git+https://github.com/fbcotter/pytorch_wavelets.git`"
+            )
+    torch.manual_seed(0)
+    sigma = 0.2
+    physics = dinv.physics.Denoising(dinv.physics.GaussianNoise(sigma))
+    x = torch.ones(imsize_1d, device=device).unsqueeze(0)
+    y = physics(x)
+
+    f = choose_denoiser(denoiser, imsize_1d).to(device)
 
     x_hat = f(y, sigma)
 


### PR DESCRIPTION
Adding download of grayscale DRUNet + pytest models with 1 channel.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.md](../../CHANGELOG.md) (as applicable) (to come).
