### PR TITLE
Fix prior

### DIFF
--- a/deepinv/optim/__init__.py
+++ b/deepinv/optim/__init__.py
@@ -1,5 +1,5 @@
 from .data_fidelity import DataFidelity, L2, L1, IndicatorL2, PoissonLikelihood
 from .optimizers import BaseOptim, optim_builder
 from .fixed_point import FixedPoint
-from .prior import Prior, ScorePrior, Tikhonov, PnP, RED
+from .prior import Prior, ScorePrior, Tikhonov, PnP, RED, L1Prior
 from .optim_iterators.optim_iterator import OptimIterator

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -211,14 +211,15 @@ class Tikhonov(Prior):
         super().__init__(*args, **kwargs)
         self.explicit_prior = True
 
-    def g(self, x):
+    def g(self, x, ths=1.0):
         r"""
-        Computes the Tikhonov regularizer :math:`g(x) = \frac{1}{2}\| x \|_2^2`.
+        Computes the Tikhonov regularizer :math:`g(x) = \frac{\tau}{2}\| x \|_2^2`.
 
         :param torch.Tensor x: Variable :math:`x` at which the prior is computed.
+        :param float ths: regularization parameter :math:`\tau`.
         :return: (torch.Tensor) prior :math:`g(x)`.
         """
-        return 0.5 * torch.norm(x.view(x.shape[0], -1), p=2, dim=-1)
+        return 0.5 * ths * torch.norm(x.view(x.shape[0], -1), p=2, dim=-1)**2
 
     def grad(self, x):
         r"""
@@ -229,41 +230,51 @@ class Tikhonov(Prior):
         """
         return x
 
-    def prox(self, x, gamma=1.0):
+    def prox(self, x, ths=1.0, gamma=1.0):
         r"""
-        Calculates the proximity operator of the Tikhonov regularization term :math:`g` at :math:`x`.
+        Calculates the proximity operator of the Tikhonov regularization term :math:`\gamma \tau g` at :math:`x`.
 
         :param torch.Tensor x: Variable :math:`x` at which the proximity operator is computed.
+        :param float ths: regularization parameter :math:`\tau`.
         :param float gamma: stepsize of the proximity operator.
         :return: (torch.Tensor) proximity operator at :math:`x`.
         """
-        return (1 / (gamma + 1)) * x
+        return (1 / (ths*gamma + 1)) * x
 
 
 class L1(Prior):
     r"""
-    L1 regularizer :math:`g(x) = \| T x \|_1`.
+    L1 regularizer :math:`g(x) = \| x \|_1`.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.explicit_prior = True
 
-    def g(self, x):
+    def g(self, x, ths=1.0):
         r"""
-        Computes the regularizer :math:`g(x) = \frac{1}{2}\| x \|_1.
+        Computes the regularizer :math:`g(x) = \tau*\| x \|_1.
 
         :param torch.Tensor x: Variable :math:`x` at which the prior is computed.
+        :param float ths: threshold parameter :math:`\tau`.
         :return: (torch.Tensor) prior :math:`g(x)`.
         """
-        return 0.5 * torch.norm(x.view(x.shape[0], -1), p=2, dim=-1)
+        return ths * torch.norm(x.view(x.shape[0], -1), p=1, dim=-1)
 
-    def prox(self, x, gamma=1.0):
+    def prox(self, x, ths=1.0, gamma=1.0):
         r"""
         Calculates the proximity operator of the l1 regularization term :math:`g` at :math:`x`.
+        More precisely, it computes
+
+        .. math::
+            \operatorname{prox}_{\gamma \tau g}(x) = \operatorname{sign}(x) \max(|x| - \gamma \tau, 0)
+
+
+        where :math:`\tau` is the threshold parameter and :math:`\gamma` is a stepsize.
 
         :param torch.Tensor x: Variable :math:`x` at which the proximity operator is computed.
+        :param float ths: threshold parameter :math:`\tau`.
         :param float gamma: stepsize of the proximity operator.
         :return: (torch.Tensor) proximity operator at :math:`x`.
         """
-        return torch.sign(x) * torch.max(torch.abs(x) - gamma, torch.zeros_like(x))
+        return torch.sign(x) * torch.max(torch.abs(x) - ths*gamma, torch.zeros_like(x))

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -219,7 +219,11 @@ class Tikhonov(Prior):
         :param float ths: regularization parameter :math:`\tau`.
         :return: (torch.Tensor) prior :math:`g(x)`.
         """
