### PR TITLE
Physics train

### DIFF
--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -175,13 +175,18 @@ class DRUNet(nn.Module):
         Run the denoiser on image with noise level :math:`\sigma`.
 
         :param torch.Tensor x: noisy image
-        :param float sigma: noise level (not used)
+        :param float, torch.Tensor sigma: noise level. If ``sigma`` is a float, it is used for all images in the batch.
+            If ``sigma`` is a tensor, it must be of shape ``(batch_size,)``.
         """
-        noise_level_map = (
-            torch.FloatTensor(x.size(0), 1, x.size(2), x.size(3))
-            .fill_(sigma)
-            .to(x.device)
-        )
+        if not isinstance(sigma, torch.Tensor):
+            noise_level_map = (
+                torch.FloatTensor(x.size(0), 1, x.size(2), x.size(3))
+                .fill_(sigma)
+                .to(x.device)
+            )
+        else:
+            noise_level_map = sigma.view(x.size(0), 1, 1, 1)
+            noise_level_map = noise_level_map.expand(x.size(0), 1, x.size(2), x.size(3))
         x = torch.cat((x, noise_level_map), 1)
         if (
             x.size(2) // 8 == 0

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -259,7 +259,7 @@ class L2(DataFidelity):
 
     def grad_d(self, u, y):
         r"""
-        Computes the gradient of :math:`\distancename`  :math:`\nabla_{u}\distance{u}{y}`, i.e.
+        Computes the gradient of :math:`\distancename`, that is  :math:`\nabla_{u}\distance{u}{y}`, i.e.
 
         .. math::
 
@@ -293,20 +293,20 @@ class L2(DataFidelity):
 
     def prox(self, x, y, physics, gamma):
         r"""
-        Proximal operator of :math:`\gamma \data_fidelity_(x) = \frac{\gamma}{2\sigma^2}\|Ax-y\|^2`.
+        Proximal operator of :math:`\gamma \datafid{Ax}{y} = \frac{\gamma}{2\sigma^2}\|Ax-y\|^2`.
 
-        Computes :math:`\operatorname{prox}_{\gamma \data_fidelity_}`, i.e.
+        Computes :math:`\operatorname{prox}_{\gamma \datafidname}`, i.e.
 
         .. math::
 
-           \operatorname{prox}_{\gamma \data_fidelity_} = \underset{u}{\text{argmin}} \frac{\gamma}{2\sigma^2}\|Au-y\|_2^2+\frac{1}{2}\|u-x\|_2^2
+           \operatorname{prox}_{\gamma \datafidname} = \underset{u}{\text{argmin}} \frac{\gamma}{2\sigma^2}\|Au-y\|_2^2+\frac{1}{2}\|u-x\|_2^2
 
 
         :param torch.tensor x: Variable :math:`x` at which the proximity operator is computed.
         :param torch.tensor y: Data :math:`y`.
         :param deepinv.physics.Physics physics: physics model.
         :param float gamma: stepsize of the proximity operator.
-        :return: (torch.tensor) proximity operator :math:`\operatorname{prox}_{\gamma \data_fidelity_}(x)`.
+        :return: (torch.tensor) proximity operator :math:`\operatorname{prox}_{\gamma \datafidname}(x)`.
         """
         return physics.prox_l2(x, y, self.norm * gamma)
 

--- a/deepinv/physics/__init__.py
+++ b/deepinv/physics/__init__.py
@@ -4,7 +4,13 @@ from .blur import Blur, BlindBlur, Downsampling, BlurFFT
 from .range import Decolorize
 from .haze import Haze
 from .forward import Denoising, Physics, LinearPhysics, DecomposablePhysics
-from .noise import GaussianNoise, PoissonNoise, PoissonGaussianNoise, UniformNoise
+from .noise import (
+    GaussianNoise,
+    PoissonNoise,
+    PoissonGaussianNoise,
+    UniformNoise,
+    UniformGaussianNoise,
+)
 from .mri import MRI
 from .tomography import Tomography
 from .lidar import SinglePhotonLidar

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -110,6 +110,10 @@ class Physics(torch.nn.Module):  # parent class for forward models
             tol=self.tol,
         )
 
