### PR TITLE
ptwt support

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,6 @@ jobs:
           pip install -e .[denoisers,doc]
       - name: Install git repository optional dependencies
         run: |
-          pip install git+https://github.com/fbcotter/pytorch_wavelets.git
           python3 -m pip install https://github.com/odlgroup/odl/archive/master.zip
       - name: Run doctests
         run: |

--- a/deepinv/models/GSPnP.py
+++ b/deepinv/models/GSPnP.py
@@ -115,15 +115,19 @@ def GSDRUNet(
     GSmodel = GSPnP(denoiser, alpha=alpha, train=train)
     if pretrained:
         if pretrained == "download":
-            url = get_weights_url(model_name="gradientstep", file_name="GSDRUNet.ckpt")
+            url = get_weights_url(
+                model_name="gradientstep", file_name="GSDRUNet_torch.ckpt"
+            )
             ckpt = torch.hub.load_state_dict_from_url(
                 url,
                 map_location=lambda storage, loc: storage,
-                file_name="GSDRUNet.ckpt",
-            )["state_dict"]
+                file_name="GSDRUNet_torch.ckpt",
+            )
         else:
-            ckpt = torch.load(pretrained, map_location=lambda storage, loc: storage)[
-                "state_dict"
-            ]
+            ckpt = torch.load(pretrained, map_location=lambda storage, loc: storage)
+
+        if "state_dict" in ckpt:
+            ckpt = ckpt["state_dict"]
+
         GSmodel.load_state_dict(ckpt, strict=False)
     return GSmodel

--- a/deepinv/models/tv.py
+++ b/deepinv/models/tv.py
@@ -21,14 +21,17 @@ class TVDenoiser(nn.Module):
     Code (and description) adapted from Laurent Condat's matlab version (https://lcondat.github.io/software.html) and
     Daniil Smolyakov's `code <https://github.com/RoundedGlint585/TGVDenoising/blob/master/TGV%20WithoutHist.ipynb>`_.
 
+    This algorithm is implemented with warm restart, i.e. the primary and dual variables are kept in memory
+    between calls to the forward method. This speeds up the computation when using this class in an iterative algorithm.
+
     :param bool verbose: Whether to print computation details or not. Default: False.
     :param int n_it_max: Maximum number of iterations. Default: 1000.
     :param float crit: Convergence criterion. Default: 1e-5.
-    :param torch.tensor, None x2: Primary variable. Default: None.
-    :param torch.tensor, None u2: Dual variable. Default: None.
+    :param torch.Tensor, None x2: Primary variable for warm restart. Default: None.
+    :param torch.Tensor, None u2: Dual variable for warm restart. Default: None.
 
     .. note::
-        The regularization term :math:\|Dx\|_{1,2} is implicitly normalized by its Lipschitz constant, i.e.
+        The regularization term :math:`\|Dx\|_{1,2}` is implicitly normalized by its Lipschitz constant, i.e.
         :math:`\sqrt{8}`, see e.g. A. Beck and M. Teboulle, "Fast gradient-based algorithms for constrained total
         variation image denoising and deblurring problems", IEEE T. on Image Processing. 18(11), 2419-2434, 2009.
 

--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -40,6 +40,11 @@ class WaveletPrior(nn.Module):
     """
 
     def __init__(self, level=3, wv="db8", device="cpu", non_linearity="soft", wvdim=2):
+        if isinstance(ptwt, ImportError):
+            raise ImportError(
+                "pytorch_wavelets is needed to use the WaveletPrior class. "
+                "It should be installed with `pip install ptwt`."
+            ) from ptwt
         super().__init__()
         self.level = level
         self.wv = wv

--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -67,9 +67,9 @@ class WaveletPrior(nn.Module):
         Applies the wavelet decomposition.
         """
         if self.dimension == 2:
