### PR TITLE
macos fix

### DIFF
--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -2,6 +2,8 @@ import deepinv
 import torch
 import pytest
 
+import matplotlib.pyplot as plt
+
 
 @pytest.fixture
 def tensorlist():
@@ -77,6 +79,6 @@ def test_plot():
     for c in range(1, 5):
         x = torch.ones((1, c, 2, 2))
         imgs = [x, x]
-        deepinv.utils.plot(imgs, titles=["a", "b"])
-        deepinv.utils.plot(x, titles="a")
-        deepinv.utils.plot(imgs)
+        deepinv.utils.plot(imgs, titles=["a", "b"], show=False)
+        deepinv.utils.plot(x, titles="a", show=False)
+        deepinv.utils.plot(imgs, show=False)

--- a/examples/patch-priors/demo_patch_priors_CT.py
+++ b/examples/patch-priors/demo_patch_priors_CT.py
@@ -12,7 +12,7 @@ For the reconstruction, we minimize the variational problem
 .. math::
     \begin{equation*}
     \label{eq:min_prob}
-    \underset{x}{\arg\min} \quad \lambda \datafid{x}{y} + g(x).
+    \underset{x}{\arg\min} \quad \datafid{x}{y} + \lambda g(x).
     \end{equation*}
 
 Here, the regularizier :math:`g` is explicitly defined as


### PR DESCRIPTION
Attempt to solve conda-forge issue. The tests on macos [seem to stall](https://github.com/conda-forge/staged-recipes/pull/25801#issuecomment-2013291888) within [this function](https://github.com/deepinv/deepinv/blob/main/deepinv/tests/test_utils.py#L76). I suspect this is due to `plt.show()` opening a figure that is never closed; I thus force `show=False`.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
