### PR TITLE
Trainer loss name fix

### DIFF
--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -216,14 +216,12 @@ class Trainer:
         # losses
         self.logs_total_loss_train = AverageMeter("Training loss", ":.2e")
         self.logs_losses_train = [
-            AverageMeter("Training loss " + l.__class__.__name__, ":.2e")
-            for l in self.losses
+            AverageMeter("Training loss " + l.name, ":.2e") for l in self.losses
         ]
 
         self.logs_total_loss_eval = AverageMeter("Validation loss", ":.2e")
         self.logs_losses_eval = [
-            AverageMeter("Validation loss " + l.__class__.__name__, ":.2e")
-            for l in self.losses
+            AverageMeter("Validation loss " + l.name, ":.2e") for l in self.losses
         ]
 
         # metrics
@@ -683,7 +681,7 @@ class Trainer:
                     )
 
                 for l in self.logs_losses_eval:
-                    self.eval_metrics_history[l.__class__.__name__] = l.avg
+                    self.eval_metrics_history[l.name] = l.avg
 
             ## Training
             self.current_iterators = [iter(loader) for loader in self.train_dataloader]

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -216,12 +216,14 @@ class Trainer:
         # losses
         self.logs_total_loss_train = AverageMeter("Training loss", ":.2e")
         self.logs_losses_train = [
-            AverageMeter("Training loss " + l.name, ":.2e") for l in self.losses
+            AverageMeter("Training loss " + l.__class__.__name__, ":.2e")
+            for l in self.losses
         ]
 
         self.logs_total_loss_eval = AverageMeter("Validation loss", ":.2e")
         self.logs_losses_eval = [
-            AverageMeter("Validation loss " + l.name, ":.2e") for l in self.losses
+            AverageMeter("Validation loss " + l.__class__.__name__, ":.2e")
+            for l in self.losses
         ]
 
         # metrics
@@ -681,7 +683,7 @@ class Trainer:
                     )
 
                 for l in self.logs_losses_eval:
-                    self.eval_metrics_history[l.name] = l.avg
+                    self.eval_metrics_history[l.__class__.__name__] = l.avg
 
             ## Training
             self.current_iterators = [iter(loader) for loader in self.train_dataloader]


### PR DESCRIPTION
In trainer, change all instances of `loss.name` to `loss.__class__.__name__` for consistency.

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
