### PR TITLE
fix: call wandb.init only when needed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ New Features
 
 Fixed
 ^^^^^
+- Call `wandb.init` only when needed (:gh:`78` by `Jérémy Scanvic`_) - 09/08/2023
 - Log epoch loss instead of batch loss (:gh:`73` by `Jérémy Scanvic`_) - 21/07/2023
 - Automatically disable backtracking is no explicit cost (:gh:`68` by `Samuel Hurault`_) - 12/07/2023
 - Added missing indent (:gh:`63` by `Jérémy Scanvic`_) - 12/07/2023

--- a/deepinv/training_utils.py
+++ b/deepinv/training_utils.py
@@ -80,7 +80,8 @@ def train(
     save_path = Path(save_path)
 
     if wandb_vis:
-        wandb.init()
+        if wandb.run is None:
+            wandb.init()
 
     if not isinstance(losses, list) or isinstance(losses, tuple):
         losses = [losses]
@@ -271,7 +272,8 @@ def test(
     show_operators = 5
 
     if wandb_vis:
-        wandb.init()
+        if wandb.run is None:
+            wandb.init()
         psnr_data = []
 
     for g in range(G):


### PR DESCRIPTION
Currently, when the functions `deepinv.train` and `deepinv.test` are called, the function `wandb.init` is called no matter if a run is already active or not. The current behavior can lead to unexpected effects. Instead, a more predictable behavior would be to call the function `wandb.init` only if no run is already active, i.e. if either the function `wandb.init` was never called, or if the function `wandb.finish` was called after the last call to the function `wandb.init`; or equivalently if the variable `wandb.run` is equal to the value `None`. In this PR, we implemented the latter behavior.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
