### PR TITLE
Correction of the TV prior implementation for backward computation

### DIFF
--- a/deepinv/models/restormer.py
+++ b/deepinv/models/restormer.py
@@ -321,7 +321,12 @@ class Restormer(nn.Module):
         ###########################
 
         self.output = nn.Conv2d(
-            int(dim * 2**1), out_channels, kernel_size=3, stride=1, padding=1, bias=bias
+            int(dim * 2**1),
+            out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            bias=bias,
         )
 
         # we don't check if our model is a good fit for the weights from the .pth file

--- a/deepinv/physics/generator/blur.py
+++ b/deepinv/physics/generator/blur.py
@@ -422,22 +422,16 @@ def define_zernike():
     Z[18] = lambda x, y: sq12 * x * (x**2 - 3 * y**2) * (5 * r2(x, y) - 4)
     Z[19] = lambda x, y: sq12 * y * (3 * x**2 - y**2) * (5 * r2(x, y) - 4)
     Z[20] = (
-        lambda x, y: sq12
-        * x
-        * (16 * x**4 - 20 * x**2 * r2(x, y) + 5 * r2(x, y) ** 2)
+        lambda x, y: sq12 * x * (16 * x**4 - 20 * x**2 * r2(x, y) + 5 * r2(x, y) ** 2)
     )
     Z[21] = (
-        lambda x, y: sq12
-        * y
-        * (16 * y**4 - 20 * y**2 * r2(x, y) + 5 * r2(x, y) ** 2)
+        lambda x, y: sq12 * y * (16 * y**4 - 20 * y**2 * r2(x, y) + 5 * r2(x, y) ** 2)
     )
     Z[22] = lambda x, y: sq7 * (
         20 * r2(x, y) ** 3 - 30 * r2(x, y) ** 2 + 12 * r2(x, y) - 1
     )
     Z[23] = lambda x, y: 2 * sq14 * x * y * (15 * r2(x, y) ** 2 - 20 * r2(x, y) + 6)
