### PR TITLE
training perform_eval problem

### DIFF
--- a/deepinv/training_utils.py
+++ b/deepinv/training_utils.py
@@ -128,8 +128,9 @@ def train(
         perform_eval = (
             (not unsupervised)
             and eval_dataloader
-            and (epoch + 1 % eval_interval == 0 or epoch + 1 == epochs)
+            and ((epoch + 1) % eval_interval == 0 or epoch + 1 == epochs)
         )
+
         if perform_eval:
             test_psnr, _, _, _ = test(
                 model,


### PR DESCRIPTION
Missing paranthesis in the perform_eval variable definition in training_utils. 

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
