### PR TITLE
Fix get_freer_gpu grep statement to work for different versions of nvidia-smi 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Fixed
 - Log epoch loss instead of batch loss (:gh:`73` by `Jérémy Scanvic`_) - 21/07/2023
 - Automatically disable backtracking is no explicit cost (:gh:`68` by `Samuel Hurault`_) - 12/07/2023
 - Added missing indent (:gh:`63` by `Jérémy Scanvic`_) - 12/07/2023
+- Fixed get_freer_gpu grep statement to work for different versions of nvidia-smi (:gh: `82` by `Alexander Mehta`_) - 20/09/2023
 
 
 Changed
@@ -37,3 +38,4 @@ Authors
 .. _Jérémy Scanvic: https://github.com/jscanvic
 .. _Samuel Hurault: https://github.com/samuro95
 .. _Matthieu Terris: https://github.com/matthieutrs
+.. _Alexander Mehta: https://github.com/alexmehta

--- a/deepinv/utils/nn.py
+++ b/deepinv/utils/nn.py
@@ -162,7 +162,7 @@ def get_freer_gpu():
 
     """
     try:
-        os.system("nvidia-smi -q -d Memory |grep -A4 GPU|grep Free >tmp")
+        os.system("nvidia-smi -q -d Memory |grep -A5 GPU|grep Free >tmp")
         memory_available = [int(x.split()[2]) for x in open("tmp", "r").readlines()]
         idx = np.argmax(memory_available)
         device = torch.device(f"cuda:{idx}")


### PR DESCRIPTION
In this PR I introduce a simple bug fix for the `get_freer_gpu` function. 

The grep statement in this function is problematic:

```nvidia-smi -q -d Memory |grep -A4 GPU|grep Free >tmp```

On some versions of nvidia-smi, this results in the "Free" label that is later referenced to be cut off. I just changed the `-A4` to `-A5` to address this. 


### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).