### PR TITLE
Fix decomposable physics noise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ New Features
 
 Fixed
 ^^^^^
+- Fixed issue in noise forward of Decomposable class (:gh:`154` by `Matthieu Terris`_) - 08/02/2024
 - Fixed new black version 24.1.1 style changes (:gh:`151` by `Julian Tachella`_) - 31/01/2024
 - Fixed test for sigma as torch tensor with gpu enable (:gh:`145` by `Brayan Monroy`_) - 23/12/2023
 - Fixed :gh:`139` BM3D tensor format grayscale (:gh:`140` by `Matthieu Terris`_) - 23/12/2023

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -502,9 +502,9 @@ class BlurFFT(DecomposablePhysics):
         >>> physics = BlurFFT(img_size=(1, 1, 16, 16), filter=filter)
         >>> y = physics(x)
         >>> y[:, :, 7:10, 7:10] # Display the center of the blurred image
-        tensor([[[[0.1801, 0.1801, 0.0360],
-                  [0.1801, 0.1801, 0.0360],
-                  [0.0360, 0.0360, 0.0072]]]])
+        tensor([[[[ 2.5000e-01,  2.5000e-01, -3.1177e-10],
+                  [ 2.5000e-01,  2.5000e-01, -7.1280e-10],
+                  [-7.5937e-10, -5.4986e-10,  3.9221e-10]]]])
 
     """
 

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -559,21 +559,6 @@ class DecomposablePhysics(LinearPhysics):
 
         return self.V(mask * self.U_adjoint(y))
 
-    def noise(self, x):
-        r"""
-        Incorporates noise into the measurements :math:`\tilde{y} = N(y)`
-
-        :param torch.Tensor x:  clean measurements
-        :return torch.Tensor: noisy measurements
-        """
-        if not isinstance(self.mask, float):
-            noise = self.U(
-                self.V_adjoint(self.V(self.U_adjoint(self.noise_model(x)) * self.mask))
-            )
-        else:
-            noise = self.noise_model(x)
-        return noise
-
     def prox_l2(self, z, y, gamma):
         r"""
         Computes proximal operator of :math:`f(x)=\frac{\gamma}{2}\|Ax-y\|^2`

--- a/deepinv/physics/inpainting.py
+++ b/deepinv/physics/inpainting.py
@@ -72,3 +72,15 @@ class Inpainting(DecomposablePhysics):
                 self.mask[:, aux[0, :, :] > mask_rate] = 0
 
         self.mask = torch.nn.Parameter(self.mask.unsqueeze(0), requires_grad=False)
+
+    def noise(self, x):
+        r"""
+        Incorporates noise into the measurements :math:`\tilde{y} = N(y)`
+
+        :param torch.Tensor x:  clean measurements
+        :return torch.Tensor: noisy measurements
+        """
+        noise = self.U(
+            self.V_adjoint(self.V(self.U_adjoint(self.noise_model(x)) * self.mask))
+        )
+        return noise

--- a/deepinv/physics/singlepixel.py
+++ b/deepinv/physics/singlepixel.py
@@ -71,7 +71,7 @@ class SinglePixelCamera(DecomposablePhysics):
         >>> physics = SinglePixelCamera(m=16, img_shape=(1, 32, 32), fast=True)
         >>> torch.sum(physics.mask).item() # Number of measurements
         48.0
-        >>> torch.round(physics(x)[:, :, :3, :3] * 10) / 10 # Compute measurements
+        >>> torch.round(physics(x)[:, :, :3, :3]).abs() # Compute measurements
         tensor([[[[1., 0., 0.],
                   [0., 0., 0.],
                   [0., 0., 0.]]]])

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -299,6 +299,43 @@ def test_noise_domain(device):
     assert y1[0, 2, 2, 2] == 0
 
 
+def test_blur(device):
+    r"""
+    Tests that there is no noise outside the domain of the measurement operator, i.e. that in y = Ax+n, we have
+    n=0 where Ax=0.
+    """
+    torch.manual_seed(0)
+    x = torch.randn((3, 128, 128), device=device).unsqueeze(0)
+    h = torch.ones((1, 1, 5, 5)) / 25.0
+
+    physics_blur = dinv.physics.Blur(
+        img_size=(1, x.shape[-2], x.shape[-1]),
+        filter=h,
+        device=device,
+    )
+
+    physics_blurfft = dinv.physics.BlurFFT(
+        img_size=(1, x.shape[-2], x.shape[-1]),
+        filter=h,
+        device=device,
+    )
+
+    y1 = physics_blur(x)
+    y2 = physics_blurfft(x)
+
+    back1 = physics_blur.A_adjoint(y1)
+    back2 = physics_blurfft.A_adjoint(y2)
+
+    assert y1.shape == y2.shape
+    assert back1.shape == back2.shape
+
+    error_A = (y1 - y2).flatten().abs().max()
+    error_At = (back1 - back2).flatten().abs().max()
+
+    assert error_A < 1e-6
+    assert error_At < 1e-6
+
+
 def test_reset_noise(device):
     r"""
     Tests that the reset function works.


### PR DESCRIPTION
Fixes #153. We remove the application of noise by default from the `DecomposablePhysics` class and move it to the appropriate classes instead (for now, only `Inpainting`).

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
