### PR TITLE
TST improve optional deps test+MTN use conftest

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,4 @@
-name: docs
+name: Build docs
 
 # Runs on pushes targeting the default branch
 on:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Install deepinv and its dependencies
         run: |
-          pip install git+https://github.com/fbcotter/pytorch_wavelets.git#egg=pytorch_wavelets
           pip install -e .[denoisers,doc]
       - name: Sphinx build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Install deepinv and its dependencies
         run: |
-          pip install git+https://github.com/fbcotter/pytorch_wavelets.git#egg=pytorch_wavelets
           pip install -e .[${{ matrix.extra }}]
 
       - name: Test with pytest and generate coverage report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,14 @@ jobs:
     strategy:
       matrix:
         include:
+          # Test with all dependencies
           - os: ubuntu-latest
             version_python: 3.9
+            extra: denoisers,test
+          # Test with no optional dependencies
+          - os: ubuntu-latest
+            version_python: 3.9
+            extra: test
 
     env:
       VERSION_PYTHON: ${{ matrix.version_python }}
@@ -30,7 +36,7 @@ jobs:
       - name: Install deepinv and its dependencies
         run: |
           pip install git+https://github.com/fbcotter/pytorch_wavelets.git#egg=pytorch_wavelets
-          pip install -e .[denoisers,test]
+          pip install -e .[${{ matrix.extra }}]
 
       - name: Test with pytest and generate coverage report
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: Test DeepInv
+    name: Test DeepInv ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -19,10 +19,12 @@ jobs:
           - os: ubuntu-latest
             version_python: 3.9
             extra: denoisers,test
+            name: "all dependencies"
           # Test with no optional dependencies
           - os: ubuntu-latest
             version_python: 3.9
             extra: test
