### PR TITLE
Small improvements to unet.UNet, shift.Shift & noise.PoissonNoise

### DIFF
--- a/deepinv/models/unet.py
+++ b/deepinv/models/unet.py
@@ -60,6 +60,10 @@ class UNet(nn.Module):
     can be controlled with the `scales` parameter. The number of trainable parameters increases with the number of
     scales.
 
+    .. warning::
+        When using the bias-free batch norm `BFBatchNorm2d` via `batch_norm=biasfree`, NaNs may be encountered
+        during training, causing the whole training procedure to fail.  
+
     :param int in_channels: input image channels
     :param int out_channels: output image channels
     :param bool residual: use a skip-connection between output and output.
@@ -67,7 +71,7 @@ class UNet(nn.Module):
     :param bool cat: use skip-connections between intermediate levels.
     :param bool bias: use learnable biases.
     :param bool|str batch_norm: if False, no batchnorm applied, if True, use `nn.BatchNorm2d`, if `biasfree`, use
-        `BFBatchNorm2d`.
+        `BFBatchNorm2d` from `"Robust And Interpretable Blind Image Denoising Via Bias-Free Convolutional Neural Networks" by Mohan et al. <https://arxiv.org/abs/1906.05478>`_.
     :param int scales: Number of downsampling steps used in the U-Net. The options are 2,3,4 and 5.
         The number of trainable parameters increases with the scale.
     """

--- a/deepinv/models/unet.py
+++ b/deepinv/models/unet.py
@@ -66,7 +66,7 @@ class UNet(nn.Module):
     :param bool circular_padding: circular padding for the convolutional layers.
     :param bool cat: use skip-connections between intermediate levels.
     :param bool bias: use learnable biases.
-    :param bool|str batch_norm: if False, no batchnorm applied, if True, use `BFBatchNorm2d`, if `noiseless`, use 
+    :param bool|str batch_norm: if False, no batchnorm applied, if True, use `BFBatchNorm2d`, if `noiseless`, use
         `nn.BatchNorm2d`.
     :param int scales: Number of downsampling steps used in the U-Net. The options are 2,3,4 and 5.
         The number of trainable parameters increases with the scale.
@@ -93,9 +93,9 @@ class UNet(nn.Module):
         self.cat = cat
         self.compact = scales
         self.Maxpool = nn.MaxPool2d(kernel_size=2, stride=2)
-        
+
         noiseless = batch_norm != "noiseless"
-        
+
         def conv_block(ch_in, ch_out):
             if batch_norm:
                 return nn.Sequential(
@@ -108,12 +108,16 @@ class UNet(nn.Module):
                         bias=bias,
                         padding_mode="circular" if circular_padding else "zeros",
                     ),
-                    BFBatchNorm2d(ch_out, use_bias=bias) if noiseless else nn.BatchNorm2d(ch_out),
+                    BFBatchNorm2d(ch_out, use_bias=bias)
+                    if noiseless
+                    else nn.BatchNorm2d(ch_out),
                     nn.ReLU(inplace=True),
                     nn.Conv2d(
                         ch_out, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
                     ),
-                    BFBatchNorm2d(ch_out, use_bias=bias) if noiseless else nn.BatchNorm2d(ch_out),
+                    BFBatchNorm2d(ch_out, use_bias=bias)
+                    if noiseless
+                    else nn.BatchNorm2d(ch_out),
                     nn.ReLU(inplace=True),
                 )
             else:
@@ -141,7 +145,9 @@ class UNet(nn.Module):
                     nn.Conv2d(
                         ch_in, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
                     ),
-                    BFBatchNorm2d(ch_out, use_bias=bias) if noiseless else nn.BatchNorm2d(ch_out),
+                    BFBatchNorm2d(ch_out, use_bias=bias)
+                    if noiseless
+                    else nn.BatchNorm2d(ch_out),
                     nn.ReLU(inplace=True),
                 )
             else:

--- a/deepinv/models/unet.py
+++ b/deepinv/models/unet.py
@@ -66,6 +66,8 @@ class UNet(nn.Module):
     :param bool circular_padding: circular padding for the convolutional layers.
     :param bool cat: use skip-connections between intermediate levels.
     :param bool bias: use learnable biases.
+    :param bool|str batch_norm: if False, no batchnorm applied, if True, use `BFBatchNorm2d`, if `noiseless`, use 
+        `nn.BatchNorm2d`.
     :param int scales: Number of downsampling steps used in the U-Net. The options are 2,3,4 and 5.
         The number of trainable parameters increases with the scale.
     """
