### PR TITLE
One iter

### DIFF
--- a/deepinv/optim/fixed_point.py
+++ b/deepinv/optim/fixed_point.py
@@ -244,50 +244,7 @@ class FixedPoint(nn.Module):
                         break
                     it += 1
                     pbar.update(1) 
-
-                # cur_params = self.update_params_fn(it) if self.update_params_fn else None
-                # cur_data_fidelity = (
-                #     self.update_data_fidelity_fn(it)
-                #     if self.update_data_fidelity_fn
-                #     else None
-                # )
-                # cur_prior = self.update_prior_fn(it) if self.update_prior_fn else None
-                # X_prev = X
-                # X = self.iterator(X_prev, cur_data_fidelity, cur_prior, cur_params, *args)
-                # if self.anderson_acceleration:
-                #     X = self.anderson_acceleration_step(
-                #         it,
-                #         X_prev,
-                #         X,
-                #         x_hist,
-                #         T_hist,
-                #         H,
-                #         q,
-                #         cur_data_fidelity,
-                #         cur_prior,
-                #         cur_params,
-                #         *args,
-                #     )
-                # check_iteration = (
-                #     self.check_iteration_fn(X_prev, X) if self.check_iteration_fn else True
-                # )
-                # if check_iteration:
-                #     metrics = (
-                #         self.update_metrics_fn(metrics, X_prev, X, x_gt=x_gt)
-                #         if self.update_metrics_fn and compute_metrics
-                #         else None
-                #     )
-                #     if (
-                #         self.early_stop
-                #         and (self.check_conv_fn is not None)
-                #         and it > 1
-                #         and self.check_conv_fn(it, X_prev, X)
-                #     ):
-                #         break
-                #     it += 1
-                #     pbar.update(1) 
-                # else:
-                #     X = X_prev
+                        
         return X, metrics
 
     def one_iteration(self, X, it, *args, compute_metrics, x_gt, **kwargs):

--- a/deepinv/optim/fixed_point.py
+++ b/deepinv/optim/fixed_point.py
@@ -83,7 +83,7 @@ class FixedPoint(nn.Module):
         beta_anderson_acc=1.0,
         eps_anderson_acc=1e-4,
         verbose=False,
-        show_progress_bar=True,
+        show_progress_bar=False,
     ):
         super().__init__()
         self.iterator = iterator

--- a/deepinv/optim/fixed_point.py
+++ b/deepinv/optim/fixed_point.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import warnings
 from tqdm import tqdm
 
+
 class FixedPoint(nn.Module):
     """
     Fixed-point iterations module.
@@ -235,11 +236,22 @@ class FixedPoint(nn.Module):
         self.x_hist, self.T_hist, self.H, self.q = self.init_anderson_acceleration(X)
         it = 0
 
-        for it in tqdm(range(self.max_iter), disable=(not self.verbose or not self.show_progress_bar)):
-                
+        for it in tqdm(
+            range(self.max_iter),
+            disable=(not self.verbose or not self.show_progress_bar),
+        ):
+
             X_prev = X
-            X = self.single_iteration(X, it, *args, compute_metrics = compute_metrics, metrics = metrics, x_gt = x_gt, **kwargs)
-            
+            X = self.single_iteration(
+                X,
+                it,
+                *args,
+                compute_metrics=compute_metrics,
+                metrics=metrics,
+                x_gt=x_gt,
+                **kwargs,
+            )
+
             if self.check_iteration:
                 metrics = (
                     self.update_metrics_fn(metrics, X_prev, X, x_gt=x_gt)
@@ -254,16 +266,14 @@ class FixedPoint(nn.Module):
                 ):
                     break
                 it += 1
-                        
+
         return X, metrics
 
     def single_iteration(self, X, it, *args, **kwargs):
 
         cur_params = self.update_params_fn(it) if self.update_params_fn else None
         cur_data_fidelity = (
-            self.update_data_fidelity_fn(it)
-            if self.update_data_fidelity_fn
-            else None
+            self.update_data_fidelity_fn(it) if self.update_data_fidelity_fn else None
         )
         cur_prior = self.update_prior_fn(it) if self.update_prior_fn else None
         X_prev = X
@@ -282,5 +292,7 @@ class FixedPoint(nn.Module):
                 cur_params,
                 *args,
             )
-        self.check_iteration = self.check_iteration_fn(X_prev, X) if self.check_iteration_fn else True
+        self.check_iteration = (
+            self.check_iteration_fn(X_prev, X) if self.check_iteration_fn else True
+        )
         return X if self.check_iteration else X_prev

--- a/deepinv/optim/fixed_point.py
+++ b/deepinv/optim/fixed_point.py
@@ -232,8 +232,10 @@ class FixedPoint(nn.Module):
             else None
         )
         self.check_iteration = True
-        # if self.anderson_acceleration:
-        self.x_hist, self.T_hist, self.H, self.q = self.init_anderson_acceleration(X)
+        if self.anderson_acceleration:
+            self.x_hist, self.T_hist, self.H, self.q = self.init_anderson_acceleration(
+                X
+            )
         it = 0
 
         for it in tqdm(

--- a/deepinv/optim/optim_iterators/pgd.py
+++ b/deepinv/optim/optim_iterators/pgd.py
@@ -53,7 +53,7 @@ class FISTAIteration(OptimIterator):
 
 
     where :math:`\gamma` is a stepsize that should satisfy :math:` \gamma \leq 1/\operatorname{Lip}(\|\nabla f\|)` and
-    :math:`\alpha_k = (k + a)/ a `.
+    :math:`\alpha_k = (k + a - 1) / (k + a) `.
     """
 
     def __init__(self, a=3, **kwargs):