+            name: "no optional dependencies"
 
     env:
       VERSION_PYTHON: ${{ matrix.version_python }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,7 @@ Fixed
 
 Changed
 ^^^^^^^
-- Update CI (:gh:`95` by `Thomas Moreau`_) - 24/10/2023
+- Update CI (:gh:`95` :gh:`99` by `Thomas Moreau`_) - 24/10/2023
 - Changed normalization CS and SPC to 1/m (:gh:`72` by `Julian Tachella`_) - 21/07/2023
 - Update docstring (:gh:`68` by `Samuel Hurault`_) - 12/07/2023
 

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ If you have any questions or suggestions, please join the conversation in our
 .. |Test Status| image:: https://github.com/deepinv/deepinv/actions/workflows/test.yml/badge.svg
    :target: https://github.com/deepinv/deepinv/actions/workflows/test.yml
 .. |Docs Status| image:: https://github.com/deepinv/deepinv/actions/workflows/documentation.yaml/badge.svg
-   :target: https://github.com/deepinv/deepinv/actions/workflows/documentation.yaml
+   :target: https://github.com/deepinv/deepinv/actions/workflows/documentation.yml
 .. |Python 3.6+| image:: https://img.shields.io/badge/python-3.6%2B-blue
    :target: https://www.python.org/downloads/release/python-360/
 .. |codecov| image:: https://codecov.io/gh/deepinv/deepinv/branch/main/graph/badge.svg?token=77JRvUhQzh

--- a/deepinv/models/bm3d.py
+++ b/deepinv/models/bm3d.py
@@ -1,14 +1,12 @@
-import warnings
-
 import numpy as np
 import torch
 import torch.nn as nn
 
-try:  # install of BM3D may fail on some architectures (arm64)
+# Compat for optional dependency on BM3D
+try:
     import bm3d
-except ImportError:
-    bm3d = None
-    raise warnings.warn("Could not import bm3d. ")
+except ImportError as e:
+    bm3d = e
 
 
 class BM3D(nn.Module):
@@ -27,10 +25,10 @@ class BM3D(nn.Module):
 
     def __init__(self):
         super().__init__()
-        if bm3d is None:
+        if isinstance(bm3d, ImportError):
             raise ImportError(
                 "BM3D denoiser not available. Please install the bm3d package with `pip install bm3d`."
-            )
+            ) from bm3d
 
     def forward(self, x, sigma):
         r"""

--- a/deepinv/models/scunet.py
+++ b/deepinv/models/scunet.py
@@ -9,6 +9,7 @@ from .denoiser import online_weights_path
 # Compatibility with optional dependency on timm
 try:
     import timm
+    from timm.models.layers import trunc_normal_, DropPath
 except ImportError as e:
     timm = e
 
@@ -38,7 +39,7 @@ class WMSA(nn.Module):
 
         self.linear = nn.Linear(self.input_dim, self.output_dim)
 
-        timm.models.layers.trunc_normal_(self.relative_position_params, std=0.02)
+        trunc_normal_(self.relative_position_params, std=0.02)
         self.relative_position_params = torch.nn.Parameter(
             self.relative_position_params.view(
                 2 * window_size - 1, 2 * window_size - 1, self.n_heads
@@ -184,7 +185,7 @@ class Block(nn.Module):
         )
         self.ln1 = nn.LayerNorm(input_dim)
         self.msa = WMSA(input_dim, input_dim, head_dim, window_size, self.type)
-        self.drop_path = timm.DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
         self.ln2 = nn.LayerNorm(input_dim)
         self.mlp = nn.Sequential(
             nn.Linear(input_dim, 4 * input_dim),
@@ -471,7 +472,7 @@ class SCUNet(nn.Module):
 
     def _init_weights(self, m):
         if isinstance(m, nn.Linear):
-            timm.models.layers.trunc_normal_(m.weight, std=0.02)
+            trunc_normal_(m.weight, std=0.02)
             if m.bias is not None:
                 nn.init.constant_(m.bias, 0)
         elif isinstance(m, nn.LayerNorm):

--- a/deepinv/models/scunet.py
+++ b/deepinv/models/scunet.py
@@ -38,7 +38,7 @@ class WMSA(nn.Module):
 
         self.linear = nn.Linear(self.input_dim, self.output_dim)
 
-        timm.trunc_normal_(self.relative_position_params, std=0.02)
+        timm.models.layers.trunc_normal_(self.relative_position_params, std=0.02)
         self.relative_position_params = torch.nn.Parameter(
             self.relative_position_params.view(
                 2 * window_size - 1, 2 * window_size - 1, self.n_heads
@@ -471,7 +471,7 @@ class SCUNet(nn.Module):
 
     def _init_weights(self, m):
         if isinstance(m, nn.Linear):
-            timm.trunc_normal_(m.weight, std=0.02)
+            timm.models.layers.trunc_normal_(m.weight, std=0.02)
             if m.bias is not None:
                 nn.init.constant_(m.bias, 0)
         elif isinstance(m, nn.LayerNorm):

--- a/deepinv/models/swinir.py
+++ b/deepinv/models/swinir.py
@@ -139,7 +139,7 @@ class WindowAttention(nn.Module):
 
         self.proj_drop = nn.Dropout(proj_drop)
 
-        timm.trunc_normal_(self.relative_position_bias_table, std=0.02)
+        timm.models.layers.trunc_normal_(self.relative_position_bias_table, std=0.02)
         self.softmax = nn.Softmax(dim=-1)
 
     def forward(self, x, mask=None):
@@ -262,7 +262,7 @@ class SwinTransformerBlock(nn.Module):
         self.norm1 = norm_layer(dim)
         self.attn = WindowAttention(
             dim,
-            window_size=timm.to_2tuple(self.window_size),
+            window_size=timm.models.layers.to_2tuple(self.window_size),
             num_heads=num_heads,
             qkv_bias=qkv_bias,
             qk_scale=qk_scale,
@@ -270,7 +270,7 @@ class SwinTransformerBlock(nn.Module):
             proj_drop=drop,
         )
 
-        self.drop_path = timm.DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.drop_path = timm.models.layers.DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
         self.mlp = Mlp(
@@ -665,8 +665,8 @@ class PatchEmbed(nn.Module):
         self, img_size=224, patch_size=4, in_chans=3, embed_dim=96, norm_layer=None
     ):
         super().__init__()
-        img_size = timm.to_2tuple(img_size)
-        patch_size = timm.to_2tuple(patch_size)
+        img_size = timm.models.layers.to_2tuple(img_size)
+        patch_size = timm.models.layers.to_2tuple(patch_size)
         patches_resolution = [
             img_size[0] // patch_size[0],
             img_size[1] // patch_size[1],
@@ -713,8 +713,8 @@ class PatchUnEmbed(nn.Module):
         self, img_size=224, patch_size=4, in_chans=3, embed_dim=96, norm_layer=None
     ):
         super().__init__()
-        img_size = timm.to_2tuple(img_size)
-        patch_size = timm.to_2tuple(patch_size)
+        img_size = timm.models.layers.to_2tuple(img_size)
+        patch_size = timm.models.layers.to_2tuple(patch_size)
         patches_resolution = [
             img_size[0] // patch_size[0],
             img_size[1] // patch_size[1],
@@ -909,7 +909,7 @@ class SwinIR(nn.Module):
             self.absolute_pos_embed = nn.Parameter(
                 torch.zeros(1, num_patches, embed_dim)
             )
-            timm.trunc_normal_(self.absolute_pos_embed, std=0.02)
+            timm.models.layers.trunc_normal_(self.absolute_pos_embed, std=0.02)
 
         self.pos_drop = nn.Dropout(p=drop_rate)
 
@@ -1036,7 +1036,7 @@ class SwinIR(nn.Module):
 
     def _init_weights(self, m):
         if isinstance(m, nn.Linear):
-            timm.trunc_normal_(m.weight, std=0.02)
+            timm.models.layers.trunc_normal_(m.weight, std=0.02)
             if isinstance(m, nn.Linear) and m.bias is not None:
                 nn.init.constant_(m.bias, 0)
         elif isinstance(m, nn.LayerNorm):

--- a/deepinv/models/swinir.py
+++ b/deepinv/models/swinir.py
@@ -270,7 +270,9 @@ class SwinTransformerBlock(nn.Module):
             proj_drop=drop,
         )
 
-        self.drop_path = timm.models.layers.DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.drop_path = (
+            timm.models.layers.DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        )
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
         self.mlp = Mlp(

--- a/deepinv/models/swinir.py
+++ b/deepinv/models/swinir.py
@@ -14,6 +14,7 @@ import torch.utils.checkpoint as checkpoint
 # Compatibility with optional dependency on timm
 try:
     import timm
+    from timm.models.layers import DropPath, to_2tuple, trunc_normal_
 except ImportError as e:
     timm = e
 
@@ -139,7 +140,7 @@ class WindowAttention(nn.Module):
 
         self.proj_drop = nn.Dropout(proj_drop)
 
-        timm.models.layers.trunc_normal_(self.relative_position_bias_table, std=0.02)
+        trunc_normal_(self.relative_position_bias_table, std=0.02)
         self.softmax = nn.Softmax(dim=-1)
 
     def forward(self, x, mask=None):
@@ -262,7 +263,7 @@ class SwinTransformerBlock(nn.Module):
         self.norm1 = norm_layer(dim)
         self.attn = WindowAttention(
             dim,
-            window_size=timm.models.layers.to_2tuple(self.window_size),
+            window_size=to_2tuple(self.window_size),
             num_heads=num_heads,
             qkv_bias=qkv_bias,
             qk_scale=qk_scale,
@@ -271,7 +272,7 @@ class SwinTransformerBlock(nn.Module):
         )
 
         self.drop_path = (
-            timm.models.layers.DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+            DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
         )
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
@@ -667,8 +668,8 @@ class PatchEmbed(nn.Module):
         self, img_size=224, patch_size=4, in_chans=3, embed_dim=96, norm_layer=None
     ):
         super().__init__()
-        img_size = timm.models.layers.to_2tuple(img_size)
-        patch_size = timm.models.layers.to_2tuple(patch_size)
+        img_size = to_2tuple(img_size)
+        patch_size = to_2tuple(patch_size)
         patches_resolution = [
             img_size[0] // patch_size[0],
             img_size[1] // patch_size[1],
@@ -715,8 +716,8 @@ class PatchUnEmbed(nn.Module):
         self, img_size=224, patch_size=4, in_chans=3, embed_dim=96, norm_layer=None
     ):
         super().__init__()
-        img_size = timm.models.layers.to_2tuple(img_size)
-        patch_size = timm.models.layers.to_2tuple(patch_size)
+        img_size = to_2tuple(img_size)
+        patch_size = to_2tuple(patch_size)
         patches_resolution = [
             img_size[0] // patch_size[0],
             img_size[1] // patch_size[1],
@@ -911,7 +912,7 @@ class SwinIR(nn.Module):
             self.absolute_pos_embed = nn.Parameter(
                 torch.zeros(1, num_patches, embed_dim)
             )
-            timm.models.layers.trunc_normal_(self.absolute_pos_embed, std=0.02)
+            trunc_normal_(self.absolute_pos_embed, std=0.02)
 
         self.pos_drop = nn.Dropout(p=drop_rate)
 
@@ -1038,7 +1039,7 @@ class SwinIR(nn.Module):
 
     def _init_weights(self, m):
         if isinstance(m, nn.Linear):
-            timm.models.layers.trunc_normal_(m.weight, std=0.02)
+            trunc_normal_(m.weight, std=0.02)
             if isinstance(m, nn.Linear) and m.bias is not None:
                 nn.init.constant_(m.bias, 0)
         elif isinstance(m, nn.LayerNorm):

--- a/deepinv/models/swinir.py
+++ b/deepinv/models/swinir.py
@@ -11,18 +11,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
 
-# Compatibility with optional dependencies
+# Compatibility with optional dependency on timm
 try:
-    from timm.models.layers import trunc_normal_, to_2tuple, DropPath
-except ImportError:
-
-    def raise_import_error(*args, **kwargs):
-        raise ImportError(
-            "timm is needed to use the SCUNet class. "
-            "It should be installed with `pip install timm`"
-        )
-
-    trunc_normal_ = DropPath = to_2tuple = raise_import_error
+    import timm
+except ImportError as e:
+    timm = e
 
 
 class Mlp(nn.Module):
@@ -146,7 +139,7 @@ class WindowAttention(nn.Module):
 
         self.proj_drop = nn.Dropout(proj_drop)
 
-        trunc_normal_(self.relative_position_bias_table, std=0.02)
+        timm.trunc_normal_(self.relative_position_bias_table, std=0.02)
         self.softmax = nn.Softmax(dim=-1)
 
     def forward(self, x, mask=None):
@@ -269,7 +262,7 @@ class SwinTransformerBlock(nn.Module):
         self.norm1 = norm_layer(dim)
         self.attn = WindowAttention(
             dim,
-            window_size=to_2tuple(self.window_size),
+            window_size=timm.to_2tuple(self.window_size),
             num_heads=num_heads,
             qkv_bias=qkv_bias,
             qk_scale=qk_scale,
@@ -277,7 +270,7 @@ class SwinTransformerBlock(nn.Module):
             proj_drop=drop,
         )
 
-        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.drop_path = timm.DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
         self.mlp = Mlp(
@@ -672,8 +665,8 @@ class PatchEmbed(nn.Module):
         self, img_size=224, patch_size=4, in_chans=3, embed_dim=96, norm_layer=None
     ):
         super().__init__()
-        img_size = to_2tuple(img_size)
-        patch_size = to_2tuple(patch_size)
+        img_size = timm.to_2tuple(img_size)
+        patch_size = timm.to_2tuple(patch_size)
         patches_resolution = [
             img_size[0] // patch_size[0],
             img_size[1] // patch_size[1],
@@ -720,8 +713,8 @@ class PatchUnEmbed(nn.Module):
         self, img_size=224, patch_size=4, in_chans=3, embed_dim=96, norm_layer=None
     ):
         super().__init__()
-        img_size = to_2tuple(img_size)
-        patch_size = to_2tuple(patch_size)
+        img_size = timm.to_2tuple(img_size)
+        patch_size = timm.to_2tuple(patch_size)
         patches_resolution = [
             img_size[0] // patch_size[0],
             img_size[1] // patch_size[1],
@@ -858,6 +851,11 @@ class SwinIR(nn.Module):
         pretrained_noise_level=15,
         **kwargs,
     ):
+        if isinstance(timm, ImportError):
+            raise ImportError(
+                "timm is needed to use the SCUNet class. Please install it with `pip install timm`"
+            ) from timm
+
         super(SwinIR, self).__init__()
         num_in_ch = in_chans
         num_out_ch = in_chans
@@ -911,7 +909,7 @@ class SwinIR(nn.Module):
             self.absolute_pos_embed = nn.Parameter(
                 torch.zeros(1, num_patches, embed_dim)
             )
-            trunc_normal_(self.absolute_pos_embed, std=0.02)
+            timm.trunc_normal_(self.absolute_pos_embed, std=0.02)
 
         self.pos_drop = nn.Dropout(p=drop_rate)
 
@@ -1038,7 +1036,7 @@ class SwinIR(nn.Module):
 
     def _init_weights(self, m):
         if isinstance(m, nn.Linear):
-            trunc_normal_(m.weight, std=0.02)
+            timm.trunc_normal_(m.weight, std=0.02)
             if isinstance(m, nn.Linear) and m.bias is not None:
                 nn.init.constant_(m.bias, 0)
         elif isinstance(m, nn.LayerNorm):

--- a/deepinv/models/swinir.py
+++ b/deepinv/models/swinir.py
@@ -271,9 +271,7 @@ class SwinTransformerBlock(nn.Module):
             proj_drop=drop,
         )
 
-        self.drop_path = (
-            DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
-        )
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
         self.norm2 = norm_layer(dim)
         mlp_hidden_dim = int(dim * mlp_ratio)
         self.mlp = Mlp(

--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -37,7 +37,7 @@ class WaveletPrior(nn.Module):
     def __init__(self, level=3, wv="db8", device="cpu", non_linearity="soft"):
         if isinstance(pytorch_wavelets, ImportError):
             raise ImportError(
-                "pywavelets is needed to use the WaveletPrior class. "
+                "pytorch_wavelets is needed to use the WaveletPrior class. "
                 "It should be installed with `pip install "
                 "git+https://github.com/fbcotter/pytorch_wavelets.git`"
             ) from pytorch_wavelets

--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -1,6 +1,11 @@
 import torch
 import torch.nn as nn
 
+try:
+    import pytorch_wavelets
+except ImportError as e:
+    pytorch_wavelets = e
+
 
 class WaveletPrior(nn.Module):
     r"""
