### PR TITLE
Improve support for parameter-dependent operators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 
 Changed
 ^^^^^^^
+- Improved support for parameter-dependent operators (:gh:`227` by `Jérémy Scanvic`_) - 28/05/2024
 - Added a divergence check in the conjugate gradient implementation (:gh:`225` by `Jérémy Scanvic`_) - 22/05/2024
 
 


### PR DESCRIPTION
Currently, it is necessary to set the parameters of parameter-dependent operators before using the methods `adjointness_test`, `compute_norm` and `prox_l2`. I suggest allowing to specify the parameters directly when calling them instead.


### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
