### PR TITLE
added auto adj + new black

### DIFF
--- a/docs/source/deepinv.physics.rst
+++ b/docs/source/deepinv.physics.rst
@@ -133,3 +133,4 @@ This module also contains some utilities for physics operators.
    :nosignatures:
 
    deepinv.physics.blur.gaussian_blur
+   deepinv.physics.forward.adjoint_function

--- a/examples/basics/demo_custom_prior.py
+++ b/examples/basics/demo_custom_prior.py
@@ -7,6 +7,7 @@ In this example, we show how to solve a deblurring inverse problem using an expl
 Here we use the simple L2 prior that penalizes the squared norm of the reconstruction, with an ADMM algorithm.
 
 """
+
 import deepinv as dinv
 from pathlib import Path
 import torch

--- a/examples/basics/demo_dataset.py
+++ b/examples/basics/demo_dataset.py
@@ -6,6 +6,7 @@ This example shows how to create your own dataset for deep image inverse problem
 of images. Here we use Set3C as a base dataset of natural images. This base dataset contains 3 images.
 
 """
+
 import deepinv as dinv
 from pathlib import Path
 import torch

--- a/examples/basics/demo_loading.py
+++ b/examples/basics/demo_loading.py
@@ -8,6 +8,7 @@ The architecture of the model and its training are described
 in the `constrained unfolded demo <https://deepinv.github.io/deepinv/auto_examples/unfolded/demo_unfolded_constrained_LISTA.html>`_.
 
 """
+
 from pathlib import Path
 import torch
 

--- a/examples/basics/demo_pansharpening.py
+++ b/examples/basics/demo_pansharpening.py
@@ -7,6 +7,7 @@ In particular, we create a pan-sharpening operator by stacking a downsampling an
 operators.
 
 """
+
 import deepinv as dinv
 import torch
 

--- a/examples/plug-and-play/demo_PnP_DPIR_deblur.py
+++ b/examples/plug-and-play/demo_PnP_DPIR_deblur.py
@@ -8,6 +8,7 @@ Zhang, K., Zuo, W., Gu, S., & Zhang, L. (2017).
 Learning deep CNN denoiser prior for image restoration. 
 In Proceedings of the IEEE conference on computer vision and pattern recognition (pp. 3929-3938).
 """
+
 import deepinv as dinv
 from pathlib import Path
 import torch

--- a/examples/plug-and-play/demo_PnP_custom_optim.py
+++ b/examples/plug-and-play/demo_PnP_custom_optim.py
@@ -6,6 +6,7 @@ This example shows how to define your own optimization algorithm.
 For example, here, we implement the Condat-Vu Primal-Dual algorithm,
 and apply it for Single Pixel Camera reconstruction.
 """
+
 import deepinv as dinv
 from pathlib import Path
 import torch

--- a/examples/plug-and-play/demo_vanilla_PnP.py
+++ b/examples/plug-and-play/demo_vanilla_PnP.py
@@ -5,6 +5,7 @@ Vanilla PnP for computed tomography (CT).
 This example shows how to use a standart PnP algorithm with DnCNN denoiser for computed tomography.
 
 """
+
 import deepinv as dinv
 from pathlib import Path
 import torch

--- a/examples/sampling/demo_diffpir.py
+++ b/examples/sampling/demo_diffpir.py
@@ -6,6 +6,7 @@ In this tutorial, we revisit the implementation of the DiffPIR diffusion algorit
 `Zhou et al. <https://arxiv.org/abs/2305.08995>`_. The full algorithm is implemented in
 :class:`deepinv.sampling.DiffPIR`.
 """
+
 import numpy as np
 import torch
 import matplotlib.pyplot as plt

--- a/examples/sampling/demo_dps.py
+++ b/examples/sampling/demo_dps.py
@@ -7,7 +7,6 @@ In this tutorial, we will go over the steps in the Diffusion Posterior Sampling 
 :meth:`deepinv.sampling.DPS`.
 """
 
-
 # %% Installing dependencies
 # -----------------------------
 # Let us ``import`` the relevant packages, and load a sample

--- a/examples/unfolded/demo_LISTA.py
+++ b/examples/unfolded/demo_LISTA.py
@@ -7,6 +7,7 @@ for a compressed sensing problem. In a nutshell, LISTA is an unfolded proximal g
 soft-thresholding proximal operator with learnable thresholding parameters.
 
 """
+
 from pathlib import Path
 import torch
 from torchvision import datasets

--- a/examples/unfolded/demo_custom_prior_unfolded.py
+++ b/examples/unfolded/demo_custom_prior_unfolded.py
@@ -6,6 +6,7 @@ This example shows how to implement a learned unrolled proximal gradient descent
 The algorithm is trained on a dataset of compressed sensing measurements of MNIST images.
 
 """
+
 from pathlib import Path
 import torch
 from torchvision import datasets

--- a/examples/unfolded/demo_unfolded_constrained_LISTA.py
+++ b/examples/unfolded/demo_unfolded_constrained_LISTA.py
@@ -21,6 +21,7 @@ In this example, we unfold the Chambolle-Pock algorithm to solve this problem, a
 a wavelet denoiser in a LISTA fashion.
 
 """
+
 from pathlib import Path
 import torch
 from torch.utils.data import DataLoader


### PR DESCRIPTION
- Added a function to automatically compute the adjoint function of a linear operator using ``torch.func``.
This can simplify the process of defining a new linear operator ``LinearPhysics`` for which the adjoint might be difficult to code in closed form.
- incorporated new black version changes (mostly small changes to the examples)
-
### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