@@ -30,19 +35,16 @@ class WaveletPrior(nn.Module):
     """
 
     def __init__(self, level=3, wv="db8", device="cpu", non_linearity="soft"):
+        if isinstance(pytorch_wavelets, ImportError):
+            raise ImportError(
+                "pywavelets is needed to use the WaveletPrior class. "
+                "It should be installed with `pip install "
+                "git+https://github.com/fbcotter/pytorch_wavelets.git`"
+            ) from pytorch_wavelets
         super().__init__()
         self.level = level
-        try:
-            from pytorch_wavelets import DWTForward, DWTInverse
-        except ImportError as e:
-            print(
-                "pywavelets is needed to use the WaveletPrior class. "
-                "It should be installed with `pip install"
-                "git+https://github.com/fbcotter/pytorch_wavelets.git`"
-            )
-            raise e
-        self.dwt = DWTForward(J=self.level, wave=wv).to(device)
-        self.iwt = DWTInverse(wave=wv).to(device)
+        self.dwt = pytorch_wavelets.DWTForward(J=self.level, wave=wv).to(device)
+        self.iwt = pytorch_wavelets.DWTInverse(wave=wv).to(device)
         self.device = device
         self.non_linearity = non_linearity
 

--- a/deepinv/tests/conftest.py
+++ b/deepinv/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+
+import torch
+
+import deepinv as dinv
+from deepinv.tests.dummy_datasets.datasets import DummyCircles
+
+
+@pytest.fixture
+def device():
+    return dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
+
+
+@pytest.fixture
+def toymatrix():
+    w = 50
+    A = torch.diag(torch.Tensor(range(1, w + 1)))
+    return A
+
+
+@pytest.fixture
+def dummy_dataset(imsize, device):
+    return DummyCircles(samples=1, imsize=imsize)
+
+
+@pytest.fixture
+def imsize():
+    h = 37
+    w = 31
+    c = 3
+    return c, h, w
+
+
+@pytest.fixture
+def imsize_1_channel():
+    h = 37
+    w = 31
+    c = 1
+    return c, h, w

--- a/deepinv/tests/test_loss.py
+++ b/deepinv/tests/test_loss.py
@@ -1,6 +1,5 @@
 import pytest
 
-import numpy as np
 import math
 import torch
 
@@ -10,20 +9,8 @@ from torch.utils.data import DataLoader
 import deepinv as dinv
 from deepinv.loss.regularisers import JacobianSpectralNorm, FNEJacobianSpectralNorm
 
-list_losses = ["sup", "mcei"]
-list_sure = ["Gaussian", "Poisson", "PoissonGaussian", "UniformGaussian"]
-
-
-@pytest.fixture
-def device():
-    return dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
-
-
-@pytest.fixture
-def toymatrix():
-    w = 50
-    A = torch.diag(torch.Tensor(range(1, w + 1)))
-    return A
+LOSSES = ["sup", "mcei"]
+LIST_SURE = ["Gaussian", "Poisson", "PoissonGaussian", "UniformGaussian"]
 
 
 def test_jacobian_spectral_values(toymatrix):
@@ -91,7 +78,7 @@ def choose_sure(noise_type):
     return loss, noise_model
 
 
-@pytest.mark.parametrize("noise_type", list_sure)
+@pytest.mark.parametrize("noise_type", LIST_SURE)
 def test_sure(noise_type, device):
     imsize = (3, 256, 256)  # a bigger image reduces the error
     # choose backbone denoiser
@@ -147,7 +134,7 @@ def dataset(physics, tmp_path, imsize, device):
     )
 
 
-@pytest.mark.parametrize("loss_name", list_losses)
+@pytest.mark.parametrize("loss_name", LOSSES)
 def test_losses(loss_name, tmp_path, dataset, physics, imsize, device):
     # choose training losses
     loss = choose_loss(loss_name)

--- a/deepinv/tests/test_loss_train.py
+++ b/deepinv/tests/test_loss_train.py
@@ -1,4 +1,3 @@
-import math
 import pytest
 from pathlib import Path
 
@@ -6,28 +5,12 @@ import torch
 from torch.utils.data import DataLoader
 
 import deepinv as dinv
-from deepinv.optim import DataFidelity
 from deepinv.optim.data_fidelity import L2
-from deepinv.optim.prior import Prior, PnP
+from deepinv.optim.prior import PnP
 from deepinv.tests.dummy_datasets.datasets import DummyCircles
-from deepinv.utils.plotting import plot, torch2cpu
 from deepinv.unfolded import unfolded_builder
-from deepinv.utils import investigate_model
 from deepinv.training_utils import train
 from deepinv.training_utils import test as feature_test
-
-
-@pytest.fixture
-def device():
-    return dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
-
-
-@pytest.fixture
-def imsize():
-    h = 28
-    w = 32
-    c = 3
-    return c, h, w
 
 
 def test_generate_dataset(tmp_path, imsize, device):
@@ -56,11 +39,6 @@ def test_generate_dataset(tmp_path, imsize, device):
     assert x.shape == imsize
 
 
-@pytest.fixture
-def dummy_dataset(imsize, device):
-    return DummyCircles(samples=1, imsize=imsize)
-
-
 # optim_algos = [
 #     "PGD",
 #     "HQS",
@@ -73,7 +51,7 @@ optim_algos = ["PGD"]
 
 
 @pytest.mark.parametrize("name_algo", optim_algos)
-def test_optim_algo(name_algo, imsize, dummy_dataset, device):
+def test_optim_algo(name_algo, imsize, device):
     # pths
     BASE_DIR = Path(".")
     ORIGINAL_DATA_DIR = BASE_DIR / "datasets"

--- a/deepinv/tests/test_loss_train.py
+++ b/deepinv/tests/test_loss_train.py
@@ -52,12 +52,12 @@ optim_algos = ["PGD"]
 
 @pytest.mark.parametrize("name_algo", optim_algos)
 def test_optim_algo(name_algo, imsize, device):
+    # This test uses WaveletPrior, which requires pytorch_wavelets
+    # TODO: we could use a dummy trainable denoiser with a linear layer instead
+    pytest.importorskip("pytorch_wavelets")
+
     # pths
     BASE_DIR = Path(".")
-    ORIGINAL_DATA_DIR = BASE_DIR / "datasets"
-    # DATA_DIR = BASE_DIR / "measurements"
-    # RESULTS_DIR = BASE_DIR / "results"
-    # DEG_DIR = BASE_DIR / "degradations"
     CKPT_DIR = BASE_DIR / "ckpts"
 
     # Select the data fidelity term
@@ -90,10 +90,8 @@ def test_optim_algo(name_algo, imsize, device):
         "lambda": lamb,
     }
 
-    trainable_params = [
-        "g_param",
-        "stepsize",
-    ]  # define which parameters from 'params_algo' are trainable
+    # define which parameters from 'params_algo' are trainable
+    trainable_params = ["g_param", "stepsize"]
 
     # Define the unfolded trainable model.
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -287,13 +287,16 @@ def test_PDNet(imsize, device):
     assert x_hat.shape == x.shape
 
 
-@pytest.mark.parametrize("denoiser, dep", [
-    ("BM3D", "bm3d"),
-    ("SCUNet", "timm"),
-    ("SwinIR", "timm"),
-    ("WaveletPrior", "pytorch_wavelets"),
-    ("WaveletDict", "pytorch_wavelets"),
-])
+@pytest.mark.parametrize(
+    "denoiser, dep",
+    [
+        ("BM3D", "bm3d"),
+        ("SCUNet", "timm"),
+        ("SwinIR", "timm"),
+        ("WaveletPrior", "pytorch_wavelets"),
+        ("WaveletDict", "pytorch_wavelets"),
+    ],
+)
 def test_optional_dependencies(denoiser, dep):
     # Skip the test if the optional dependency is installed
     if dep in sys.modules:
@@ -302,6 +305,7 @@ def test_optional_dependencies(denoiser, dep):
     klass = getattr(dinv.models, denoiser)
     with pytest.raises(ImportError, match=f"pip install .*{dep}"):
         klass()
+
 
 # def test_dip(imsize, device): TODO: fix this test
 #     torch.manual_seed(0)

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -362,6 +362,10 @@ def test_pnp_algo(pnp_algo, imsize, dummy_dataset, device):
 
 @pytest.mark.parametrize("red_algo", ["GD", "PGD"])
 def test_red_algo(red_algo, imsize, dummy_dataset, device):
+    # This test uses WaveletPrior, which requires pytorch_wavelets
+    # TODO: we could use a dummy trainable denoiser with a linear layer instead
+    pytest.importorskip("pytorch_wavelets")
+
     # 1. Generate a dummy dataset
     dataloader = DataLoader(dummy_dataset, batch_size=1, shuffle=False, num_workers=0)
     test_sample = next(iter(dataloader)).to(device)

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -297,13 +297,10 @@ def test_denoiser(imsize, dummy_dataset, device):
 # GD not implemented for this one
 @pytest.mark.parametrize("pnp_algo", ["PGD", "HQS", "DRS", "ADMM", "CP"])
 def test_pnp_algo(pnp_algo, imsize, dummy_dataset, device):
-
     pytest.importorskip("pytorch_wavelets")
 
     # 1. Generate a dummy dataset
-    dataloader = DataLoader(
-        dummy_dataset, batch_size=1, shuffle=False, num_workers=0
-    )
+    dataloader = DataLoader(dummy_dataset, batch_size=1, shuffle=False, num_workers=0)
     test_sample = next(iter(dataloader)).to(device)
 
     # 2. Set a physical experiment (here, deblurring)
@@ -320,9 +317,7 @@ def test_pnp_algo(pnp_algo, imsize, dummy_dataset, device):
     data_fidelity = L2()
 
     # here the prior model is common for all iterations
-    prior = PnP(
-        denoiser=dinv.models.WaveletPrior(wv="db8", level=3, device=device)
-    )
+    prior = PnP(denoiser=dinv.models.WaveletPrior(wv="db8", level=3, device=device))
 
     stepsize_dual = 1.0 if pnp_algo == "CP" else None
     params_algo = {
@@ -368,9 +363,7 @@ def test_pnp_algo(pnp_algo, imsize, dummy_dataset, device):
 @pytest.mark.parametrize("red_algo", ["GD", "PGD"])
 def test_red_algo(red_algo, imsize, dummy_dataset, device):
     # 1. Generate a dummy dataset
-    dataloader = DataLoader(
-        dummy_dataset, batch_size=1, shuffle=False, num_workers=0
-    )
+    dataloader = DataLoader(dummy_dataset, batch_size=1, shuffle=False, num_workers=0)
     test_sample = next(iter(dataloader)).to(device)
 
     # 2. Set a physical experiment (here, deblurring)

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1,33 +1,13 @@
-import math
 import pytest
+
+import torch
+from torch.utils.data import DataLoader
 
 import deepinv as dinv
 from deepinv.optim import DataFidelity
 from deepinv.optim.data_fidelity import L2, IndicatorL2, L1
 from deepinv.optim.prior import Prior, PnP, RED
-from deepinv.optim.optimizers import *
-from deepinv.tests.dummy_datasets.datasets import DummyCircles
-from deepinv.utils.plotting import plot, torch2cpu
-
-from torch.utils.data import DataLoader
-
-
-@pytest.fixture
-def device():
-    return dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
-
-
-@pytest.fixture
-def imsize():
-    h = 28
-    w = 32
-    c = 3
-    return c, h, w
-
-
-@pytest.fixture
-def dummy_dataset(imsize, device):
-    return DummyCircles(samples=1, imsize=imsize)
+from deepinv.optim.optimizers import optim_builder
 
 
 def custom_init_CP(y, physics):
@@ -193,11 +173,8 @@ def test_data_fidelity_l1(device):
     assert torch.allclose(data_fidelity.prox_d(x, y, threshold), prox_manual)
 
 
-optim_algos = ["PGD", "ADMM", "DRS", "HQS"]
-
-
 # we do not test CP (Chambolle-Pock) as we have a dedicated test (due to more specific optimality conditions)
-@pytest.mark.parametrize("name_algo", optim_algos)
+@pytest.mark.parametrize("name_algo", ["PGD", "ADMM", "DRS", "HQS"])
 def test_optim_algo(name_algo, imsize, dummy_dataset, device):
     for g_first in [True, False]:
         # Define two points
@@ -317,40 +294,35 @@ def test_denoiser(imsize, dummy_dataset, device):
     assert model.has_converged
 
 
-optim_algos = ["PGD", "HQS", "DRS", "ADMM", "CP"]  # GD not implemented for this one
-
-
-@pytest.mark.parametrize("pnp_algo", optim_algos)
+# GD not implemented for this one
+@pytest.mark.parametrize("pnp_algo", ["PGD", "HQS", "DRS", "ADMM", "CP"])
 def test_pnp_algo(pnp_algo, imsize, dummy_dataset, device):
-    try:
-        import pytorch_wavelets
-    except ImportError:
-        pytest.xfail(
-            "This test requires pytorch_wavelets. "
-            "It should be installed with `pip install"
-            "git+https://github.com/fbcotter/pytorch_wavelets.git`"
-        )
+
+    pytest.importorskip("pytorch_wavelets")
+
+    # 1. Generate a dummy dataset
     dataloader = DataLoader(
         dummy_dataset, batch_size=1, shuffle=False, num_workers=0
-    )  # 1. Generate a dummy dataset
+    )
     test_sample = next(iter(dataloader)).to(device)
 
+    # 2. Set a physical experiment (here, deblurring)
     physics = dinv.physics.Blur(
         dinv.physics.blur.gaussian_blur(sigma=(2, 0.1), angle=45.0), device=device
-    )  # 2. Set a physical experiment (here, deblurring)
+    )
     y = physics(test_sample)
     max_iter = 1000
-    sigma_denoiser = torch.tensor(
-        [[0.1]]
-    )  # Note: results are better for sigma_denoiser=0.001, but it takes longer to run.
+    # Note: results are better for sigma_denoiser=0.001, but it takes longer to run.
+    sigma_denoiser = torch.tensor([[0.1]])
     stepsize = 1.0
     lamb = 1.0
 
     data_fidelity = L2()
 
+    # here the prior model is common for all iterations
     prior = PnP(
         denoiser=dinv.models.WaveletPrior(wv="db8", level=3, device=device)
-    )  # here the prior model is common for all iterations
+    )
 
     stepsize_dual = 1.0 if pnp_algo == "CP" else None
     params_algo = {
@@ -393,19 +365,18 @@ def test_pnp_algo(pnp_algo, imsize, dummy_dataset, device):
     assert pnp.has_converged
 
 
-optim_algos = ["PGD", "GD"]  # GD not implemented for this one
-
-
-@pytest.mark.parametrize("red_algo", optim_algos)
+@pytest.mark.parametrize("red_algo", ["GD", "PGD"])
 def test_red_algo(red_algo, imsize, dummy_dataset, device):
+    # 1. Generate a dummy dataset
     dataloader = DataLoader(
         dummy_dataset, batch_size=1, shuffle=False, num_workers=0
-    )  # 1. Generate a dummy dataset
+    )
     test_sample = next(iter(dataloader)).to(device)
 
+    # 2. Set a physical experiment (here, deblurring)
     physics = dinv.physics.Blur(
         dinv.physics.blur.gaussian_blur(sigma=(2, 0.1), angle=45.0), device=device
-    )  # 2. Set a physical experiment (here, deblurring)
+    )
     y = physics(test_sample)
     max_iter = 1000
     sigma_denoiser = 1.0  # Note: results are better for sigma_denoiser=0.001, but it takes longer to run.
@@ -430,7 +401,7 @@ def test_red_algo(red_algo, imsize, dummy_dataset, device):
         g_first=True,
     )
 
-    x = red(y, physics)
+    red(y, physics)
 
     assert red.has_converged
 

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1,16 +1,12 @@
 import pytest
 import torch
-import deepinv as dinv
 import numpy as np
 
-
-@pytest.fixture
-def device():
-    return dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
+import deepinv as dinv
 
 
 # Linear forward operators to test (make sure they appear in find_operator as well)
-operators = [
+OPERATORS = [
     "CS",
     "fastCS",
     "inpainting",
@@ -23,8 +19,9 @@ operators = [
     "MRI",
     "pansharpen",
 ]
+NONLINEAR_OPERATORS = ["haze", "blind_deblur", "lidar"]
 
-list_noise = [
+NOISES = [
     "Gaussian",
     "Poisson",
     "PoissonGaussian",
@@ -32,12 +29,6 @@ list_noise = [
     "Uniform",
     "Neighbor2Neighbor",
 ]
-
-operators_reset = [
-    "MRI",
-]
-
-nonlinear_operators = ["haze", "blind_deblur", "lidar"]
 
 
 def find_operator(name, device):
@@ -143,7 +134,7 @@ def find_nonlinear_operator(name, device):
     return p, x
 
 
-@pytest.mark.parametrize("name", operators)
+@pytest.mark.parametrize("name", OPERATORS)
 def test_operators_adjointness(name, device):
     r"""
     Tests if a linear forward operator has a well defined adjoint.
