### PR TITLE
PDNet+r2r fixes

### DIFF
--- a/deepinv/loss/r2r.py
+++ b/deepinv/loss/r2r.py
@@ -35,6 +35,12 @@ class R2RLoss(nn.Module):
 
         :math:`\eta` should be chosen equal or close to :math:`\sigma` to obtain the best performance.
 
+    .. note::
+
+        To obtain the best test performance, the trained model should be averagedv at test time
+        over multiple realizations of the added noise, i.e. :math:`\hat{x} = \frac{1}{N}\sum_{i=1}^N R(y+\alpha z_i)`
+        where :math:`N>1`.
+
     :param float eta: standard deviation of the Gaussian noise used for the perturbation.
     :param float alpha: scaling factor of the perturbation.
     """
@@ -56,8 +62,7 @@ class R2RLoss(nn.Module):
         :return: (torch.Tensor) R2R loss.
         """
 
-        eta_rnd = torch.rand(1, device=y.device) * self.eta
-        pert = torch.randn_like(y) * eta_rnd
+        pert = torch.randn_like(y) * self.eta
 
         y_plus = y + pert * self.alpha
         y_minus = y - pert / self.alpha

--- a/deepinv/models/PDNet.py
+++ b/deepinv/models/PDNet.py
@@ -10,20 +10,23 @@ def init_weights(m):
 
 
 class PDNet_PrimalBlock(nn.Module):
+    r"""
+    Primal block for the Primal-Dual unfolding model.
+
+    From https://arxiv.org/abs/1707.06474.
+
+    Primal variables are images of shape (batch_size, in_channels, height, width). The input of each
+    primal block is the concatenation of the current primal variable and the backprojected dual variable along
+    the channel dimension. The output of each primal block is the current primal variable.
+
+    :param int in_channels: number of input channels. Default: 6.
+    :param int out_channels: number of output channels. Default: 5.
+    :param int depth: number of convolutional layers in the block. Default: 3.
+    :param bool bias: whether to use bias in convolutional layers. Default: True.
+    :param int nf: number of features in the convolutional layers. Default: 32.
+    """
+
     def __init__(self, in_channels=6, out_channels=5, depth=3, bias=True, nf=32):
-        r"""
-        Primal block for the Primal-Dual unfolding model (PDNet) from https://arxiv.org/abs/1707.06474.
-
-        Primal variables are images of shape (batch_size, in_channels, height, width). The input of each
-        primal block is the concatenation of the current primal variable and the backprojected dual variable along
-        the channel dimension. The output of each primal block is the current primal variable.
-
-        :param int in_channels: number of input channels. Default: 6.
-        :param int out_channels: number of output channels. Default: 5.
-        :param int depth: number of convolutional layers in the block. Default: 3.
-        :param bool bias: whether to use bias in convolutional layers. Default: True.
-        :param int nf: number of features in the convolutional layers. Default: 32.
-        """
         super(PDNet_PrimalBlock, self).__init__()
 
         self.depth = depth
@@ -60,20 +63,23 @@ class PDNet_PrimalBlock(nn.Module):
 
 
 class PDNet_DualBlock(nn.Module):
+    r"""
+    Dual block for the Primal-Dual unfolding model.
+
+    From https://arxiv.org/abs/1707.06474.
+
+    Dual variables are images of shape (batch_size, in_channels, height, width). The input of each
+    primal block is the concatenation of the current dual variable with the projected primal variable and
+    the measurements. The output of each dual block is the current primal variable.
+
+    :param int in_channels: number of input channels. Default: 7.
+    :param int out_channels: number of output channels. Default: 5.
+    :param int depth: number of convolutional layers in the block. Default: 3.
+    :param bool bias: whether to use bias in convolutional layers. Default: True.
+    :param int nf: number of features in the convolutional layers. Default: 32.
+    """
+
     def __init__(self, in_channels=7, out_channels=5, depth=3, bias=True, nf=32):
-        r"""
-        Dual block for the Primal-Dual unfolding model (PDNet) from https://arxiv.org/abs/1707.06474.
-
-        Dual variables are images of shape (batch_size, in_channels, height, width). The input of each
-        primal block is the concatenation of the current dual variable with the projected primal variable and
-        the measurements. The output of each dual block is the current primal variable.
-
-        :param int in_channels: number of input channels. Default: 7.
-        :param int out_channels: number of output channels. Default: 5.
-        :param int depth: number of convolutional layers in the block. Default: 3.
-        :param bool bias: whether to use bias in convolutional layers. Default: True.
-        :param int nf: number of features in the convolutional layers. Default: 32.
-        """
         super(PDNet_DualBlock, self).__init__()
 
         self.depth = depth


### PR DESCRIPTION
I applied two small fixes
- the docstrings of PDNet where in the wrong place (after the __init__ and not before), and thus not displaying.
- the R2R loss was randomizing eta, which is a suboptimal procedure (eta should be fixed).
 
### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