-            dec = ptwt.wavedec2(x, pywt.Wavelet(self.wv), mode='zero', level=self.level)
+            dec = ptwt.wavedec2(x, pywt.Wavelet(self.wv), mode="zero", level=self.level)
         elif self.dimension == 3:
-            dec = ptwt.wavedec3(x, pywt.Wavelet(self.wv), mode='zero', level=self.level)
+            dec = ptwt.wavedec3(x, pywt.Wavelet(self.wv), mode="zero", level=self.level)
         dec = [list(t) if isinstance(t, tuple) else t for t in dec]
         return dec
 
@@ -147,7 +147,7 @@ class WaveletPrior(nn.Module):
         return torch.reshape(out, x.shape)
 
     def thresold_func(self, x, ths):
-        r""""
+        r""" "
         Apply thresholding to the wavelet coefficients.
         """
         if self.non_linearity == "soft":
@@ -174,7 +174,7 @@ class WaveletPrior(nn.Module):
         """
         for level in range(1, self.level + 1):
             ths_cur = self.reshape_ths(ths, level)
-            for c, key in enumerate(['aad', 'ada', 'daa', 'add', 'dad', 'dda', 'ddd']):
+            for c, key in enumerate(["aad", "ada", "daa", "add", "dad", "dda", "ddd"]):
                 coeffs[level][key] = self.prox_l1(coeffs[level][key], ths_cur[c])
         return coeffs
 
@@ -207,17 +207,14 @@ class WaveletPrior(nn.Module):
         """
         padding_bottom, padding_right = padding
         h, w = x.size()[-2:]
-        return x[..., :h-padding_bottom, :w-padding_right]
+        return x[..., : h - padding_bottom, : w - padding_right]
 
     def reshape_ths(self, ths, level):
         r"""
         Reshape the thresholding parameter in the appropriate format, i.e. a list of 3 elements.
         """
         if not torch.is_tensor(ths):
-            if (
-                    isinstance(ths, int)
-                    or isinstance(ths, float)
-            ):
+            if isinstance(ths, int) or isinstance(ths, float):
                 ths_cur = [ths] * 3
             elif len(ths) == 1:
                 ths_cur = [ths[0]] * 3

--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -205,10 +205,10 @@ class WaveletPrior(nn.Module):
         """
         d, h, w = x.size()[-3:]
         if len(padding) == 2:
-            x[..., : h - padding[0], : w - padding[1]]
+            out = x[..., : h - padding[0], : w - padding[1]]
         elif len(padding) == 3:
-            x[..., : d - padding[0], : h - padding[1], : w - padding[2]]
-        return x
+            out = x[..., : d - padding[0], : h - padding[1], : w - padding[2]]
+        return out
 
     def reshape_ths(self, ths, level):
         r"""

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -39,7 +39,7 @@ class Prior(nn.Module):
         r"""
         Computes the prior :math:`g(x)`.
 
-        :param torch.tensor x: Variable :math:`x` at which the prior is computed.
+        :param torch.Tensor x: Variable :math:`x` at which the prior is computed.
         :return: (torch.tensor) prior :math:`g(x)`.
         """
         return self._g(x, *args, **kwargs)
@@ -48,7 +48,7 @@ class Prior(nn.Module):
         r"""
         Computes the prior :math:`g(x)`.
 
-        :param torch.tensor x: Variable :math:`x` at which the prior is computed.
+        :param torch.Tensor x: Variable :math:`x` at which the prior is computed.
         :return: (torch.tensor) prior :math:`g(x)`.
         """
         return self.g(x, *args, **kwargs)
@@ -58,7 +58,7 @@ class Prior(nn.Module):
         Calculates the gradient of the prior term :math:`g` at :math:`x`.
         By default, the gradient is computed using automatic differentiation.
 
-        :param torch.tensor x: Variable :math:`x` at which the gradient is computed.
+        :param torch.Tensor x: Variable :math:`x` at which the gradient is computed.
         :return: (torch.tensor) gradient :math:`\nabla_x g`, computed in :math:`x`.
         """
         with torch.enable_grad():
