### PR TITLE
changed normalization of CS class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,6 @@ Current (v0.0.2)
 
 New Features
 ^^^^^^^^^^^^
-- Changed norm of CS to 1/m (:gh:`72` by `Julian Tachella`_) - 21/07/2023
 - Added hard-threshold (:gh:`71` by `Matthieu Terris`_) - 18/07/2023
 - Added discord server (:gh:`64` by `Julian Tachella`_) - 10/07/2023
 - Added changelog file (:gh:`64` by `Julian Tachella`_) - 10/07/2023
@@ -21,6 +20,7 @@ Fixed
 
 Changed
 ^^^^^^^
+- Changed normalization CS and SPC to 1/m (:gh:`72` by `Julian Tachella`_) - 21/07/2023
 - Update docstring (:gh:`68` by `Samuel Hurault`_) - 12/07/2023
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,5 +29,5 @@ Authors
 
 .. _Julian Tachella: https://github.com/tachella
 .. _Jérémy Scanvic: https://github.com/jscanvic
-.. _Samuel Hurault:: https://github.com/samuro95
+.. _Samuel Hurault: https://github.com/samuro95
 .. _Matthieu Terris: https://github.com/matthieutrs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Current (v0.0.2)
 
 New Features
 ^^^^^^^^^^^^
+- Changed norm of CS to 1/m (:gh:`72` by `Julian Tachella`_) - 21/07/2023
 - Added hard-threshold (:gh:`71` by `Matthieu Terris`_) - 18/07/2023
 - Added discord server (:gh:`64` by `Julian Tachella`_) - 10/07/2023
 - Added changelog file (:gh:`64` by `Julian Tachella`_) - 10/07/2023

--- a/deepinv/physics/compressed_sensing.py
+++ b/deepinv/physics/compressed_sensing.py
@@ -103,11 +103,8 @@ class CompressedSensing(LinearPhysics):
             self.D = torch.nn.Parameter(self.D, requires_grad=False)
             self.mask = torch.nn.Parameter(self.mask, requires_grad=False)
         else:
