### PR TITLE
Fix bugs 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Current (v0.0.2)
 
 New Features
 ^^^^^^^^^^^^
+- Added L1 prior, change distance in DataFidelity (:gh:`108` by `Samuel Hurault`_) - 03/11/2023
 - Added Kaiming init (:gh:`102` by `Matthieu Terris`_) - 29/10/2023
 - Added Anderson Acceleration (:gh:`86` by `Samuel Hurault`_) - 23/10/2023
 - Added `DPS` diffusion method (:gh:`92` by `Julian Tachella`_ and `Hyungjin Chung`_) - 20/10/2023

--- a/deepinv/models/dncnn.py
+++ b/deepinv/models/dncnn.py
@@ -1,6 +1,7 @@
 import torch.nn as nn
 import torch
 from .denoiser import online_weights_path
+import math
 
 
 class DnCNN(nn.Module):

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -183,16 +183,16 @@ class DRUNet(nn.Module):
             If ``sigma`` is a tensor, it must be of shape ``(batch_size,)``.
         """
         if isinstance(sigma, torch.Tensor):
-            if len(sigma.size()) > 0: 
+            if len(sigma.size()) > 0:
                 noise_level_map = sigma.view(x.size(0), 1, 1, 1).to(x.device)
-            else :
+            else:
                 sigma = sigma.item()
                 noise_level_map = (
-                torch.FloatTensor(x.size(0), 1, x.size(2), x.size(3))
-                .fill_(sigma)
-                .to(x.device)
-            )
-        else :
+                    torch.FloatTensor(x.size(0), 1, x.size(2), x.size(3))
+                    .fill_(sigma)
+                    .to(x.device)
+                )
+        else:
             noise_level_map = (
                 torch.FloatTensor(x.size(0), 1, x.size(2), x.size(3))
                 .fill_(sigma)

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -182,15 +182,22 @@ class DRUNet(nn.Module):
         :param float, torch.Tensor sigma: noise level. If ``sigma`` is a float, it is used for all images in the batch.
             If ``sigma`` is a tensor, it must be of shape ``(batch_size,)``.
         """
-        if not isinstance(sigma, torch.Tensor):
+        if isinstance(sigma, torch.Tensor):
+            if len(sigma.size()) > 0: 
+                noise_level_map = sigma.view(x.size(0), 1, 1, 1).to(x.device)
+            else :
+                sigma = sigma.item()
+                noise_level_map = (
+                torch.FloatTensor(x.size(0), 1, x.size(2), x.size(3))
+                .fill_(sigma)
+                .to(x.device)
+            )
+        else :
             noise_level_map = (
                 torch.FloatTensor(x.size(0), 1, x.size(2), x.size(3))
                 .fill_(sigma)
                 .to(x.device)
             )