@@ -91,7 +93,9 @@ class UNet(nn.Module):
         self.cat = cat
         self.compact = scales
         self.Maxpool = nn.MaxPool2d(kernel_size=2, stride=2)
-
+        
+        noiseless = batch_norm != "noiseless"
+        
         def conv_block(ch_in, ch_out):
             if batch_norm:
                 return nn.Sequential(
@@ -104,12 +108,12 @@ class UNet(nn.Module):
                         bias=bias,
                         padding_mode="circular" if circular_padding else "zeros",
                     ),
-                    BFBatchNorm2d(ch_out, use_bias=bias),
+                    BFBatchNorm2d(ch_out, use_bias=bias) if noiseless else nn.BatchNorm2d(ch_out),
                     nn.ReLU(inplace=True),
                     nn.Conv2d(
                         ch_out, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
                     ),
-                    BFBatchNorm2d(ch_out, use_bias=bias),
+                    BFBatchNorm2d(ch_out, use_bias=bias) if noiseless else nn.BatchNorm2d(ch_out),
                     nn.ReLU(inplace=True),
                 )
             else:
@@ -137,7 +141,7 @@ class UNet(nn.Module):
                     nn.Conv2d(
                         ch_in, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
                     ),
-                    BFBatchNorm2d(ch_out, use_bias=bias),
+                    BFBatchNorm2d(ch_out, use_bias=bias) if noiseless else nn.BatchNorm2d(ch_out),
                     nn.ReLU(inplace=True),
                 )
             else:

--- a/deepinv/models/unet.py
+++ b/deepinv/models/unet.py
@@ -66,8 +66,8 @@ class UNet(nn.Module):
     :param bool circular_padding: circular padding for the convolutional layers.
     :param bool cat: use skip-connections between intermediate levels.
     :param bool bias: use learnable biases.
-    :param bool|str batch_norm: if False, no batchnorm applied, if True, use `BFBatchNorm2d`, if `noiseless`, use
-        `nn.BatchNorm2d`.
+    :param bool|str batch_norm: if False, no batchnorm applied, if True, use `nn.BatchNorm2d`, if `biasfree`, use
+        `BFBatchNorm2d`.
     :param int scales: Number of downsampling steps used in the U-Net. The options are 2,3,4 and 5.
         The number of trainable parameters increases with the scale.
     """
@@ -94,7 +94,7 @@ class UNet(nn.Module):
         self.compact = scales
         self.Maxpool = nn.MaxPool2d(kernel_size=2, stride=2)
 
-        noiseless = batch_norm != "noiseless"
+        biasfree = batch_norm == "biasfree"
 
         def conv_block(ch_in, ch_out):
             if batch_norm:
@@ -109,14 +109,14 @@ class UNet(nn.Module):
                         padding_mode="circular" if circular_padding else "zeros",
                     ),
                     BFBatchNorm2d(ch_out, use_bias=bias)
-                    if noiseless
+                    if biasfree
                     else nn.BatchNorm2d(ch_out),
                     nn.ReLU(inplace=True),
                     nn.Conv2d(
                         ch_out, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
                     ),
                     BFBatchNorm2d(ch_out, use_bias=bias)
-                    if noiseless
+                    if biasfree
                     else nn.BatchNorm2d(ch_out),
                     nn.ReLU(inplace=True),
                 )
@@ -146,7 +146,7 @@ class UNet(nn.Module):
                         ch_in, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
                     ),
                     BFBatchNorm2d(ch_out, use_bias=bias)
-                    if noiseless
+                    if biasfree
                     else nn.BatchNorm2d(ch_out),
                     nn.ReLU(inplace=True),
                 )

--- a/deepinv/models/unet.py
+++ b/deepinv/models/unet.py
@@ -62,7 +62,7 @@ class UNet(nn.Module):
 
     .. warning::
         When using the bias-free batch norm `BFBatchNorm2d` via `batch_norm=biasfree`, NaNs may be encountered
-        during training, causing the whole training procedure to fail.  
+        during training, causing the whole training procedure to fail.
 
     :param int in_channels: input image channels
     :param int out_channels: output image channels

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -114,7 +114,7 @@ class PoissonNoise(torch.nn.Module):
         :param torch.Tensor x: measurements
         :returns: noisy measurements
         """