@@ -81,7 +81,7 @@ class Prior(nn.Module):
         r"""
         Calculates the proximity operator of :math:`g` at :math:`x`. By default, the proximity operator is computed using internal gradient descent.
 
-        :param torch.tensor x: Variable :math:`x` at which the proximity operator is computed.
+        :param torch.Tensor x: Variable :math:`x` at which the proximity operator is computed.
         :param float gamma: stepsize of the proximity operator.
         :param float stepsize_inter: stepsize used for internal gradient descent
         :param int max_iter_inter: maximal number of iterations for internal gradient descent.
@@ -282,7 +282,7 @@ class L1Prior(Prior):
         :param torch.Tensor x: Variable :math:`x` at which the proximity operator is computed.
         :param float ths: threshold parameter :math:`\tau`.
         :param float gamma: stepsize of the proximity operator.
-        :return: (torch.Tensor) proximity operator at :math:`x`.
+        :return torch.Tensor: proximity operator at :math:`x`.
         """
         return torch.sign(x) * torch.max(
             torch.abs(x) - ths * gamma, torch.zeros_like(x)
@@ -301,23 +301,23 @@ class TVPrior(Prior):
 
     def g(self, x, ths=1.0, **kwargs):
         r"""
-         Computes the regularizer
+        Computes the regularizer
 
-         .. math:
-
-                 g(x) = \tau \|Dx\|_{1,2}
+        .. math::
+             \tau g(x) = \tau \|Dx\|_{1,2}
 
 
         where D is the finite differences linear operator,
         and the 2-norm is taken on the dimension of the differences.
 
-         :param torch.Tensor x: Variable :math:`x` at which the prior is computed.
-         :return: (torch.Tensor) prior :math:`g(x)`.
+        :param torch.Tensor x: Variable :math:`x` at which the prior is computed.
+        :param torch.Tensor, float ths: Regularization parameter :math:`\tau` in the proximal operator (default value = 1.0).
+        :return: (torch.Tensor) prior :math:`\tau g(x)`.
         """
         return ths * torch.sum(torch.sqrt(torch.sum(self.nabla(x) ** 2, axis=-1)))
 
     def prox(self, x, ths=1.0, gamma=1.0, *args, **kwargs):
-        r"""Compute the proximity operator of TV with the denoiser :meth:`deepinv.models.tv.TV`.
+        r"""Compute the proximity operator of TV with the denoiser :class:`~deepinv.models.TVDenoiser`.
 
         :param torch.Tensor x: Variable :math:`x` at which the proximity operator is computed.
         :param float ths: threshold parameter :math:`\tau`.

--- a/deepinv/tests/test_loss_train.py
+++ b/deepinv/tests/test_loss_train.py
@@ -54,7 +54,7 @@ optim_algos = ["PGD"]
 def test_optim_algo(name_algo, imsize, device):
     # This test uses WaveletPrior, which requires pytorch_wavelets
     # TODO: we could use a dummy trainable denoiser with a linear layer instead
-    pytest.importorskip("pytorch_wavelets")
+    pytest.importorskip("ptwt")
 
     # pths
     BASE_DIR = Path(".")
@@ -82,8 +82,12 @@ def test_optim_algo(name_algo, imsize, device):
         1.0
     ] * max_iter  # initialization of the stepsizes. A distinct stepsize is trained for each iteration.
 