-        else:
-            noise_level_map = sigma.view(x.size(0), 1, 1, 1)
-            noise_level_map = noise_level_map.expand(x.size(0), 1, x.size(2), x.size(3))
         x = torch.cat((x, noise_level_map), 1)
         if self.training or (
             x.size(2) % 8 == 0

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -185,6 +185,7 @@ class DRUNet(nn.Module):
         if isinstance(sigma, torch.Tensor):
             if len(sigma.size()) > 0:
                 noise_level_map = sigma.view(x.size(0), 1, 1, 1).to(x.device)
+                noise_level_map = noise_level_map.expand(x.size(0), 1, x.size(2), x.size(3))
             else:
                 sigma = sigma.item()
                 noise_level_map = (

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -185,7 +185,9 @@ class DRUNet(nn.Module):
         if isinstance(sigma, torch.Tensor):
             if len(sigma.size()) > 0:
                 noise_level_map = sigma.view(x.size(0), 1, 1, 1).to(x.device)
-                noise_level_map = noise_level_map.expand(x.size(0), 1, x.size(2), x.size(3))
+                noise_level_map = noise_level_map.expand(
+                    x.size(0), 1, x.size(2), x.size(3)
+                )
             else:
                 sigma = sigma.item()
                 noise_level_map = (

--- a/deepinv/models/tv.py
+++ b/deepinv/models/tv.py
@@ -10,7 +10,7 @@ class TV(nn.Module):
 
     .. math::
 
-        \underset{x}{\arg\min} \;  \frac{1}{2}\|x-y\|_2^2 + \lambda \|Dx\|_{2},
+        \underset{x}{\arg\min} \;  \frac{1}{2}\|x-y\|_2^2 + \lambda \|Dx\|_{1,2},
 
     where :math:`D` maps an image to its gradient field.
 

--- a/deepinv/models/tv.py
+++ b/deepinv/models/tv.py
@@ -10,7 +10,7 @@ class TV(nn.Module):
 
     .. math::
 
-        \underset{x}{\arg\min} \;  \frac{1}{2}\|x-y\|_2^2 + \lambda \|Dx\|_{1,2},
+        \underset{x}{\arg\min} \;  \frac{1}{2}\|x-y\|_2^2 + \lambda \|Dx\|_{2},
 
     where :math:`D` maps an image to its gradient field.
 

--- a/deepinv/optim/__init__.py
+++ b/deepinv/optim/__init__.py
@@ -2,3 +2,4 @@ from .data_fidelity import DataFidelity, L2, L1, IndicatorL2, PoissonLikelihood
 from .optimizers import BaseOptim, optim_builder
 from .fixed_point import FixedPoint
 from .prior import Prior, ScorePrior, Tikhonov, PnP, RED
+from .optim_iterators.optim_iterator import OptimIterator

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -57,7 +57,7 @@ class DataFidelity(nn.Module):
         :param torch.tensor y: Data :math:`y`.
         :return: (torch.tensor) data fidelity :math:`\distance{u}{y}`.
         """
-        return self._d(u - y, *args, **kwargs)
+        return self._d(u, y, *args, **kwargs)
 
     def grad_d(self, u, y, *args, **kwargs):
         r"""

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -79,8 +79,8 @@ class DataFidelity(nn.Module):
         self,
         u,
         y,
-        gamma,
         *args,
+        gamma=1.0,
         stepsize_inter=1.0,
         max_iter_inter=50,
         tol_inter=1e-3,
@@ -130,8 +130,8 @@ class DataFidelity(nn.Module):
         x,
         y,
         physics,
-        gamma,
         *args,
+        gamma=1.0,
         stepsize_inter=1.0,
         max_iter_inter=50,
         tol_inter=1e-3,
@@ -154,7 +154,7 @@ class DataFidelity(nn.Module):
             grad, x, step_size=stepsize_inter, max_iter=max_iter_inter, tol=tol_inter
         )
 
-    def prox_conjugate(self, x, y, physics, gamma, *args, lamb=1, **kwargs):
+    def prox_conjugate(self, x, y, physics, *args, gamma=1., lamb=1., **kwargs):
         r"""
         Calculates the proximity operator of the convex conjugate :math:`(\lambda \datafidname)^*` at :math:`x`,
         using the Moreau formula.
@@ -175,7 +175,7 @@ class DataFidelity(nn.Module):
             x / gamma, y, physics, lamb / gamma, *args, **kwargs
         )
 
-    def prox_d_conjugate(self, u, y, gamma, *args, lamb=1, **kwargs):
+    def prox_d_conjugate(self, u, y, *args, gamma=1., lamb=1., **kwargs):
         r"""
         Calculates the proximity operator of the convex conjugate :math:`(\lambda \distancename)^*` at :math:`u`,
         using the Moreau formula.
@@ -272,7 +272,7 @@ class L2(DataFidelity):
         """
         return self.norm * (u - y)
 
-    def prox_d(self, x, y, gamma):
+    def prox_d(self, x, y, gamma=1.):
         r"""
         Proximal operator of :math:`\gamma \distance{x}{y} = \frac{\gamma}{2\sigma^2}\|x-y\|^2`.
 
@@ -291,7 +291,7 @@ class L2(DataFidelity):
         gamma_ = self.norm * gamma
         return (x + gamma_ * y) / (1 + gamma_)
 
-    def prox(self, x, y, physics, gamma):
+    def prox(self, x, y, physics, gamma=1.):
         r"""
         Proximal operator of :math:`\gamma \datafid{Ax}{y} = \frac{\gamma}{2\sigma^2}\|Ax-y\|^2`.
 
@@ -351,7 +351,7 @@ class IndicatorL2(DataFidelity):
         loss = (dist > radius) * 1e16
         return loss
 
-    def prox_d(self, x, y, gamma=None, radius=None):
+    def prox_d(self, x, y, radius=None):
         r"""
         Proximal operator of the indicator of :math:`\ell_2` ball with radius `radius`, i.e.
 
@@ -385,7 +385,6 @@ class IndicatorL2(DataFidelity):
         stepsize=None,
         crit_conv=1e-5,
         max_iter=100,
-        gamma=None,
     ):
         r"""
         Proximal operator of the indicator of :math:`\ell_2` ball with radius `radius`, i.e.
@@ -466,7 +465,7 @@ class PoissonLikelihood(DataFidelity):
             y = y * self.gain
         return (1 / self.gain) * (torch.ones_like(x) - y / (self.gain * x + self.bkg))
 
-    def prox_d(self, x, y, gamma):
+    def prox_d(self, x, y, gamma=1.):
         if self.normalize:
             y = y * self.gain
         out = (
@@ -516,7 +515,7 @@ class L1(DataFidelity):
         """
         return torch.sign(x - y)
 
-    def prox_d(self, u, y, gamma):
+    def prox_d(self, u, y, gamma=1.):
         r"""
         Proximal operator of the :math:`\ell_1` norm, i.e.
 
@@ -538,7 +537,7 @@ class L1(DataFidelity):
         )
         return aux + y
 
-    def prox(self, x, y, physics, gamma, stepsize=None, crit_conv=1e-5, max_iter=100):
+    def prox(self, x, y, physics, gamma=1., stepsize=None, crit_conv=1e-5, max_iter=100):
         r"""
         Proximal operator of the :math:`\ell_1` norm composed with A, i.e.
 

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -154,7 +154,7 @@ class DataFidelity(nn.Module):
             grad, x, step_size=stepsize_inter, max_iter=max_iter_inter, tol=tol_inter
         )
 
