### PR TITLE
fix blur fft

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ New Features
 
 Fixed
 ^^^^^
+- Fix BlurFFT adjoint (:gh:`89` by `Matthieu Terris`_) - 15/10/2023
 - Minor fixes DiffPIR + other typos (:gh:`81` by `Matthieu Terris`_) - 10/09/2023
 - Call `wandb.init` only when needed (:gh:`78` by `Jérémy Scanvic`_) - 09/08/2023
 - Log epoch loss instead of batch loss (:gh:`73` by `Jérémy Scanvic`_) - 21/07/2023

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -482,7 +482,7 @@ class BlurFFT(DecomposablePhysics):
         # Romberg notes)
 
     def V(self, x):
-        return fft.irfft2(torch.view_as_complex(x), norm="ortho")
+        return fft.irfft2(torch.view_as_complex(x), norm="ortho", s=self.img_size[-2:])
 
 
 # # test code

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -76,10 +76,12 @@ def find_operator(name, device):
             1 + np.sqrt(np.prod(img_size) / m)
         ) ** 2 - 3.7  # Marcenko-Pastur law, second term is a small n correction
     elif name == "deblur":
+        img_size = (3, 17, 19)
         p = dinv.physics.Blur(
             dinv.physics.blur.gaussian_blur(sigma=(2, 0.1), angle=45.0), device=device
         )
     elif name == "deblur_fft":
+        img_size = (3, 17, 19)
         p = dinv.physics.BlurFFT(
             img_size=img_size,
             filter=dinv.physics.blur.gaussian_blur(sigma=(0.1, 0.5), angle=45.0),


### PR DESCRIPTION
Addresses #89, i.e. fix adjointness fail of BlurFFT in odd dimension.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