-        return 0.5 * ths * torch.norm(x.contiguous().view(x.shape[0], -1), p=2, dim=-1)**2
+        return (
+            0.5
+            * ths
+            * torch.norm(x.contiguous().view(x.shape[0], -1), p=2, dim=-1) ** 2
+        )
 
     def grad(self, x):
         r"""
@@ -239,7 +243,7 @@ class Tikhonov(Prior):
         :param float gamma: stepsize of the proximity operator.
         :return: (torch.Tensor) proximity operator at :math:`x`.
         """
-        return (1 / (ths*gamma + 1)) * x
+        return (1 / (ths * gamma + 1)) * x
 
 
 class L1Prior(Prior):
@@ -277,4 +281,6 @@ class L1Prior(Prior):
         :param float gamma: stepsize of the proximity operator.
         :return: (torch.Tensor) proximity operator at :math:`x`.
         """
-        return torch.sign(x) * torch.max(torch.abs(x) - ths*gamma, torch.zeros_like(x))
+        return torch.sign(x) * torch.max(
+            torch.abs(x) - ths * gamma, torch.zeros_like(x)
+        )

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -219,7 +219,7 @@ class Tikhonov(Prior):
         :param float ths: regularization parameter :math:`\tau`.
         :return: (torch.Tensor) prior :math:`g(x)`.
         """
-        return 0.5 * ths * torch.norm(x.view(x.shape[0], -1), p=2, dim=-1)**2
+        return 0.5 * ths * torch.norm(x.contiguous().view(x.shape[0], -1), p=2, dim=-1)**2
 
     def grad(self, x):
         r"""
@@ -242,9 +242,9 @@ class Tikhonov(Prior):
         return (1 / (ths*gamma + 1)) * x
 
 
-class L1(Prior):
+class L1Prior(Prior):
     r"""
-    L1 regularizer :math:`g(x) = \| x \|_1`.
+    L1 prior :math:`g(x) = \| x \|_1`.
     """
 
     def __init__(self, *args, **kwargs):
@@ -259,7 +259,7 @@ class L1(Prior):
         :param float ths: threshold parameter :math:`\tau`.
         :return: (torch.Tensor) prior :math:`g(x)`.
         """