-    def prox_conjugate(self, x, y, physics, *args, gamma=1., lamb=1., **kwargs):
+    def prox_conjugate(self, x, y, physics, *args, gamma=1.0, lamb=1.0, **kwargs):
         r"""
         Calculates the proximity operator of the convex conjugate :math:`(\lambda \datafidname)^*` at :math:`x`,
         using the Moreau formula.
@@ -172,10 +172,10 @@ class DataFidelity(nn.Module):
             computed in :math:`x`.
         """
         return x - gamma * self.prox(
-            x / gamma, y, physics, *args, gamma = lamb / gamma, **kwargs
+            x / gamma, y, physics, *args, gamma=lamb / gamma, **kwargs
         )
 
-    def prox_d_conjugate(self, u, y, *args, gamma=1., lamb=1., **kwargs):
+    def prox_d_conjugate(self, u, y, *args, gamma=1.0, lamb=1.0, **kwargs):
         r"""
         Calculates the proximity operator of the convex conjugate :math:`(\lambda \distancename)^*` at :math:`u`,
         using the Moreau formula.
@@ -191,7 +191,9 @@ class DataFidelity(nn.Module):
         :return: (torch.tensor) proximity operator :math:`\operatorname{prox}_{\gamma (\lambda \distancename)^*}(x)`,
             computed in :math:`x`.
         """
-        return u - gamma * self.prox_d(u / gamma, y, *args, gamma = lamb / gamma, **kwargs)
+        return u - gamma * self.prox_d(
+            u / gamma, y, *args, gamma=lamb / gamma, **kwargs
+        )
 
 
 class L2(DataFidelity):
@@ -272,7 +274,7 @@ class L2(DataFidelity):
         """
         return self.norm * (u - y)
 
-    def prox_d(self, x, y, gamma=1.):
+    def prox_d(self, x, y, gamma=1.0):
         r"""
         Proximal operator of :math:`\gamma \distance{x}{y} = \frac{\gamma}{2\sigma^2}\|x-y\|^2`.
 
@@ -291,7 +293,7 @@ class L2(DataFidelity):
         gamma_ = self.norm * gamma
         return (x + gamma_ * y) / (1 + gamma_)
 
-    def prox(self, x, y, physics, gamma=1.):
+    def prox(self, x, y, physics, gamma=1.0):
         r"""
         Proximal operator of :math:`\gamma \datafid{Ax}{y} = \frac{\gamma}{2\sigma^2}\|Ax-y\|^2`.
 
@@ -465,7 +467,7 @@ class PoissonLikelihood(DataFidelity):
             y = y * self.gain
         return (1 / self.gain) * (torch.ones_like(x) - y / (self.gain * x + self.bkg))
 
-    def prox_d(self, x, y, gamma=1.):
+    def prox_d(self, x, y, gamma=1.0):
         if self.normalize:
             y = y * self.gain
         out = (
@@ -515,7 +517,7 @@ class L1(DataFidelity):
         """
         return torch.sign(x - y)
 
-    def prox_d(self, u, y, gamma=1.):
+    def prox_d(self, u, y, gamma=1.0):
         r"""
         Proximal operator of the :math:`\ell_1` norm, i.e.
 
@@ -537,7 +539,9 @@ class L1(DataFidelity):
         )
         return aux + y
 
-    def prox(self, x, y, physics, gamma=1., stepsize=None, crit_conv=1e-5, max_iter=100):
+    def prox(
+        self, x, y, physics, gamma=1.0, stepsize=None, crit_conv=1e-5, max_iter=100
+    ):
         r"""
         Proximal operator of the :math:`\ell_1` norm composed with A, i.e.
 

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -172,7 +172,7 @@ class DataFidelity(nn.Module):
             computed in :math:`x`.
         """
         return x - gamma * self.prox(
-            x / gamma, y, physics, lamb / gamma, *args, **kwargs
+            x / gamma, y, physics, *args, gamma = lamb / gamma, **kwargs
         )
 
     def prox_d_conjugate(self, u, y, *args, gamma=1., lamb=1., **kwargs):
@@ -191,7 +191,7 @@ class DataFidelity(nn.Module):
         :return: (torch.tensor) proximity operator :math:`\operatorname{prox}_{\gamma (\lambda \distancename)^*}(x)`,
             computed in :math:`x`.
         """
-        return u - gamma * self.prox_d(u / gamma, y, lamb / gamma, *args, **kwargs)
+        return u - gamma * self.prox_d(u / gamma, y, *args, gamma = lamb / gamma, **kwargs)
 
 
 class L2(DataFidelity):