-        y = torch.poisson(torch.clip(x / self.gain, min=0.))
+        y = torch.poisson(torch.clip(x / self.gain, min=0.0))
         if self.normalize:
             y *= self.gain
         return y

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -107,6 +107,7 @@ class PoissonNoise(torch.nn.Module):
             torch.tensor(normalize), requires_grad=False
         )
         self.gain = torch.nn.Parameter(torch.tensor(gain), requires_grad=False)
+        self.clip_positive = clip_positive
 
     def forward(self, x):
         r"""
@@ -116,7 +117,7 @@ class PoissonNoise(torch.nn.Module):
         :returns: noisy measurements
         """
         y = torch.poisson(
-            torch.clip(x / self.gain, min=0.0) if clip_positive else x / self.gain
+            torch.clip(x / self.gain, min=0.0) if self.clip_positive else x / self.gain
         )
         if self.normalize:
             y *= self.gain

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -114,7 +114,7 @@ class PoissonNoise(torch.nn.Module):
         :param torch.Tensor x: measurements
         :returns: noisy measurements
         """
-        y = torch.poisson(x / self.gain)
+        y = torch.poisson(torch.clip(x / self.gain, min=0.))
         if self.normalize:
             y *= self.gain
         return y

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -115,7 +115,9 @@ class PoissonNoise(torch.nn.Module):
         :param torch.Tensor x: measurements
         :returns: noisy measurements
         """
-        y = torch.poisson(torch.clip(x / self.gain, min=0.0) if clip_positive else x / self.gain)
+        y = torch.poisson(
+            torch.clip(x / self.gain, min=0.0) if clip_positive else x / self.gain
+        )
         if self.normalize:
             y *= self.gain
         return y

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -97,10 +97,11 @@ class PoissonNoise(torch.nn.Module):
 
     :param float gain: gain of the noise.
     :param bool normalize: normalize the output.
+    :param bool clip_positive: clip the input to be positive before adding noise. This may be needed when a NN outputs negative values e.g. when using LeakyReLU.
 
     """
 
-    def __init__(self, gain=1.0, normalize=True):
+    def __init__(self, gain=1.0, normalize=True, clip_positive=False):
         super().__init__()
         self.normalize = torch.nn.Parameter(
             torch.tensor(normalize), requires_grad=False
@@ -114,7 +115,7 @@ class PoissonNoise(torch.nn.Module):
         :param torch.Tensor x: measurements
         :returns: noisy measurements
         """
-        y = torch.poisson(torch.clip(x / self.gain, min=0.0))
+        y = torch.poisson(torch.clip(x / self.gain, min=0.0) if clip_positive else x / self.gain)
         if self.normalize:
             y *= self.gain
         return y

