### PR TITLE
CLN avoid border effect from importing deepinv

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Fixed
 - Fixed test for sigma as torch tensor with gpu enable (:gh:`145` by `Brayan Monroy`_) - 23/12/2023
 - Fixed :gh:`139` BM3D tensor format grayscale (:gh:`140` by `Matthieu Terris`_) - 23/12/2023
 - Fixed :gh:`136` noise additive model for DecomposablePhysics (:gh:`138` by `Matthieu Terris`_) - 22/12/2023
+- Importing `deepinv` does not modify matplotlib config anymore (:gh`1501` by `Thomas Moreau`_) - 30/01/2024
 
 
 Changed

--- a/deepinv/tests/dummy_datasets/datasets.py
+++ b/deepinv/tests/dummy_datasets/datasets.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
 
     import matplotlib.pyplot as plt
     from deepinv.utils.plotting import config_matplotlib
+
     config_matplotlib()
 
     plt.imshow(x.permute(1, 2, 0).cpu().numpy())

--- a/deepinv/tests/dummy_datasets/datasets.py
+++ b/deepinv/tests/dummy_datasets/datasets.py
@@ -52,6 +52,8 @@ if __name__ == "__main__":
     x = dataset[0]
 
     import matplotlib.pyplot as plt
+    from deepinv.utils.plotting import config_matplotlib
+    config_matplotlib()
 
     plt.imshow(x.permute(1, 2, 0).cpu().numpy())
     plt.show()

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -1,22 +1,27 @@
-import numpy as np
-import matplotlib.pyplot as plt
-from torchvision.utils import make_grid
-import wandb
 import math
-import torch
-import matplotlib.pyplot as plt
+import shutil
 from pathlib import Path
 from collections.abc import Iterable
-import matplotlib
-import shutil
+
+import wandb
+import torch
+import numpy as np
+from torchvision.utils import make_grid
 import torchvision.transforms as T
 import torchvision.transforms.functional as F
 
-matplotlib.rcParams.update({"font.size": 17})
-matplotlib.rcParams["lines.linewidth"] = 2
+import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
 
-plt.rcParams["text.usetex"] = True if shutil.which("latex") else False
+
+def config_matplotlib():
+    """Config matplotlib for nice plots in the examples."""
+    plt.rcParams.update({"font.size": 17})
+    plt.rcParams["lines.linewidth"] = 2
+
+    plt.rcParams["text.usetex"] = (
+        True if shutil.which("latex") else False
+    )
 
 
 def resize_pad_square_tensor(tensor, size):
@@ -114,6 +119,9 @@ def plot(
     :param bool show: show the image plot.
     :param bool return_fig: return the figure object.
     """
+    # Use the matplotlib config from deepinv
+    config_matplotlib()
+
     if save_dir:
         save_dir = Path(save_dir)
         save_dir.mkdir(parents=True, exist_ok=True)
@@ -181,6 +189,9 @@ def plot_curves(metrics, save_dir=None, show=True):
     :param str save_dir: path to save the plot.
     :param bool show: show the image plot.
     """
+    # Use the matplotlib config from deepinv
+    config_matplotlib()
+
     if save_dir:
         save_dir = Path(save_dir)
         save_dir.mkdir(parents=True, exist_ok=True)

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -19,9 +19,7 @@ def config_matplotlib():
     plt.rcParams.update({"font.size": 17})
     plt.rcParams["lines.linewidth"] = 2
 
-    plt.rcParams["text.usetex"] = (
-        True if shutil.which("latex") else False
-    )
+    plt.rcParams["text.usetex"] = True if shutil.which("latex") else False
 
 
 def resize_pad_square_tensor(tensor, size):

--- a/examples/basics/demo_lidar.py
+++ b/examples/basics/demo_lidar.py
@@ -10,6 +10,11 @@ import deepinv as dinv
 import torch
 import matplotlib.pyplot as plt
 
+# Use matplotlib config from deepinv to get nice plots
+from deepinv.utils.plotting import config_matplotlib
+config_matplotlib()
+
+
 # %%
 # Create forward model
 # -----------------------------------------------

--- a/examples/basics/demo_lidar.py
+++ b/examples/basics/demo_lidar.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 
 # Use matplotlib config from deepinv to get nice plots
 from deepinv.utils.plotting import config_matplotlib
+
 config_matplotlib()
 
 

--- a/examples/sampling/demo_diffpir.py
+++ b/examples/sampling/demo_diffpir.py
@@ -17,6 +17,7 @@ from deepinv.utils.demo import load_url_image, get_image_url
 
 # Use matplotlib config from deepinv to get nice plots
 from deepinv.utils.plotting import config_matplotlib
+
 config_matplotlib()
 
 # %%

--- a/examples/sampling/demo_diffpir.py
+++ b/examples/sampling/demo_diffpir.py
@@ -15,6 +15,10 @@ from deepinv.utils.plotting import plot
 from deepinv.optim.data_fidelity import L2
 from deepinv.utils.demo import load_url_image, get_image_url
 
+# Use matplotlib config from deepinv to get nice plots
+from deepinv.utils.plotting import config_matplotlib
+config_matplotlib()
+
 # %%
 # Generate an inverse problem
 # ---------------------------


### PR DESCRIPTION
Right now, simply importing `deepinv` mess up with the `matplotlib` config, and can result in `matplotlib` not working anymore (independently from `deepinv`) with incomplete latex installation.
As a rule of thumb, it is usually better to not change global library config on import.

I propose a small helper that sets up the `matplotlib` config with `deepinv` settings, only when needed. (hopefully I watched all the places where it was needed but this might need to be checked).


### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