@@ -160,7 +151,7 @@ def test_operators_adjointness(name, device):
     assert error < 1e-3
 
 
-@pytest.mark.parametrize("name", operators)
+@pytest.mark.parametrize("name", OPERATORS)
 def test_operators_norm(name, device):
     r"""
     Tests if a linear physics operator has a norm close to 1.
@@ -181,7 +172,7 @@ def test_operators_norm(name, device):
     assert torch.abs(norm - norm_ref) < 0.2
 
 
-@pytest.mark.parametrize("name", nonlinear_operators)
+@pytest.mark.parametrize("name", NONLINEAR_OPERATORS)
 def test_nonlinear_operators(name, device):
     r"""
     Tests if a linear physics operator has a norm close to 1.
@@ -197,7 +188,7 @@ def test_nonlinear_operators(name, device):
     assert x.shape == xhat.shape
 
 
-@pytest.mark.parametrize("name", operators)
+@pytest.mark.parametrize("name", OPERATORS)
 def test_pseudo_inverse(name, device):
     r"""
     Tests if a linear physics operator has a well defined pseudoinverse.
@@ -263,7 +254,7 @@ def choose_noise(noise_type):
     return noise_model
 
 
-@pytest.mark.parametrize("noise_type", list_noise)
+@pytest.mark.parametrize("noise_type", NOISES)
 def test_noise(device, noise_type):
     r"""
     Tests noise models.