--- a/deepinv/transform/shift.py
+++ b/deepinv/transform/shift.py
@@ -11,7 +11,7 @@ class Shift(torch.nn.Module):
     :param float shift_max: maximum shift as fraction of total height/width.
     """
 
-    def __init__(self, n_trans=1, shift_max=1.):
+    def __init__(self, n_trans=1, shift_max=1.0):
         super(Shift, self).__init__()
         self.n_trans = n_trans
         self.shift_max = shift_max

--- a/deepinv/transform/shift.py
+++ b/deepinv/transform/shift.py
@@ -25,11 +25,19 @@ class Shift(torch.nn.Module):
         """
         H, W = x.shape[-2:]
         assert self.n_trans <= H - 1 and self.n_trans <= W - 1
-        
+
         H_max, W_max = int(self.shift_max * H), int(self.shift_max * W)
-        
-        x_shift = torch.arange(-H_max, H_max)[torch.randperm(2 * H_max)][: self.n_trans] if H_max > 0 else torch.zeros(self.n_trans)
-        y_shift = torch.arange(-W_max, W_max)[torch.randperm(2 * W_max)][: self.n_trans] if W_max > 0 else torch.zeros(self.n_trans)
+
+        x_shift = (
+            torch.arange(-H_max, H_max)[torch.randperm(2 * H_max)][: self.n_trans]
+            if H_max > 0
+            else torch.zeros(self.n_trans)
+        )
+        y_shift = (
+            torch.arange(-W_max, W_max)[torch.randperm(2 * W_max)][: self.n_trans]
+            if W_max > 0
+            else torch.zeros(self.n_trans)
+        )
 
         out = torch.cat(
             [torch.roll(x, [sx, sy], [-2, -1]) for sx, sy in zip(x_shift, y_shift)],

--- a/deepinv/transform/shift.py
+++ b/deepinv/transform/shift.py
@@ -11,7 +11,7 @@ class Shift(torch.nn.Module):
     :param float shift_max: maximum shift as fraction of total height/width.
     """
 
-    def __init__(self, n_trans=1, shift_max=1):
+    def __init__(self, n_trans=1, shift_max=1.):
         super(Shift, self).__init__()
         self.n_trans = n_trans
         self.shift_max = shift_max

--- a/deepinv/transform/shift.py
+++ b/deepinv/transform/shift.py
@@ -8,11 +8,13 @@ class Shift(torch.nn.Module):
     Generates n_transf randomly shifted versions of 2D images with circular padding.
 
     :param n_trans: number of shifted versions generated per input image.
+    :param shift_max: maximum shift as fraction of total height/width
     """
 
-    def __init__(self, n_trans=1):
+    def __init__(self, n_trans=1, shift_max=1):
         super(Shift, self).__init__()
         self.n_trans = n_trans
+        self.shift_max = shift_max
 
     def forward(self, x):
         r"""
@@ -23,8 +25,11 @@ class Shift(torch.nn.Module):
         """
         H, W = x.shape[-2:]
         assert self.n_trans <= H - 1 and self.n_trans <= W - 1
-        x_shift = torch.arange(-H, H)[torch.randperm(2 * H)][: self.n_trans]
-        y_shift = torch.arange(-W, W)[torch.randperm(2 * W)][: self.n_trans]
+        
+        H_max, W_max = int(self.shift_max * H), int(self.shift_max * W)
+        
+        x_shift = torch.arange(-H_max, H_max)[torch.randperm(2 * H_max)][: self.n_trans] if H_max > 0 else torch.zeros(self.n_trans)
+        y_shift = torch.arange(-W_max, W_max)[torch.randperm(2 * W_max)][: self.n_trans] if W_max > 0 else torch.zeros(self.n_trans)
 
         out = torch.cat(
             [torch.roll(x, [sx, sy], [-2, -1]) for sx, sy in zip(x_shift, y_shift)],


### PR DESCRIPTION
- UNet: option to select nn.BatchNorm2d as batch norm instead of BFBatchNorm2d
- Shift: add option for max percentage shift
- PoissonNoise: clip input to non-negative


### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