@@ -351,7 +351,7 @@ class IndicatorL2(DataFidelity):
         loss = (dist > radius) * 1e16
         return loss
 
-    def prox_d(self, x, y, radius=None):
+    def prox_d(self, x, y, radius=None, gamma=None):
         r"""
         Proximal operator of the indicator of :math:`\ell_2` ball with radius `radius`, i.e.
 

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -149,7 +149,7 @@ class DataFidelity(nn.Module):
         :param float tol_inter: internal gradient descent has converged when the L2 distance between two consecutive iterates is smaller than tol_inter.
         :return: (torch.tensor) proximity operator :math:`\operatorname{prox}_{\gamma \datafidname}(x)`, computed in :math:`x`.
         """
-        grad = lambda z: gamma * self.grad(z, y, *args, **kwargs) + (z - x)
+        grad = lambda z: gamma * self.grad(z, y, physics, *args, **kwargs) + (z - x)
         return gradient_descent(
             grad, x, step_size=stepsize_inter, max_iter=max_iter_inter, tol=tol_inter
         )

--- a/deepinv/optim/optim_iterators/admm.py
+++ b/deepinv/optim/optim_iterators/admm.py
@@ -89,7 +89,7 @@ class fStepADMM(fStep):
         else:
             p = x - z
         return cur_data_fidelity.prox(
-            p, y, physics, cur_params["lambda"] * cur_params["stepsize"]
+            p, y, physics, gamma = cur_params["lambda"] * cur_params["stepsize"]
         )
 
 
@@ -114,4 +114,4 @@ class gStepADMM(gStep):
             p = x - z
         else:
             p = x + z
-        return cur_prior.prox(p, cur_params["stepsize"], cur_params["g_param"])
+        return cur_prior.prox(p, cur_params["g_param"], gamma = cur_params["stepsize"])

--- a/deepinv/optim/optim_iterators/admm.py
+++ b/deepinv/optim/optim_iterators/admm.py
@@ -89,7 +89,7 @@ class fStepADMM(fStep):
         else:
             p = x - z
         return cur_data_fidelity.prox(
-            p, y, physics, gamma = cur_params["lambda"] * cur_params["stepsize"]
+            p, y, physics, gamma=cur_params["lambda"] * cur_params["stepsize"]
         )
 
 
@@ -114,4 +114,4 @@ class gStepADMM(gStep):
             p = x - z
         else:
             p = x + z
-        return cur_prior.prox(p, cur_params["g_param"], gamma = cur_params["stepsize"])
+        return cur_prior.prox(p, cur_params["g_param"], gamma=cur_params["stepsize"])

--- a/deepinv/optim/optim_iterators/drs.py
+++ b/deepinv/optim/optim_iterators/drs.py
@@ -87,7 +87,7 @@ class fStepDRS(fStep):
         else:
             p = z
         return cur_data_fidelity.prox(
-            p, y, physics, gamma = cur_params["lambda"] * cur_params["stepsize"]
+            p, y, physics, gamma=cur_params["lambda"] * cur_params["stepsize"]
         )
 
 
@@ -112,4 +112,4 @@ class gStepDRS(gStep):
             p = z
         else:
             p = 2 * x - z
-        return cur_prior.prox(p, cur_params["g_param"], gamma = cur_params["stepsize"])
+        return cur_prior.prox(p, cur_params["g_param"], gamma=cur_params["stepsize"])

--- a/deepinv/optim/optim_iterators/drs.py
+++ b/deepinv/optim/optim_iterators/drs.py
@@ -87,7 +87,7 @@ class fStepDRS(fStep):
         else:
             p = z
         return cur_data_fidelity.prox(
-            p, y, physics, cur_params["lambda"] * cur_params["stepsize"]
+            p, y, physics, gamma = cur_params["lambda"] * cur_params["stepsize"]
         )
 
 
@@ -112,4 +112,4 @@ class gStepDRS(gStep):
             p = z
         else:
             p = 2 * x - z
-        return cur_prior.prox(p, cur_params["stepsize"], cur_params["g_param"])
+        return cur_prior.prox(p, cur_params["g_param"], gamma = cur_params["stepsize"])

--- a/deepinv/optim/optim_iterators/hqs.py
+++ b/deepinv/optim/optim_iterators/hqs.py
@@ -51,7 +51,7 @@ class fStepHQS(fStep):
         :param deepinv.physics physics: Instance of the physics modeling the data-fidelity term.
         """
         return cur_data_fidelity.prox(
-            x, y, physics, cur_params["lambda"] * cur_params["stepsize"]
+            x, y, physics, gamma = cur_params["lambda"] * cur_params["stepsize"]
         )
 
 
@@ -71,4 +71,4 @@ class gStepHQS(gStep):
         :param dict cur_prior: Class containing the current prior.
         :param dict cur_params: Dictionary containing the current parameters of the algorithm.
         """
