### PR TITLE
fix bm3d grayscale

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ New Features
 
 Fixed
 ^^^^^
+- Fixed :gh:`139` BM3D tensor format grayscale (:gh:`140` by `Matthieu Terris`_) - 23/12/2023
 - Fixed :gh:`136` noise additive model for DecomposablePhysics (:gh:`138` by `Matthieu Terris`_) - 22/12/2023
 
 

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -237,9 +237,9 @@ class LinearPhysics(Physics):
         Computes transpose of the forward operator :math:`\tilde{x} = A^{\top}y`.
         If :math:`A` is linear, it should be the exact transpose of the forward matrix.
 
-        .. note:
+        .. note::
 
-            If problem is non-linear, there is not a well-defined transpose operation,
+            If the problem is non-linear, there is not a well-defined transpose operation,
             but defining one can be useful for some reconstruction networks, such as ``deepinv.models.ArtifactRemoval``.
 
         :param torch.Tensor y: measurements.

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -84,7 +84,7 @@ def choose_denoiser(name, imsize):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST)
-def test_denoiser(imsize, device, denoiser):
+def test_denoiser_color(imsize, device, denoiser):
     model = choose_denoiser(denoiser, imsize).to(device)
 
     torch.manual_seed(0)
@@ -95,6 +95,23 @@ def test_denoiser(imsize, device, denoiser):
     x_hat = model(y, sigma)
 
     assert x_hat.shape == x.shape
+
+
+@pytest.mark.parametrize("denoiser", MODEL_LIST)
+def test_denoiser_gray(imsize_1_channel, device, denoiser):
+
+    if denoiser != "scunet":  # scunet does not support 1 channel
+
+        model = choose_denoiser(denoiser, imsize_1_channel).to(device)
+
+        torch.manual_seed(0)
+        sigma = 0.2
+        physics = dinv.physics.Denoising(dinv.physics.GaussianNoise(sigma))
+        x = torch.ones(imsize_1_channel, device=device).unsqueeze(0)
+        y = physics(x)
+        x_hat = model(y, sigma)
+
+        assert x_hat.shape == x.shape
 
 
 def test_equivariant(imsize, device):

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -99,9 +99,7 @@ def test_denoiser_color(imsize, device, denoiser):
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST)
 def test_denoiser_gray(imsize_1_channel, device, denoiser):
-
     if denoiser != "scunet":  # scunet does not support 1 channel
-
         model = choose_denoiser(denoiser, imsize_1_channel).to(device)
 
         torch.manual_seed(0)


### PR DESCRIPTION
Fix #139 ; the BM3D input tensors had wrong format (W,H,C) instead of (W,H).

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