+    def reset(self, **kwargs):
+        if isinstance(self.noise_model, torch.nn.Module):
+            self.noise_model.__init__(**kwargs)
+
     def forward(self, x):
         r"""
         Computes forward operator :math:`y = N(A(x))` (with noise and/or sensor non-linearities)

--- a/deepinv/training_utils.py
+++ b/deepinv/training_utils.py
@@ -137,6 +137,7 @@ def train(
             for g in G_perm:
                 if fly_estimate:
                     x, _ = next(iterators[g])  # In this case the dataloader outputs also a class label
+                    x = x.to(device)
                     physics_cur = physics[g]
                     y = physics_cur(x)
                 else:

--- a/deepinv/training_utils.py
+++ b/deepinv/training_utils.py
@@ -140,9 +140,12 @@ def train(
 
             for g in G_perm:
                 if fly_estimate:
-                    x, _ = next(iterators[g])  # In this case the dataloader outputs also a class label
+                    x, _ = next(
+                        iterators[g]
+                    )  # In this case the dataloader outputs also a class label
                     x = x.to(device)
                     physics_cur = physics[g]
+                    physics_cur.reset()
                     y = physics_cur(x)
                 else:
                     if unsupervised:
@@ -188,14 +191,15 @@ def train(
                 if wandb_vis:
                     wandb.log({"training loss": loss_total.item()})
 
-        if wandb_vis:  # Note that this may not be 16 images because the last batch may be smaller
+        if (
+            wandb_vis
+        ):  # Note that this may not be 16 images because the last batch may be smaller
             in_image = physics_cur.A_adjoint(y)
             vis_array = torch.cat((in_image, x_net, x), dim=0)
             vis_array = torch.clip(vis_array, 0, 1)
-            grid_image = torchvision.utils.make_grid(vis_array, nrow=3)
+            grid_image = torchvision.utils.make_grid(vis_array, nrow=y.shape[0])
             images = wandb.Image(
-                grid_image,
-                caption="Top: Input, Middle: Output, Bottom: target"
+                grid_image, caption="Top: Input, Middle: Output, Bottom: target"
             )
             wandb.log({"Training samples": images})
 

--- a/deepinv/training_utils.py
+++ b/deepinv/training_utils.py
@@ -138,7 +138,7 @@ def train(
                 if fly_estimate:
                     x, _ = next(iterators[g])  # In this case the dataloader outputs also a class label
                     physics_cur = physics[g]
-                    y = physics(x)
+                    y = physics_cur(x)
                 else:
                     if unsupervised:
                         y = next(iterators[g])

--- a/deepinv/utils/demo.py
+++ b/deepinv/utils/demo.py
@@ -1,4 +1,3 @@
-import git
 import requests
 import shutil
 import os
@@ -45,6 +44,7 @@ class MRIData(torch.utils.data.Dataset):
 
 
 def get_git_root():
+    import git
     git_repo = git.Repo(".", search_parent_directories=True)
     git_root = git_repo.git.rev_parse("--show-toplevel")
     return git_root

--- a/deepinv/utils/demo.py
+++ b/deepinv/utils/demo.py
@@ -45,6 +45,7 @@ class MRIData(torch.utils.data.Dataset):
 
 def get_git_root():
     import git
+
     git_repo = git.Repo(".", search_parent_directories=True)
     git_root = git_repo.git.rev_parse("--show-toplevel")
     return git_root


### PR DESCRIPTION
Proposes a mild update in the base trainer to allow for non-fixed datasets. The core of the training loop in this case is simply:
```python
x, _ = batch  # batch variable only contains groundtruths
physics.reset()  # regenerate random elements in the physics process
y = physics(x) # generate measurements
out = model(y, physics) # apply model depending on physics
```

Side stuff:
- adding a physics noise model `UniformGaussianNoise` that generates Gaussian noise with standard deviation sampled uniformly at random - useful for training DRUNet
- moving git loading (raises error on nodes without internet access) #85 
- minor fix in the doc

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
