### PR TITLE
fix noise range decomposable physics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ New Features
 
 Fixed
 ^^^^^
+- Fixed noise additive model for DecomposablePhysics (:gh:`138` by `Matthieu Terris`_) - 22/12/2023
 
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ New Features
 
 Fixed
 ^^^^^
-- Fixed noise additive model for DecomposablePhysics (:gh:`138` by `Matthieu Terris`_) - 22/12/2023
+- Fixed :gh:`136` noise additive model for DecomposablePhysics (:gh:`138` by `Matthieu Terris`_) - 22/12/2023
 
 
 Changed

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -491,7 +491,11 @@ class BlurFFT(DecomposablePhysics):
         # Romberg notes)
 
     def V(self, x):
-        return fft.irfft2(torch.view_as_complex(x), norm="ortho", s=self.img_size[-2:])
+        if x.shape[-1] == 2:
+            y = torch.view_as_complex(x)
+        else:
+            y = x
+        return fft.irfft2(y, norm="ortho", s=self.img_size[-2:])
 
 
 # # test code

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -487,15 +487,10 @@ class BlurFFT(DecomposablePhysics):
     def U_adjoint(self, x):
         return torch.view_as_real(
             fft.rfft2(x, norm="ortho") * torch.conj(self.angle)
-        )  # make it a true SVD (see J.
-        # Romberg notes)
+        )  # make it a true SVD (see J. Romberg notes)
 
     def V(self, x):
-        if x.shape[-1] == 2:
-            y = torch.view_as_complex(x)
-        else:
-            y = x
-        return fft.irfft2(y, norm="ortho", s=self.img_size[-2:])
+        return fft.irfft2(torch.view_as_complex(x), norm="ortho", s=self.img_size[-2:])
 
 
 # # test code

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -491,6 +491,21 @@ class DecomposablePhysics(LinearPhysics):
 
         return self.V(mask * self.U_adjoint(y))
 
+    def noise(self, x):
+        r"""
+        Incorporates noise into the measurements :math:`\tilde{y} = N(y)`
+
+        :param torch.Tensor x:  clean measurements
+        :return torch.Tensor: noisy measurements
+        """
+        if not isinstance(self.mask, float):
+            noise = self.U(
+                self.V_adjoint(self.V(self.U_adjoint(self.noise_model(x)) * self.mask))
+            )
+        else:
+            noise = self.noise_model(x)
+        return noise
+
     def prox_l2(self, z, y, gamma):
         r"""
         Computes proximal operator of :math:`f(x)=\frac{\gamma}{2}\|Ax-y\|^2`

--- a/deepinv/physics/remote_sensing.py
+++ b/deepinv/physics/remote_sensing.py
@@ -73,7 +73,7 @@ class Pansharpen(LinearPhysics):
         self.colorize = Decolorize()
 
     def A(self, x):
-        return TensorList([self.downsampling(x), self.colorize(x)])
+        return TensorList([self.downsampling.A(x), self.colorize.A(x)])
 
     def A_adjoint(self, y):
         return self.downsampling.A_adjoint(y[0]) + self.colorize.A_adjoint(y[1])

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -148,7 +148,6 @@ def test_operators_adjointness(name, device):
     physics, imsize, _ = find_operator(name, device)
     x = torch.randn(imsize, device=device).unsqueeze(0)
     error = physics.adjointness_test(x).abs()
-    print(physics.__module__)
     assert error < 1e-3
 
 

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -148,6 +148,7 @@ def test_operators_adjointness(name, device):
     physics, imsize, _ = find_operator(name, device)
     x = torch.randn(imsize, device=device).unsqueeze(0)
     error = physics.adjointness_test(x).abs()
+    print(physics.__module__)
     assert error < 1e-3
 
 
@@ -273,6 +274,30 @@ def test_noise(device, noise_type):
         y2 = physics(x)
         error = (y1 - y2).flatten().abs().sum()
         assert error > 0.0
+
+
+def test_noise_domain(device):
+    r"""
+    Tests that there is no noise outside the domain of the measurement operator, i.e. that in y = Ax+n, we have
+    n=0 where Ax=0.
+    """
+    x = torch.ones((3, 12, 7), device=device).unsqueeze(0)
+    mask = torch.ones_like(x[0])
+    # mask[:, x.shape[-2]//2-3:x.shape[-2]//2+3, x.shape[-1]//2-3:x.shape[-1]//2+3] = 0
+    mask[0, 0, 0] = 0
+    mask[1, 1, 1] = 0
+    mask[2, 2, 2] = 0
+
+    physics = dinv.physics.Inpainting(tensor_size=x.shape, mask=mask, device=device)
+    physics.noise_model = choose_noise("Gaussian")
+    y1 = physics(
+        x
+    )  # Note: this works but not physics.A(x) because only the noise is reset (A does not encapsulate noise)
+    assert y1.shape == x.shape
+
+    assert y1[0, 0, 0, 0] == 0
+    assert y1[0, 1, 1, 1] == 0
+    assert y1[0, 2, 2, 2] == 0
 
 
 def test_reset_noise(device):


### PR DESCRIPTION
This is a fix for #136. In essence, we ensure that in the DecomposablePhysics class, the noise is only added to the range of A and not to non-measured data.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