-        return cur_prior.prox(x, cur_params["stepsize"], cur_params["g_param"])
+        return cur_prior.prox(x, cur_params["g_param"], gamma = cur_params["stepsize"])

--- a/deepinv/optim/optim_iterators/hqs.py
+++ b/deepinv/optim/optim_iterators/hqs.py
@@ -51,7 +51,7 @@ class fStepHQS(fStep):
         :param deepinv.physics physics: Instance of the physics modeling the data-fidelity term.
         """
         return cur_data_fidelity.prox(
-            x, y, physics, gamma = cur_params["lambda"] * cur_params["stepsize"]
+            x, y, physics, gamma=cur_params["lambda"] * cur_params["stepsize"]
         )
 
 
@@ -71,4 +71,4 @@ class gStepHQS(gStep):
         :param dict cur_prior: Class containing the current prior.
         :param dict cur_params: Dictionary containing the current parameters of the algorithm.
         """
-        return cur_prior.prox(x, cur_params["g_param"], gamma = cur_params["stepsize"])
+        return cur_prior.prox(x, cur_params["g_param"], gamma=cur_params["stepsize"])

--- a/deepinv/optim/optim_iterators/pgd.py
+++ b/deepinv/optim/optim_iterators/pgd.py
@@ -62,7 +62,7 @@ class fStepPGD(fStep):
             return gradient_descent_step(x, grad)
         else:
             return cur_data_fidelity.prox(
-                x, y, physics, cur_params["lambda"] * cur_params["stepsize"]
+                x, y, physics, gamma = cur_params["lambda"] * cur_params["stepsize"]
             )
 
 
@@ -83,7 +83,7 @@ class gStepPGD(gStep):
         :param dict cur_params: Dictionary containing the current parameters of the algorithm.
         """
         if not self.g_first:
-            return cur_prior.prox(x, cur_params["stepsize"], cur_params["g_param"])
+            return cur_prior.prox(x, cur_params["g_param"], gamma = cur_params["stepsize"])
         else:
             grad = cur_params["stepsize"] * cur_prior.grad(x, cur_params["g_param"])
             return gradient_descent_step(x, grad)

--- a/deepinv/optim/optim_iterators/pgd.py
+++ b/deepinv/optim/optim_iterators/pgd.py
@@ -62,7 +62,7 @@ class fStepPGD(fStep):
             return gradient_descent_step(x, grad)
         else:
             return cur_data_fidelity.prox(
-                x, y, physics, gamma = cur_params["lambda"] * cur_params["stepsize"]
+                x, y, physics, gamma=cur_params["lambda"] * cur_params["stepsize"]
             )
 
 
@@ -83,7 +83,9 @@ class gStepPGD(gStep):
         :param dict cur_params: Dictionary containing the current parameters of the algorithm.
         """
         if not self.g_first:
-            return cur_prior.prox(x, cur_params["g_param"], gamma = cur_params["stepsize"])
+            return cur_prior.prox(
+                x, cur_params["g_param"], gamma=cur_params["stepsize"]
+            )
         else:
             grad = cur_params["stepsize"] * cur_prior.grad(x, cur_params["g_param"])
             return gradient_descent_step(x, grad)

--- a/deepinv/optim/optim_iterators/primal_dual_CP.py
+++ b/deepinv/optim/optim_iterators/primal_dual_CP.py
@@ -107,12 +107,12 @@ class fStepCP(fStep):
         if self.g_first:
             p = x - cur_params["stepsize"] * w
             return cur_data_fidelity.prox(
-                p, y, physics, cur_params["stepsize"] * cur_params["lambda"]
+                p, y, physics, gamma = cur_params["stepsize"] * cur_params["lambda"]
             )
         else:
             p = x + cur_params["stepsize_dual"] * w
             return cur_data_fidelity.prox_d_conjugate(
-                p, y, cur_params["stepsize_dual"], lamb=cur_params["lambda"]
+                p, y, gamma = cur_params["stepsize_dual"], lamb=cur_params["lambda"]
             )
 
 
@@ -136,8 +136,8 @@ class gStepCP(gStep):
         if self.g_first:
             p = x + cur_params["stepsize_dual"] * w
             return cur_prior.prox_conjugate(
-                p, cur_params["stepsize_dual"], cur_params["g_param"]
+                p, cur_params["g_param"], gamma = cur_params["stepsize_dual"]
             )
         else:
             p = x - cur_params["stepsize"] * w
-            return cur_prior.prox(p, cur_params["stepsize"], cur_params["g_param"])
+            return cur_prior.prox(p, cur_params["g_param"], gamma = cur_params["stepsize"])

