### PR TITLE
adapt sigma when batch size > 1

### DIFF
--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -47,7 +47,7 @@ class GaussianNoise(torch.nn.Module):
         if sigma is not None:
             self.sigma = to_nn_parameter(sigma)
 
-        return x + torch.randn_like(x) * self.sigma
+        return x + torch.randn_like(x) * self.sigma[(...,) + (None,) * (x.ndim - 1)]
 
 
 class UniformGaussianNoise(torch.nn.Module):
@@ -199,7 +199,7 @@ class PoissonGaussianNoise(torch.nn.Module):
 
         y = torch.poisson(x / self.gain) * self.gain
 
-        y += torch.randn_like(x) * self.sigma
+        y += torch.randn_like(x) * self.sigma[(...,) + (None,) * (x.ndim - 1)]
         return y
 
 


### PR DESCRIPTION
When using a batch size greater than 1 and a noise model using a parameter sigma (which is a tensor of the length equals to the batch size when using a generator), then an error happens when multiplying `torch.rand_like(x) * sigma`.

The fix proposed here completes the missing dimensions of sigma to perform the operation.

### Checks to be done before submitting your PR
(based on https://github.com/Nils-Laurent/deepinv/commits/main/)
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