-    Z[24] = (
-        lambda x, y: sq14 * (x**2 - y**2) * (15 * r2(x, y) ** 2 - 20 * r2(x, y) + 6)
-    )
+    Z[24] = lambda x, y: sq14 * (x**2 - y**2) * (15 * r2(x, y) ** 2 - 20 * r2(x, y) + 6)
     Z[25] = lambda x, y: 4 * sq14 * x * y * (x**2 - y**2) * (6 * r2(x, y) - 5)
     Z[26] = (
         lambda x, y: sq14
@@ -451,10 +445,7 @@ def define_zernike():
         * (32 * x**4 - 32 * x**2 * r2(x, y) + 6 * r2(x, y) ** 2)
     )
     Z[28] = lambda x, y: sq14 * (
-        32 * x**6
-        - 48 * x**4 * r2(x, y)
-        + 18 * x**2 * r2(x, y) ** 2
-        - r2(x, y) ** 3
+        32 * x**6 - 48 * x**4 * r2(x, y) + 18 * x**2 * r2(x, y) ** 2 - r2(x, y) ** 3
     )
     Z[29] = (
         lambda x, y: 4
@@ -481,18 +472,12 @@ def define_zernike():
     Z[33] = (
         lambda x, y: 4
         * (7 * r2(x, y) - 6)
-        * (
-            4 * x**2 * y * (x**2 - y**2)
-            + y * (r2(x, y) ** 2 - 8 * x**2 * y**2)
-        )
+        * (4 * x**2 * y * (x**2 - y**2) + y * (r2(x, y) ** 2 - 8 * x**2 * y**2))
     )
     Z[34] = lambda x, y: (
         4
         * (7 * r2(x, y) - 6)
-        * (
-            x * (r2(x, y) ** 2 - 8 * x**2 * y**2)
-            - 4 * x * y**2 * (x**2 - y**2)
-        )
+        * (x * (r2(x, y) ** 2 - 8 * x**2 * y**2) - 4 * x * y**2 * (x**2 - y**2))
     )
     Z[35] = lambda x, y: (
         8 * x**2 * y * (3 * r2(x, y) ** 2 - 16 * x**2 * y**2)

--- a/deepinv/physics/generator/blur.py
+++ b/deepinv/physics/generator/blur.py
@@ -422,16 +422,22 @@ def define_zernike():
     Z[18] = lambda x, y: sq12 * x * (x**2 - 3 * y**2) * (5 * r2(x, y) - 4)
     Z[19] = lambda x, y: sq12 * y * (3 * x**2 - y**2) * (5 * r2(x, y) - 4)
     Z[20] = (
-        lambda x, y: sq12 * x * (16 * x**4 - 20 * x**2 * r2(x, y) + 5 * r2(x, y) ** 2)
+        lambda x, y: sq12
+        * x
+        * (16 * x**4 - 20 * x**2 * r2(x, y) + 5 * r2(x, y) ** 2)
     )
     Z[21] = (
-        lambda x, y: sq12 * y * (16 * y**4 - 20 * y**2 * r2(x, y) + 5 * r2(x, y) ** 2)
+        lambda x, y: sq12
+        * y
+        * (16 * y**4 - 20 * y**2 * r2(x, y) + 5 * r2(x, y) ** 2)
     )
     Z[22] = lambda x, y: sq7 * (
         20 * r2(x, y) ** 3 - 30 * r2(x, y) ** 2 + 12 * r2(x, y) - 1
     )
     Z[23] = lambda x, y: 2 * sq14 * x * y * (15 * r2(x, y) ** 2 - 20 * r2(x, y) + 6)
-    Z[24] = lambda x, y: sq14 * (x**2 - y**2) * (15 * r2(x, y) ** 2 - 20 * r2(x, y) + 6)
+    Z[24] = (
+        lambda x, y: sq14 * (x**2 - y**2) * (15 * r2(x, y) ** 2 - 20 * r2(x, y) + 6)
+    )
     Z[25] = lambda x, y: 4 * sq14 * x * y * (x**2 - y**2) * (6 * r2(x, y) - 5)
     Z[26] = (
         lambda x, y: sq14
@@ -445,7 +451,10 @@ def define_zernike():
         * (32 * x**4 - 32 * x**2 * r2(x, y) + 6 * r2(x, y) ** 2)
     )
     Z[28] = lambda x, y: sq14 * (
-        32 * x**6 - 48 * x**4 * r2(x, y) + 18 * x**2 * r2(x, y) ** 2 - r2(x, y) ** 3
+        32 * x**6
+        - 48 * x**4 * r2(x, y)
+        + 18 * x**2 * r2(x, y) ** 2
+        - r2(x, y) ** 3
     )
     Z[29] = (
         lambda x, y: 4
@@ -472,12 +481,18 @@ def define_zernike():
     Z[33] = (
         lambda x, y: 4
         * (7 * r2(x, y) - 6)
-        * (4 * x**2 * y * (x**2 - y**2) + y * (r2(x, y) ** 2 - 8 * x**2 * y**2))
+        * (
+            4 * x**2 * y * (x**2 - y**2)
+            + y * (r2(x, y) ** 2 - 8 * x**2 * y**2)
+        )
     )
     Z[34] = lambda x, y: (
         4
         * (7 * r2(x, y) - 6)
-        * (x * (r2(x, y) ** 2 - 8 * x**2 * y**2) - 4 * x * y**2 * (x**2 - y**2))
+        * (
+            x * (r2(x, y) ** 2 - 8 * x**2 * y**2)
+            - 4 * x * y**2 * (x**2 - y**2)
+        )
     )
     Z[35] = lambda x, y: (
         8 * x**2 * y * (3 * r2(x, y) ** 2 - 16 * x**2 * y**2)

--- a/deepinv/training/testing.py
+++ b/deepinv/training/testing.py
@@ -6,6 +6,7 @@ from tqdm import tqdm
 import torch
 from pathlib import Path
 from deepinv.loss import PSNR
+import warnings
 
 
 def test(
@@ -42,6 +43,9 @@ def test(
         :ref:`See the libraries' evaluation metrics <loss>`.
     :param bool online_measurements: Generate the measurements in an online manner at each iteration by calling
         ``physics(x)``.
+    :param None, deepinv.physics.generator.PhysicsGenerator physics_generator: Optional physics generator for generating
+        the physics operators. If not None, the physics operators are randomly sampled at each iteration using the generator.
+        Should be used in conjunction with ``online_measurements=True``.
     :param torch.device device: gpu or cpu.
     :param bool plot_images: Plot the ground-truth and estimated images.
     :param str save_folder: Directory in which to save plotted reconstructions.
@@ -54,6 +58,12 @@ def test(
     :returns: A tuple of floats (test_psnr, test_std_psnr, linear_std_psnr, linear_std_psnr) with the PSNR of the
         reconstruction network and a simple linear inverse on the test set.
     """
+
+    if physics_generator is not None and not online_measurements:
+        warnings.warn(
+            "Physics generator is provided but online_measurements is False. Physics generator will not be used."
+        )
+
     save_folder = Path(save_folder)
 
     model.eval()


### PR DESCRIPTION
- As noticed in #194. Change the way the replacement is implemented in order to allow backward automatic differentiation.
- Julian: added warning to test function.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
