### PR TITLE
fix: log epoch loss instead of batch loss

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ New Features
 
 Fixed
 ^^^^^
+- Log epoch loss instead of batch loss (:gh:`73` by `Jérémy Scanvic`_) - 21/07/2023
 - Automatically disable backtracking is no explicit cost (:gh:`68` by `Samuel Hurault`_) - 12/07/2023
 - Added missing indent (:gh:`63` by `Jérémy Scanvic`_) - 12/07/2023
 

--- a/deepinv/training_utils.py
+++ b/deepinv/training_utils.py
@@ -190,10 +190,10 @@ def train(
         if scheduler:
             scheduler.step()
 
-        loss_history.append(loss_total.detach().cpu().numpy())
+        loss_history.append(loss_meter.avg)
 
         if wandb_vis:
-            wandb.log({"training loss": loss_total}, step=epoch)
+            wandb.log({"training loss": loss_meter.avg}, step=epoch)
 
         if (epoch + 1) % log_interval == 0:
             progress.display(epoch + 1)


### PR DESCRIPTION
When called, the function `deepinv.train` should log the average batch loss of each epoch to wandb and to the disk. However, for both records, what is actually logged in the current implementation is the latest batch loss of each epoch. In this PR, we fixed the two bugs by logging, in both cases, the value `loss_meter.avg` instead of `loss_total`.

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