--- a/deepinv/optim/optim_iterators/primal_dual_CP.py
+++ b/deepinv/optim/optim_iterators/primal_dual_CP.py
@@ -107,12 +107,12 @@ class fStepCP(fStep):
         if self.g_first:
             p = x - cur_params["stepsize"] * w
             return cur_data_fidelity.prox(
-                p, y, physics, gamma = cur_params["stepsize"] * cur_params["lambda"]
+                p, y, physics, gamma=cur_params["stepsize"] * cur_params["lambda"]
             )
         else:
             p = x + cur_params["stepsize_dual"] * w
             return cur_data_fidelity.prox_d_conjugate(
-                p, y, gamma = cur_params["stepsize_dual"], lamb=cur_params["lambda"]
+                p, y, gamma=cur_params["stepsize_dual"], lamb=cur_params["lambda"]
             )
 
 
@@ -136,8 +136,10 @@ class gStepCP(gStep):
         if self.g_first:
             p = x + cur_params["stepsize_dual"] * w
             return cur_prior.prox_conjugate(
-                p, cur_params["g_param"], gamma = cur_params["stepsize_dual"]
+                p, cur_params["g_param"], gamma=cur_params["stepsize_dual"]
             )
         else:
             p = x - cur_params["stepsize"] * w
-            return cur_prior.prox(p, cur_params["g_param"], gamma = cur_params["stepsize"])
+            return cur_prior.prox(
+                p, cur_params["g_param"], gamma=cur_params["stepsize"]
+            )

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -114,7 +114,7 @@ class BaseOptim(nn.Module):
     :param list, deepinv.optim.Prior: regularization prior.
                             Either a single instance (same prior for each iteration) or a list of instances of
                             :meth:`deepinv.optim.Prior` (distinct prior for each iteration). Default: ``None``.
-    :param int max_iter: maximum number of iterations of the optimization algorithm. Default: 50.
+    :param int max_iter: maximum number of iterations of the optimization algorithm. Default: 100.
     :param str crit_conv: convergence criterion to be used for claiming convergence, either ``"residual"`` (residual
                           of the iterate norm) or `"cost"` (on the cost function). Default: ``"residual"``
     :param float thres_conv: value of the threshold for claiming convergence. Default: ``1e-05``.
@@ -142,7 +142,7 @@ class BaseOptim(nn.Module):
         params_algo={"lambda": 1.0, "stepsize": 1.0},
         data_fidelity=None,
         prior=None,
-        max_iter=50,
+        max_iter=100,
         crit_conv="residual",
         thres_conv=1e-5,
         early_stop=False,

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -124,7 +124,7 @@ class PnP(Prior):
         Uses denoising as the proximity operator of the PnP prior :math:`g` at :math:`x`.
 
         :param torch.tensor x: Variable :math:`x` at which the proximity operator is computed.
-        :param float gamma: stepsize of the proximity operator.
+        :param float sigma_denoiser: noise level parameter of the denoiser.
         :return: (torch.tensor) proximity operator at :math:`x`.
         """
         return self.denoiser(x, sigma_denoiser)

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -70,8 +70,8 @@ class Prior(nn.Module):
     def prox(
         self,
         x,
-        gamma,
         *args,
+        gamma=1.0,
         stepsize_inter=1.0,
         max_iter_inter=50,
         tol_inter=1e-3,
@@ -92,7 +92,7 @@ class Prior(nn.Module):
             grad, x, step_size=stepsize_inter, max_iter=max_iter_inter, tol=tol_inter
         )
 
-    def prox_conjugate(self, x, gamma, *args, lamb=1, **kwargs):
+    def prox_conjugate(self, x, *args, gamma = 1.0, lamb=1.0, **kwargs):
         r"""
         Calculates the proximity operator of the convex conjugate :math:`(\lambda g)^*` at :math:`x`, using the Moreau formula.
 
@@ -119,7 +119,7 @@ class PnP(Prior):
         self.denoiser = denoiser
         self.explicit_prior = False
 
-    def prox(self, x, gamma, sigma_denoiser, *args, **kwargs):
+    def prox(self, x, sigma_denoiser, *args, **kwargs):
         r"""
         Uses denoising as the proximity operator of the PnP prior :math:`g` at :math:`x`.
 
@@ -180,7 +180,7 @@ class Tikhonov(Prior):
         """
         return x
 
-    def prox(self, x, gamma):
+    def prox(self, x, gamma=1.):
         r"""
         Calculates the proximity operator of the Tikhonov regularization term :math:`g` at :math:`x`.
 

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -92,7 +92,7 @@ class Prior(nn.Module):
             grad, x, step_size=stepsize_inter, max_iter=max_iter_inter, tol=tol_inter
         )
 
-    def prox_conjugate(self, x, *args, gamma = 1.0, lamb=1.0, **kwargs):
+    def prox_conjugate(self, x, *args, gamma=1.0, lamb=1.0, **kwargs):
         r"""
         Calculates the proximity operator of the convex conjugate :math:`(\lambda g)^*` at :math:`x`, using the Moreau formula.
 
@@ -228,7 +228,7 @@ class Tikhonov(Prior):
         """
         return x
 
-    def prox(self, x, gamma=1.):
+    def prox(self, x, gamma=1.0):
         r"""
         Calculates the proximity operator of the Tikhonov regularization term :math:`g` at :math:`x`.
 