-    sigma_denoiser = [0.01 * torch.ones(level, 1)] * max_iter
-    # sigma_denoiser = [torch.Tensor([sigma_denoiser_init])]*max_iter
+    sigma_denoiser = [
+        0.01
+        * torch.ones(
+            level,
+        )
+    ] * max_iter
     params_algo = {  # wrap all the restoration parameters in a 'params_algo' dictionary
         "stepsize": stepsize,
         "g_param": sigma_denoiser,

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -29,7 +29,7 @@ MODEL_LIST = MODEL_LIST_1_CHANNEL + [
 def choose_denoiser(name, imsize):
     if name.startswith("waveletdict") or name == "waveletprior":
         pytest.importorskip(
-            "pytorch_wavelets",
+            "ptwt",
             reason="This test requires pytorch_wavelets. It should be "
             "installed with `pip install "
             "git+https://github.com/fbcotter/pytorch_wavelets.git`",
@@ -358,8 +358,8 @@ def test_PDNet(imsize_1_channel, device):
         ("BM3D", "bm3d"),
         ("SCUNet", "timm"),
         ("SwinIR", "timm"),
-        ("WaveletPrior", "pytorch_wavelets"),
-        ("WaveletDict", "pytorch_wavelets"),
+        ("WaveletPrior", "ptwt"),
+        ("WaveletDict", "ptwt"),
     ],
 )
 def test_optional_dependencies(denoiser, dep):

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -118,6 +118,13 @@ def test_TVs_adjoint():
 
 def test_wavelet_adjoints():
 
+    pytest.importorskip(
+        "ptwt",
+        reason="This test requires pytorch_wavelets. It should be "
+        "installed with `pip install "
+        "git+https://github.com/fbcotter/pytorch_wavelets.git`",
+    )
+
     torch.manual_seed(0)
 
     def gen_function(Au, wvdim=2):
@@ -165,8 +172,15 @@ def test_wavelet_adjoints():
         assert torch.allclose(e, torch.tensor([0.0], dtype=torch.float64))
 
 
-def test_variational_models_identity():
+def test_wavelet_models_identity():
     # We check that variational models yield identity when regularization parameter is set to 0.
+
+    pytest.importorskip(
+        "ptwt",
+        reason="This test requires pytorch_wavelets. It should be "
+        "installed with `pip install "
+        "git+https://github.com/fbcotter/pytorch_wavelets.git`",
+    )
 
     # 1. Wavelet Prior & dictionary
     for dimension in ["2d", "3d"]:
@@ -193,6 +207,9 @@ def test_variational_models_identity():
         x_hat = model(x, 0.0)
         assert x_hat.shape == x.shape
         assert torch.allclose(x, x_hat, atol=1e-5)  # The model should be the identity
+
+
+def test_TV_models_identity():
 
     # Next priors are checked for 2D only
     x = torch.randn((4, 3, 31, 27))

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -295,7 +295,7 @@ def test_denoiser(imsize, dummy_dataset, device):
 # GD not implemented for this one
 @pytest.mark.parametrize("pnp_algo", ["PGD", "HQS", "DRS", "ADMM", "CP"])
 def test_pnp_algo(pnp_algo, imsize, dummy_dataset, device):
-    pytest.importorskip("pytorch_wavelets")
+    pytest.importorskip("ptwt")
 
     # 1. Generate a dummy dataset
     dataloader = DataLoader(dummy_dataset, batch_size=1, shuffle=False, num_workers=0)
@@ -433,7 +433,7 @@ def test_priors_algo(pnp_algo, imsize, dummy_dataset, device):
 def test_red_algo(red_algo, imsize, dummy_dataset, device):
     # This test uses WaveletPrior, which requires pytorch_wavelets
     # TODO: we could use a dummy trainable denoiser with a linear layer instead
-    pytest.importorskip("pytorch_wavelets")
+    pytest.importorskip("ptwt")
 
     # 1. Generate a dummy dataset
     dataloader = DataLoader(dummy_dataset, batch_size=1, shuffle=False, num_workers=0)

--- a/deepinv/tests/test_unfolded.py
+++ b/deepinv/tests/test_unfolded.py
@@ -12,7 +12,7 @@ OPTIM_ALGO = ["PGD", "HQS"]
 
 @pytest.mark.parametrize("unfolded_algo", OPTIM_ALGO)
 def test_unfolded(unfolded_algo, imsize, dummy_dataset, device):
-    pytest.importorskip("pytorch_wavelets")
+    pytest.importorskip("ptwt")
 
     # Select the data fidelity term
     data_fidelity = L2()
@@ -67,7 +67,7 @@ def test_unfolded(unfolded_algo, imsize, dummy_dataset, device):
 
 @pytest.mark.parametrize("unfolded_algo", OPTIM_ALGO)
 def test_DEQ(unfolded_algo, imsize, dummy_dataset, device):
-    pytest.importorskip("pytorch_wavelets")
+    pytest.importorskip("ptwt")
     torch.set_grad_enabled(
         True
     )  # Disabled somewhere in previous test files, necessary for this test to pass

--- a/examples/basics/demo_loading.py
+++ b/examples/basics/demo_loading.py
@@ -9,6 +9,7 @@ in the `constrained unfolded demo <https://deepinv.github.io/deepinv/auto_exampl
 
 """
 
+import importlib.util
 from pathlib import Path
 import torch
 
@@ -176,11 +177,16 @@ print(
 
 
 # load a state_dict checkpoint
-file_name = "demo_unfolded_CP.pth"
+file_name = (
+    "demo_unfolded_CP_ptwt.pth"
+    if importlib.util.find_spec("ptwt")
+    else "demo_unfolded_CP.pth"
+)
 url = get_weights_url(model_name="demo", file_name=file_name)
 ckpt_state_dict = torch.hub.load_state_dict_from_url(
     url, map_location=lambda storage, loc: storage, file_name=file_name
 )
+
 # load a state_dict checkpoint
 model_new.load_state_dict(ckpt_state_dict)
 

--- a/examples/basics/demo_physics_tour.py
+++ b/examples/basics/demo_physics_tour.py
@@ -8,11 +8,12 @@ We restrict ourselves to operators where the signal is a 2D image. The full list
 
 """
 
+import numpy as np
 import deepinv as dinv
 from deepinv.utils.plotting import plot
 import torch
 import requests
-from imageio.v2 import imread
+from PIL import Image
 from io import BytesIO
 
 # %%
@@ -25,7 +26,7 @@ device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
 
 url = "https://www-iuem.univ-brest.fr/intranet/communication/logos/tutelles-iuem/cnrs/cnrs-poster.png"
 res = requests.get(url)
-x = imread(BytesIO(res.content)) / 255.0
+x = np.array(Image.open(BytesIO(res.content))) / 255.0
 
 x = torch.tensor(x, device=device, dtype=torch.float).permute(2, 0, 1).unsqueeze(0)
 x = torch.nn.functional.interpolate(x, size=(64, 64))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ doc = [
 denoisers = [
     "bm3d",
     "timm",
-    "pywt",
+    "PyWavelets",
     "ptwt"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "numpy",
     "matplotlib",
     "hdf5storage",
+    "tqdm",
     "torch",
     "torchvision",
     "einops",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "torchvision",
     "einops",
     "wandb",
-    "fastmri",
 ]
 
 [tool.setuptools]
@@ -61,7 +60,9 @@ doc = [
 # optional dependencies for specific denoisers
 denoisers = [
     "bm3d",
-    "timm"
+    "timm",
+    "pywt",
+    "ptwt"
 ]
 
 


### PR DESCRIPTION
This PR proposes to integrate [ptwt](https://github.com/v0lta/PyTorch-Wavelet-Toolbox) instead of [pytorch_wavelets](https://github.com/fbcotter/pytorch_wavelets). 2 main reasons for this: ptwt supports 3D wavelets, and pytorch_wavelets support is getting discontinued.

Also removes the dependency to fastmri #134 which carried several hidden dependencies e.g. torch-lighthning, imageio etc.

This PR contains only a re-implementations of the wavelet denoisers. An example with a 3D denoising problem will come next.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