@@ -80,7 +80,7 @@ class FISTAIteration(OptimIterator):
         """
         x_prev, z_prev = X["est"][0], X["est"][1]
         k = 0 if "it" not in X else X["it"]
-        alpha = (k + self.a) / self.a
+        alpha = (k + self.a - 1) / (k + self.a)
 
         if not self.g_first:
             z = self.f_step(z_prev, cur_data_fidelity, cur_params, y, physics)

--- a/deepinv/optim/optim_iterators/pgd.py
+++ b/deepinv/optim/optim_iterators/pgd.py
@@ -53,7 +53,7 @@ class FISTAIteration(OptimIterator):
 
 
     where :math:`\gamma` is a stepsize that should satisfy :math:` \gamma \leq 1/\operatorname{Lip}(\|\nabla f\|)` and
-    :math:`\alpha_k = (t_k + a - 1)/(t_k + a)`.
+    :math:`\alpha_k = (k + a)/ a `.
     """
 
     def __init__(self, a=3, **kwargs):
@@ -80,7 +80,7 @@ class FISTAIteration(OptimIterator):
         """
         x_prev, z_prev = X["est"][0], X["est"][1]
         k = 0 if "it" not in X else X["it"]
-        alpha = (k - 1) / (k + self.a)
+        alpha = (k + self.a) / self.a
 
         if not self.g_first:
             z = self.f_step(z_prev, cur_data_fidelity, cur_params, y, physics)

--- a/deepinv/optim/optim_iterators/pgd.py
+++ b/deepinv/optim/optim_iterators/pgd.py
@@ -79,7 +79,7 @@ class FISTAIteration(OptimIterator):
         :return: Dictionary `{"est": (x, z), "cost": F}` containing the updated current iterate and the estimated current cost.
         """
         x_prev, z_prev = X["est"][0], X["est"][1]
-        k = 2 if "it" not in X else X["it"]
+        k = 0 if "it" not in X else X["it"]
         alpha = (k - 1) / (k + self.a)
 
         if not self.g_first:

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -501,9 +501,12 @@ def create_iterator(iteration, prior=None, F_fn=None, g_first=False):
     :param bool g_first: whether to perform the step on :math:`g` before that on :math:`f` before or not. Default: False
     """
     # If no custom objective function F_fn is given but g is explicitly given, we have an explicit objective function.
-    explicit_prior = (
-        prior[0].explicit_prior if isinstance(prior, list) else prior.explicit_prior
-    )
+    if prior:
+        explicit_prior = (
+            prior[0].explicit_prior if isinstance(prior, list) else prior.explicit_prior
+        )
+    else:
+        explicit_prior = False
     if F_fn is None and explicit_prior:
 
         def F_fn(x, data_fidelity, prior, cur_params, y, physics):

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -505,12 +505,7 @@ def create_iterator(iteration, prior=None, F_fn=None, g_first=False):
     if prior is None:
         prior = Zero()
     # If no custom objective function F_fn is given but g is explicitly given, we have an explicit objective function.
-    if prior:
-        explicit_prior = (
-            prior[0].explicit_prior if isinstance(prior, list) else prior.explicit_prior
-        )
-    else:
-        explicit_prior = False
+    explicit_prior = prior[0].explicit_prior if isinstance(prior, list) else prior.explicit_prior
     if F_fn is None and explicit_prior:
 
         def F_fn(x, data_fidelity, prior, cur_params, y, physics):

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -253,7 +253,7 @@ class BaseOptim(nn.Module):
             history_size=history_size,
             beta_anderson_acc=beta_anderson_acc,
             eps_anderson_acc=eps_anderson_acc,
-            verbose=verbose
+            verbose=verbose,
         )
 
     def update_params_fn(self, it):

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -505,7 +505,9 @@ def create_iterator(iteration, prior=None, F_fn=None, g_first=False):
     if prior is None:
         prior = Zero()
     # If no custom objective function F_fn is given but g is explicitly given, we have an explicit objective function.
-    explicit_prior = prior[0].explicit_prior if isinstance(prior, list) else prior.explicit_prior
+    explicit_prior = (
+        prior[0].explicit_prior if isinstance(prior, list) else prior.explicit_prior
+    )
     if F_fn is None and explicit_prior:
 
         def F_fn(x, data_fidelity, prior, cur_params, y, physics):

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -253,6 +253,7 @@ class BaseOptim(nn.Module):
             history_size=history_size,
             beta_anderson_acc=beta_anderson_acc,
             eps_anderson_acc=eps_anderson_acc,
+            verbose=verbose
         )
 
     def update_params_fn(self, it):

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -125,7 +125,7 @@ class Zero(Prior):
 
     def __init__(self):
         super().__init__()
-        self._g = lambda x: 0.0
+        self._g = lambda x, *args, **kwargs: 0.0
         self.explicit_prior = True
 
     def grad(self, x, *args):

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -125,7 +125,6 @@ class Zero(Prior):
 
     def __init__(self):
         super().__init__()
-        self._g = lambda x, *args, **kwargs: 0.0
         self.explicit_prior = True
 
     def grad(self, x, *args):


### PR DESCRIPTION
I implemented the one_iteration method for the FixedPoint class. This method allows iterating one step at a time, which is particularly useful when using DeepInv with the benchopt package. It also provides access to the algorithm's outputs at different iterations, rather than just the final one.

Additionally, I included a tqdm bar to track the algorithm's progress. However, this might be redundant for some users since a verbose argument already exists (although I'm unsure if it displays anything when set to True). To address this, we could introduce a verbose attribute in the BaseOptim class and propagate it to FixedPoint. This would allow users to control the activation of the tqdm bar.

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