-            A = np.random.randn(m, n) / np.sqrt(m)
-            A_dagger = np.linalg.pinv(A)
-            self._A = torch.from_numpy(A).type(dtype).to(device)
-            self._A_dagger = torch.from_numpy(A_dagger).type(dtype).to(device)
-
+            self._A = torch.randn((m, n), device=device) / np.sqrt(m)
+            self._A_dagger = torch.linalg.pinv(self._A)
             self._A = torch.nn.Parameter(self._A, requires_grad=False)
             self._A_dagger = torch.nn.Parameter(self._A_dagger, requires_grad=False)
             self._A_adjoint = (

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -41,7 +41,9 @@ def find_operator(name, device):
     if name == "CS":
         m = 30
         p = dinv.physics.CompressedSensing(m=m, img_shape=img_size, device=device)
-        norm = (1+np.sqrt(np.prod(img_size)/m))**2 - .7  # Marcenko-Pastur law, second term is a small n correction
+        norm = (
+            1 + np.sqrt(np.prod(img_size) / m)
+        ) ** 2 - 0.7  # Marcenko-Pastur law, second term is a small n correction
     elif name == "fastCS":
         p = dinv.physics.CompressedSensing(
             m=20, fast=True, channelwise=True, img_shape=img_size, device=device

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import deepinv as dinv
+import numpy as np
 
 
 @pytest.fixture
@@ -38,7 +39,9 @@ def find_operator(name, device):
     norm = 1
     torch.manual_seed(0)
     if name == "CS":
-        p = dinv.physics.CompressedSensing(m=30, img_shape=img_size, device=device)
+        m = 30
+        p = dinv.physics.CompressedSensing(m=m, img_shape=img_size, device=device)
+        norm = (1+np.sqrt(np.prod(img_size)/m))**2 - .7  # Marcenko-Pastur law, second term is a small n correction
     elif name == "fastCS":
         p = dinv.physics.CompressedSensing(
             m=20, fast=True, channelwise=True, img_shape=img_size, device=device

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -42,7 +42,7 @@ def find_operator(name, device):
         p = dinv.physics.CompressedSensing(m=m, img_shape=img_size, device=device)
         norm = (
             1 + np.sqrt(np.prod(img_size) / m)
-        ) ** 2 - 1.57  # Marcenko-Pastur law, second term is a small n correction
+        ) ** 2 - 0.75  # Marcenko-Pastur law, second term is a small n correction
     elif name == "fastCS":
         p = dinv.physics.CompressedSensing(
             m=20, fast=True, channelwise=True, img_shape=img_size, device=device
@@ -74,7 +74,7 @@ def find_operator(name, device):
         )
         norm = (
             1 + np.sqrt(np.prod(img_size) / m)
-        ) ** 2 - 2.5  # Marcenko-Pastur law, second term is a small n correction
+        ) ** 2 - 3.7  # Marcenko-Pastur law, second term is a small n correction
     elif name == "deblur":
         p = dinv.physics.Blur(
             dinv.physics.blur.gaussian_blur(sigma=(2, 0.1), angle=45.0), device=device
@@ -156,6 +156,9 @@ def test_operators_norm(name, device):
     :param device: (torch.device) cpu or cuda:x
     :return: asserts norm is in (.8,1.2)
     """
+    if name == "singlepixel" or name == "CS":
+        device = torch.device("cpu")
+
     torch.manual_seed(0)
     physics, imsize, norm_ref = find_operator(name, device)
     x = torch.randn(imsize, device=device).unsqueeze(0)

--- a/examples/unfolded/demo_LISTA.py
+++ b/examples/unfolded/demo_LISTA.py
@@ -73,7 +73,7 @@ num_workers = 4 if torch.cuda.is_available() else 0
 
 # Generate the compressed sensing measurement operator with 10x under-sampling factor.
 physics = dinv.physics.CompressedSensing(
-    m=78, img_shape=(n_channels, img_size, img_size), device=device
+    m=78, img_shape=(n_channels, img_size, img_size), fast=True, device=device
 )
 my_dataset_name = "demo_LISTA"
 n_images_max = (
@@ -130,7 +130,7 @@ data_fidelity = L2()
 max_iter = 30 if torch.cuda.is_available() else 10  # Number of unrolled iterations
 level = 2
 prior = [
-    PnP(denoiser=dinv.models.WaveletPrior(wv="db8", level=level).to(device))
+    PnP(denoiser=dinv.models.WaveletPrior(wv="db8", level=level, device=device))
     for i in range(max_iter)
 ]
 

--- a/examples/unfolded/demo_custom_prior_unfolded.py
+++ b/examples/unfolded/demo_custom_prior_unfolded.py
@@ -69,7 +69,7 @@ num_workers = 4 if torch.cuda.is_available() else 0
 
 # Generate the compressed sensing measurement operator with 10x under-sampling factor.
 physics = dinv.physics.CompressedSensing(
-    m=78, img_shape=(n_channels, img_size, img_size), device=device
+    m=78, img_shape=(n_channels, img_size, img_size), fast=True, device=device
 )
 my_dataset_name = "demo_LICP"
 n_images_max = (
@@ -258,10 +258,6 @@ test(
 # We now plot the weights of the network that were learned and check that they are different from their initialization
 # values. Note that ``g_param`` corresponds to :math:`1/\lambda` in the proximal gradient algorithm.
 #
-
-# %%
-# Plotting the trained parameters.
-# --------------------------------
 
 dinv.utils.plotting.plot_parameters(
     model, init_params=params_algo, save_dir=RESULTS_DIR / method / operation


### PR DESCRIPTION
- Changed normalization of CompressedSensing and SinglePhotonCamera to 1/m to match standard practices, e.g. [like in this paper](https://arxiv.org/abs/1907.04235).
- fixed some docstrings
- moved the generation from numpy to torch, such that setting the manual seed in torch fully controls the creation of the forward operators.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