--- a/deepinv/tests/test_unfolded.py
+++ b/deepinv/tests/test_unfolded.py
@@ -1,39 +1,19 @@
 import pytest
-
-# from pathlib import Path
-
 import torch
 
 import deepinv as dinv
+from deepinv.optim.prior import PnP
 from deepinv.optim.data_fidelity import L2
-from deepinv.optim.prior import PnP  # Prior
-from deepinv.tests.dummy_datasets.datasets import DummyCircles
 from deepinv.unfolded import unfolded_builder, DEQ_builder
 
 
-@pytest.fixture
-def device():
-    return dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
+OPTIM_ALGO = ["PGD", "HQS"]
 
 
-@pytest.fixture
-def imsize():
-    h = 28
-    w = 32
-    c = 3
-    return c, h, w
-
-
-@pytest.fixture
-def dummy_dataset(imsize, device):
-    return DummyCircles(samples=1, imsize=imsize)
-
-
-optim_algos = ["PGD", "HQS"]
-
-
-@pytest.mark.parametrize("unfolded_algo", optim_algos)
+@pytest.mark.parametrize("unfolded_algo", OPTIM_ALGO)
 def test_unfolded(unfolded_algo, imsize, dummy_dataset, device):
+    pytest.importorskip("pytorch_wavelets")
+
     # Select the data fidelity term
     data_fidelity = L2()
 
@@ -85,8 +65,9 @@ def test_unfolded(unfolded_algo, imsize, dummy_dataset, device):
         assert (trainable_params[0] in name) or (trainable_params[1] in name)
 
 
-@pytest.mark.parametrize("unfolded_algo", optim_algos)
+@pytest.mark.parametrize("unfolded_algo", OPTIM_ALGO)
 def test_DEQ(unfolded_algo, imsize, dummy_dataset, device):
+    pytest.importorskip("pytorch_wavelets")
     torch.set_grad_enabled(
         True
     )  # Disabled somewhere in previous test files, necessary for this test to pass


### PR DESCRIPTION
- Use `conftest.py` to define fixtures across test files.
- More consistent tests for optional dependencies
- Add a test to check that the reported error without optional dependencies indicates how to install the dep.
- Add a CI entry to check that the package can run and passes the test without optional deps for `denoisers`.

~I will add a  CI entry to test the package without optional dependencies.~