### PR TITLE
Solve problem of gradient of GSPnP

### DIFF
--- a/deepinv/models/GSPnP.py
+++ b/deepinv/models/GSPnP.py
@@ -43,7 +43,6 @@ class GSPnP(nn.Module):
         :param torch.tensor x: Input image
         :param float sigma: Denoiser level :math:`\sigma` (std)
         """
-        # torch.set_grad_enabled(True)
         with torch.enable_grad():
             x = x.float()
             x = x.requires_grad_()
@@ -51,8 +50,6 @@ class GSPnP(nn.Module):
             JN = torch.autograd.grad(
                 N, x, grad_outputs=x - N, create_graph=True, only_inputs=True
             )[0]
-        # if not self.train:
-        #     torch.set_grad_enabled(False)
         Dg = x - N - JN
         return self.alpha * Dg
 

--- a/deepinv/models/GSPnP.py
+++ b/deepinv/models/GSPnP.py
@@ -43,7 +43,7 @@ class GSPnP(nn.Module):
         :param torch.tensor x: Input image
         :param float sigma: Denoiser level :math:`\sigma` (std)
         """
-        #torch.set_grad_enabled(True)
+        # torch.set_grad_enabled(True)
         with torch.enable_grad():
             x = x.float()
             x = x.requires_grad_()

--- a/deepinv/models/GSPnP.py
+++ b/deepinv/models/GSPnP.py
@@ -43,15 +43,16 @@ class GSPnP(nn.Module):
         :param torch.tensor x: Input image
         :param float sigma: Denoiser level :math:`\sigma` (std)
         """
-        torch.set_grad_enabled(True)
-        x = x.float()
-        x = x.requires_grad_()
-        N = self.student_grad(x, sigma)
-        JN = torch.autograd.grad(
-            N, x, grad_outputs=x - N, create_graph=True, only_inputs=True
-        )[0]
-        if not self.train:
-            torch.set_grad_enabled(False)
+        #torch.set_grad_enabled(True)
+        with torch.enable_grad():
+            x = x.float()
+            x = x.requires_grad_()
+            N = self.student_grad(x, sigma)
+            JN = torch.autograd.grad(
+                N, x, grad_outputs=x - N, create_graph=True, only_inputs=True
+            )[0]
+        # if not self.train:
+        #     torch.set_grad_enabled(False)
         Dg = x - N - JN
         return self.alpha * Dg
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -117,7 +117,6 @@ def test_TVs_adjoint():
 
 
 def test_wavelet_adjoints():
-
     pytest.importorskip(
         "ptwt",
         reason="This test requires pytorch_wavelets. It should be "
@@ -212,7 +211,6 @@ def test_wavelet_models_identity():
 
 
 def test_TV_models_identity():
-
     # Next priors are checked for 2D only
     x = torch.randn((4, 3, 31, 27))
 


### PR DESCRIPTION
GSPnP was changing the global variable set_grad_enabled, which was making other gradient computations impossible afterwards as raised in #166. This is now solved by using 

```
with torch.enable_grad():
... 
```

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