@@ -237,8 +237,8 @@ class Tikhonov(Prior):
         :return: (torch.Tensor) proximity operator at :math:`x`.
         """
         return (1 / (gamma + 1)) * x
-    
-    
+
+
 class L1(Prior):
     r"""
     L1 regularizer :math:`g(x) = \| T x \|_1`.
@@ -256,7 +256,7 @@ class L1(Prior):
         """
         return 0.5 * torch.norm(x.view(x.shape[0], -1), p=2, dim=-1)
 
-    def prox(self, x, gamma=1.):
+    def prox(self, x, gamma=1.0):
         r"""
         Calculates the proximity operator of the l1 regularization term :math:`g` at :math:`x`.
 
@@ -265,4 +265,3 @@ class L1(Prior):
         :return: (torch.Tensor) proximity operator at :math:`x`.
         """
         return torch.sign(x) * torch.max(torch.abs(x) - gamma, torch.zeros_like(x))
-    

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -141,6 +141,11 @@ def test_drunet_inputs(imsize_1_channel, device):
     x_hat = f(y, sigma_tensor)
     assert x_hat.shape == x.shape
 
+    # Case 4: sigma is a tensor with no dimension
+    sigma_tensor = torch.tensor(sigma).to(device)
+    x_hat = f(y, sigma_tensor)
+    assert x_hat.shape == x.shape
+
 
 def test_diffunetmodel(imsize, device):
     # This model is a bit different from others as not strictly a denoiser as such.

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -66,7 +66,7 @@ def test_data_fidelity_l2(device):
     )
 
     # Compute the deepinv proximity operator
-    deepinv_prox = data_fidelity.prox(x, y, physics, gamma)
+    deepinv_prox = data_fidelity.prox(x, y, physics, gamma = gamma)
 
     assert torch.allclose(deepinv_prox, manual_prox)
 
@@ -77,8 +77,8 @@ def test_data_fidelity_l2(device):
     assert torch.allclose(grad_deepinv, grad_manual)
 
     # 5. Testing the torch autograd implementation of the gradient
-    def dummy_torch_l2(x):
-        return 0.5 * torch.norm((B @ x).flatten(), p=2, dim=-1) ** 2
+    def dummy_torch_l2(x,y):
+        return 0.5 * torch.norm((B @ (x - y)).flatten(), p=2, dim=-1) ** 2
 
     torch_loss = DataFidelity(d=dummy_torch_l2)
     torch_loss_grad = torch_loss.grad_d(x, y)
@@ -86,12 +86,10 @@ def test_data_fidelity_l2(device):
     assert torch.allclose(torch_loss_grad, grad_manual)
 
     # 6. Testing the torch autograd implementation of the prox
-    def dummy_torch_l2(x):
-        return 0.5 * torch.norm((B @ x).flatten(), p=2) ** 2
 
     torch_loss = DataFidelity(d=dummy_torch_l2)
     torch_loss_prox = torch_loss.prox_d(
-        x, y, gamma, stepsize_inter=0.1, max_iter_inter=1000, tol_inter=1e-6
+        x, y, gamma = gamma, stepsize_inter=0.1, max_iter_inter=1000, tol_inter=1e-6
     )
 
     manual_prox = (Id + gamma * B.transpose(0, 1) @ B).inverse() @ (
@@ -126,7 +124,7 @@ def test_data_fidelity_indicator(device):
 
     # 2. Testing trivial operations on f (and not f \circ A)
     x_proj = torch.Tensor([[[1.0], [1 + radius]]]).to(device)
-    assert torch.allclose(data_fidelity.prox_d(x, y, gamma=None), x_proj)
+    assert torch.allclose(data_fidelity.prox_d(x, y), x_proj)
 
     # 3. Testing the proximity operator of the f \circ A
     data_fidelity = IndicatorL2(radius=0.5)
@@ -238,7 +236,7 @@ def test_optim_algo(name_algo, imsize, dummy_dataset, device):
             if not g_first:
                 subdiff = prior.grad(x)
                 moreau_grad = (
-                    x - data_fidelity.prox(x, y, physics, lamb * stepsize)
+                    x - data_fidelity.prox(x, y, physics, gamma = lamb * stepsize)
                 ) / (
                     lamb * stepsize
                 )  # Gradient of the moreau envelope
@@ -248,7 +246,7 @@ def test_optim_algo(name_algo, imsize, dummy_dataset, device):
             else:
                 subdiff = lamb * data_fidelity.grad(x, y, physics)
                 moreau_grad = (
-                    x - prior.prox(x, stepsize)
+                    x - prior.prox(x, gamma = stepsize)
                 ) / stepsize  # Gradient of the moreau envelope
                 assert torch.allclose(
                     moreau_grad, -subdiff, atol=1e-8

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -66,7 +66,7 @@ def test_data_fidelity_l2(device):
     )
 
     # Compute the deepinv proximity operator
-    deepinv_prox = data_fidelity.prox(x, y, physics, gamma = gamma)
+    deepinv_prox = data_fidelity.prox(x, y, physics, gamma=gamma)
 
     assert torch.allclose(deepinv_prox, manual_prox)
 
@@ -77,7 +77,7 @@ def test_data_fidelity_l2(device):
     assert torch.allclose(grad_deepinv, grad_manual)
 
     # 5. Testing the torch autograd implementation of the gradient
-    def dummy_torch_l2(x,y):
+    def dummy_torch_l2(x, y):
         return 0.5 * torch.norm((B @ (x - y)).flatten(), p=2, dim=-1) ** 2
 
     torch_loss = DataFidelity(d=dummy_torch_l2)
@@ -89,7 +89,7 @@ def test_data_fidelity_l2(device):
 
     torch_loss = DataFidelity(d=dummy_torch_l2)
     torch_loss_prox = torch_loss.prox_d(
-        x, y, gamma = gamma, stepsize_inter=0.1, max_iter_inter=1000, tol_inter=1e-6
+        x, y, gamma=gamma, stepsize_inter=0.1, max_iter_inter=1000, tol_inter=1e-6
     )
 
     manual_prox = (Id + gamma * B.transpose(0, 1) @ B).inverse() @ (
@@ -236,7 +236,7 @@ def test_optim_algo(name_algo, imsize, dummy_dataset, device):
             if not g_first:
                 subdiff = prior.grad(x)
                 moreau_grad = (
-                    x - data_fidelity.prox(x, y, physics, gamma = lamb * stepsize)
+                    x - data_fidelity.prox(x, y, physics, gamma=lamb * stepsize)
                 ) / (
                     lamb * stepsize
                 )  # Gradient of the moreau envelope
@@ -246,7 +246,7 @@ def test_optim_algo(name_algo, imsize, dummy_dataset, device):
             else:
                 subdiff = lamb * data_fidelity.grad(x, y, physics)
                 moreau_grad = (
-                    x - prior.prox(x, gamma = stepsize)
+                    x - prior.prox(x, gamma=stepsize)
                 ) / stepsize  # Gradient of the moreau envelope
                 assert torch.allclose(
                     moreau_grad, -subdiff, atol=1e-8

--- a/examples/plug-and-play/demo_PnP_custom_optim.py
+++ b/examples/plug-and-play/demo_PnP_custom_optim.py
@@ -114,7 +114,7 @@ class fStepCV(fStep):
         :param deepinv.physics physics: Instance of the physics modeling the data-fidelity term.
         """
         return cur_data_fidelity.prox_d_conjugate(
-            u, y, cur_params["sigma"], lamb=cur_params["lambda"]
+            u, y, gamma = cur_params["sigma"], lamb=cur_params["lambda"]
         )
 
 
