### PR TITLE
Add a divergence check in conjugate_gradient

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 
 Changed
 ^^^^^^^
+- Added a divergence check in the conjugate gradient implementation (:gh:`225` by `Jérémy Scanvic`_) - 22/05/2024
 
 
 

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -76,6 +76,7 @@ def conjugate_gradient(
         x = x + p * alpha
         r = r - Ap * alpha
         rsnew = dot(r, r)
+        assert rsnew.isfinite().all(), "Conjugate gradient diverged"
         if all(rsnew.abs() < tol**2):
             break
         p = r + p * (rsnew / (rsold + eps))


### PR DESCRIPTION
The function `deepinv.optim.utils.conjugate_gradient` currently lacks a proper divergence check and may silently introduce NaN values (see #222). Instead, I suggest adding a check with an explanatory error message.

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