-        return ths * torch.norm(x.view(x.shape[0], -1), p=1, dim=-1)
+        return ths * torch.norm(x.contiguous().view(x.shape[0], -1), p=1, dim=-1)
 
     def prox(self, x, ths=1.0, gamma=1.0):
         r"""

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -361,10 +361,11 @@ def test_pnp_algo(pnp_algo, imsize, dummy_dataset, device):
 @pytest.mark.parametrize("pnp_algo", ["PGD", "HQS", "DRS", "ADMM", "CP"])
 def test_priors_algo(pnp_algo, imsize, dummy_dataset, device):
     # for prior_name in ['L1Prior', 'Tikhonov']:
-    for prior_name in ['L1Prior', 'Tikhonov']:
-
+    for prior_name in ["L1Prior", "Tikhonov"]:
         # 1. Generate a dummy dataset
-        dataloader = DataLoader(dummy_dataset, batch_size=1, shuffle=False, num_workers=0)
+        dataloader = DataLoader(
+            dummy_dataset, batch_size=1, shuffle=False, num_workers=0
+        )
         test_sample = next(iter(dataloader)).to(device)
 
         # 2. Set a physical experiment (here, deblurring)
@@ -382,9 +383,9 @@ def test_priors_algo(pnp_algo, imsize, dummy_dataset, device):
         data_fidelity = L2()
 
         # here the prior model is common for all iterations
-        if prior_name == 'L1Prior':
+        if prior_name == "L1Prior":
             prior = dinv.optim.prior.L1Prior()
-        elif prior_name == 'Tikhonov':
+        elif prior_name == "Tikhonov":
             prior = dinv.optim.prior.Tikhonov()
 
         stepsize_dual = 1.0 if pnp_algo == "CP" else None
@@ -426,7 +427,6 @@ def test_priors_algo(pnp_algo, imsize, dummy_dataset, device):
         #     )
 
         assert opt_algo.has_converged
-
 
 
 @pytest.mark.parametrize("red_algo", ["GD", "PGD"])

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -358,6 +358,77 @@ def test_pnp_algo(pnp_algo, imsize, dummy_dataset, device):
     assert pnp.has_converged
 
 
+@pytest.mark.parametrize("pnp_algo", ["PGD", "HQS", "DRS", "ADMM", "CP"])
+def test_priors_algo(pnp_algo, imsize, dummy_dataset, device):
+    # for prior_name in ['L1Prior', 'Tikhonov']:
+    for prior_name in ['L1Prior', 'Tikhonov']:
+
+        # 1. Generate a dummy dataset
+        dataloader = DataLoader(dummy_dataset, batch_size=1, shuffle=False, num_workers=0)
+        test_sample = next(iter(dataloader)).to(device)
+
+        # 2. Set a physical experiment (here, deblurring)
+        physics = dinv.physics.Blur(
+            dinv.physics.blur.gaussian_blur(sigma=(2, 0.1), angle=45.0), device=device
+        )
+        y = physics(test_sample)
+        max_iter = 1000
+        # Note: results are better for sigma_denoiser=0.001, but it takes longer to run.
+        # sigma_denoiser = torch.tensor([[0.1]])
+        sigma_denoiser = torch.tensor([[1.0]])
+        stepsize = 1.0
+        lamb = 1.0
+
+        data_fidelity = L2()
+
+        # here the prior model is common for all iterations
+        if prior_name == 'L1Prior':
+            prior = dinv.optim.prior.L1Prior()
+        elif prior_name == 'Tikhonov':
+            prior = dinv.optim.prior.Tikhonov()
+
+        stepsize_dual = 1.0 if pnp_algo == "CP" else None
+        params_algo = {
+            "stepsize": stepsize,
+            "g_param": sigma_denoiser,
+            "lambda": lamb,
+            "stepsize_dual": stepsize_dual,
+        }
+
+        custom_init = custom_init_CP if pnp_algo == "CP" else None
+
+        opt_algo = optim_builder(
+            pnp_algo,
+            prior=prior,
+            data_fidelity=data_fidelity,
+            max_iter=max_iter,
+            thres_conv=1e-4,
+            verbose=True,
+            params_algo=params_algo,
+            early_stop=True,
+            custom_init=custom_init,
+        )
+
+        x = opt_algo(y, physics)
+
+        # # For debugging  # Remark: to get nice results, lower sigma_denoiser to 0.001
+        # plot = True
+        # if plot:
+        #     imgs = []
+        #     imgs.append(torch2cpu(y[0, :, :, :].unsqueeze(0)))
+        #     imgs.append(torch2cpu(x[0, :, :, :].unsqueeze(0)))
+        #     imgs.append(torch2cpu(test_sample[0, :, :, :].unsqueeze(0)))
+        #
+        #     titles = ["Input", "Output", "Groundtruth"]
+        #     num_im = 3
+        #     plot_debug(
+        #         imgs, shape=(1, num_im), titles=titles, row_order=True, save_dir=None
+        #     )
+
+        assert opt_algo.has_converged
+
+
+
 @pytest.mark.parametrize("red_algo", ["GD", "PGD"])
 def test_red_algo(red_algo, imsize, dummy_dataset, device):
     # This test uses WaveletPrior, which requires pytorch_wavelets

--- a/docs/source/deepinv.optim.rst
+++ b/docs/source/deepinv.optim.rst
@@ -98,6 +98,7 @@ computing the proximity operator is overwritten by a method performing denoising
    deepinv.optim.RED
    deepinv.optim.ScorePrior
    deepinv.optim.Tikhonov
+   deepinv.optim.L1Prior
 
 
 .. _optim-params:


### PR DESCRIPTION
In this PR we fix a bug that was raised when using priors from the `Prior` class, namely Tikhonov and L1Prior.

EDIT: there remains a convergence issue that fails when the regularization parameter is not 1, I still need to fix this.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