@@ -135,7 +135,7 @@ class gStepCV(gStep):
         :param dict cur_params: Dictionary containing the current gStep parameters
             (keys `"stepsize"` and `"g_param"`).
         """
-        return cur_prior.prox(v, cur_params["stepsize"], cur_params["g_param"])
+        return cur_prior.prox(v, cur_params["g_param"], gamma = cur_params["stepsize"])
 
 
 # %%

--- a/examples/plug-and-play/demo_PnP_custom_optim.py
+++ b/examples/plug-and-play/demo_PnP_custom_optim.py
@@ -114,7 +114,7 @@ class fStepCV(fStep):
         :param deepinv.physics physics: Instance of the physics modeling the data-fidelity term.
         """
         return cur_data_fidelity.prox_d_conjugate(
-            u, y, gamma = cur_params["sigma"], lamb=cur_params["lambda"]
+            u, y, gamma=cur_params["sigma"], lamb=cur_params["lambda"]
         )
 
 
@@ -135,7 +135,7 @@ class gStepCV(gStep):
         :param dict cur_params: Dictionary containing the current gStep parameters
             (keys `"stepsize"` and `"g_param"`).
         """
-        return cur_prior.prox(v, cur_params["g_param"], gamma = cur_params["stepsize"])
+        return cur_prior.prox(v, cur_params["g_param"], gamma=cur_params["stepsize"])
 
 
 # %%


### PR DESCRIPTION
- In all the Prox calculations in the DataFidelity and Prior classes, the stepsize gamma parameter is set to 1 by default. So as to compute the prox of a function without needing to specify a stepsize.
- The d function, argument in the DataFidelity class, took only one argument as input and then the distance was computed by sending x-y to d() . This is not desirable because most of the distances don't take x-y as input. For instance the KL divergence. I changed d to take both x and y as inputs (as it was actually written in the docs). Changed the examples and tests accodringly.
- DRUNet would not be used in unfolded because the sigma_denoiser parameter sent is a tensor (with no dimensions). Changed the forward implementation to use sigma.item() in this case.
- Add L1 prior in the prior.py file. 

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
