### PR TITLE
Fix diffpir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ New Features
 
 Fixed
 ^^^^^
+- Minor fixes DiffPIR + other typos (:gh:`81` by `Matthieu Terris`_) - 10/09/2023
 - Call `wandb.init` only when needed (:gh:`78` by `Jérémy Scanvic`_) - 09/08/2023
 - Log epoch loss instead of batch loss (:gh:`73` by `Jérémy Scanvic`_) - 21/07/2023
 - Automatically disable backtracking is no explicit cost (:gh:`68` by `Samuel Hurault`_) - 12/07/2023

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -420,9 +420,11 @@ class IndicatorL2(DataFidelity):
 
                 t = x - physics.A_adjoint(u)
                 u_ = u + stepsize * physics.A(t)
-                u = u_ - stepsize * self.prox_d(u_ / stepsize, y, radius=radius)
+                u = u_ - stepsize * self.prox_d(
+                    u_ / stepsize, y, radius=radius, gamma=None
+                )
                 rel_crit = ((u - u_prev).norm()) / (u.norm() + 1e-12)
-                if rel_crit < crit_conv and it > 1:
+                if rel_crit < crit_conv:
                     break
             return t
 

--- a/deepinv/physics/compressed_sensing.py
+++ b/deepinv/physics/compressed_sensing.py
@@ -141,9 +141,8 @@ class CompressedSensing(LinearPhysics):
             N2 = N
 
         if self.fast:
-            # x = dct1(y)
             y2 = torch.zeros((N2, self.n), device=y.device)
-            y2[:, self.mask] = y
+            y2[:, self.mask] = y.type(y2.dtype)
             x = dst1(y2) * self.D
         else:
             x = torch.einsum("im, nm->in", y, self._A_adjoint)  # x:(N, n, 1)

--- a/deepinv/sampling/diffusion.py
+++ b/deepinv/sampling/diffusion.py
@@ -301,7 +301,12 @@ class DiffPIR(nn.Module):
         return idx
 
     def forward(
-        self, y, physics: deepinv.physics.LinearPhysics, sigma: float = None, seed=None
+        self,
+        y,
+        physics: deepinv.physics.LinearPhysics,
+        sigma: float = None,
+        seed=None,
+        x_init=None,
     ):
         r"""
         Runs the diffusion to obtain a random sample of the posterior distribution.
@@ -310,6 +315,7 @@ class DiffPIR(nn.Module):
         :param deepinv.physics.LinearPhysics physics: the physics operator.
         :param float sigma: the noise level of the data.
         :param int seed: the seed for the random number generator.
+        :param torch.Tensor x_init: the initial guess for the reconstruction.
         """
 
         if seed:
@@ -319,7 +325,10 @@ class DiffPIR(nn.Module):
             self.rhos, self.sigmas, self.seq = self.get_noise_schedule(sigma=sigma)
 
         # Initialization
-        x = 2 * y - 1
+        if x_init is None:  # Necessary when x and y don't live in the same space
+            x = 2 * y - 1
+        else:
+            x = 2 * x_init - 1
 
         for i in range(len(self.seq)):
             # Current noise level

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -160,10 +160,10 @@ def test_data_fidelity_indicator(device):
     physics = dinv.physics.LinearPhysics(A=A_forward, A_adjoint=A_adjoint)
 
     # Define the physics model associated to this operator
-    x_proj = torch.Tensor([[[0.5290], [2.9917]]]).to(device)
-    dfb_proj = data_fidelity.prox(x, y, physics)
-    assert torch.allclose(x_proj, dfb_proj)
-    assert torch.norm(A_forward(dfb_proj) - y) <= radius
+    x_proj = torch.Tensor([[[0.5290], [2.9932]]]).to(device)
+    dfb_proj = data_fidelity.prox(x, y, physics, max_iter=1000, crit_conv=1e-12)
+    assert torch.allclose(x_proj, dfb_proj, atol=1e-4)
+    assert torch.norm(A_forward(dfb_proj) - y) <= radius + 1e-06
 
 
 def test_data_fidelity_l1(device):

--- a/examples/basics/demo_physics_tour.py
+++ b/examples/basics/demo_physics_tour.py
@@ -163,7 +163,7 @@ physics = dinv.physics.Pansharpen(img_size=img_size, device=device)
 y = physics(x)
 
 # plot results
-plot([x, y[0], y[1]], titles=["signal", "high res gray", "low res rgb"])
+plot([x, y[0], y[1]], titles=["signal", "low res rgb", "high res gray"])
 
 # %%
 # Single-Pixel Camera


### PR DESCRIPTION
We propose a minor update to DiffPIR allowing to work with measurements in space different from that of the target image. Other typos are fixed.

note: it seems that the CNRS cloud repo is down, thus all the `Image.open(BytesIO(response.content))` resulting in failing docs atm

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
