### PR TITLE
DiffPIR progress bar

### DIFF
--- a/deepinv/sampling/diffusion.py
+++ b/deepinv/sampling/diffusion.py
@@ -420,7 +420,7 @@ class DiffPIR(nn.Module):
         sqrt_recip_alphas_cumprod, sqrt_recipm1_alphas_cumprod = self.get_alpha_prod()
 
         with torch.no_grad():
-            for i in range(len(self.seq)):
+            for i in tqdm(range(len(self.seq)), disable=(not self.verbose)):
                 # Current noise level
                 curr_sigma = self.sigmas[self.seq[i]].cpu().numpy()
 


### PR DESCRIPTION
FIX: Add a progress bar to the DiffPIR model when verbose is set to True, which was the behavior expected according to the documentation.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
