### PR TITLE
Remove train argument in models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ results/
 *.tar.gz
 *tmp
 *.tar
+*.ipynb
 
 # Folders
 /docs/build/

--- a/deepinv/models/GSPnP.py
+++ b/deepinv/models/GSPnP.py
@@ -125,4 +125,5 @@ def GSDRUNet(
             ckpt = ckpt["state_dict"]
 
         GSmodel.load_state_dict(ckpt, strict=False)
+        GSmodel.eval()
     return GSmodel

--- a/deepinv/models/GSPnP.py
+++ b/deepinv/models/GSPnP.py
@@ -22,11 +22,10 @@ class GSPnP(nn.Module):
     :param float alpha: Relaxation parameter
     """
 
-    def __init__(self, denoiser, alpha=1.0, train=False):
+    def __init__(self, denoiser, alpha=1.0):
         super().__init__()
         self.student_grad = StudentGrad(denoiser)
         self.alpha = alpha
-        self.train = train
 
     def potential(self, x, sigma, *args, **kwargs):
         N = self.student_grad(x, sigma)
@@ -73,7 +72,6 @@ def GSDRUNet(
     nc=[64, 128, 256, 512],
     act_mode="E",
     pretrained=None,
-    train=False,
     device=torch.device("cpu"),
 ):
     """
@@ -107,10 +105,9 @@ def GSDRUNet(
         nc=nc,
         act_mode=act_mode,
         pretrained=None,
-        train=train,
         device=device,
     )
-    GSmodel = GSPnP(denoiser, alpha=alpha, train=train)
+    GSmodel = GSPnP(denoiser, alpha=alpha)
     if pretrained:
         if pretrained == "download":
             url = get_weights_url(

--- a/deepinv/models/diffunet.py
+++ b/deepinv/models/diffunet.py
@@ -264,6 +264,7 @@ class DiffUNet(nn.Module):
                 ckpt = torch.load(pretrained, map_location=lambda storage, loc: storage)
 
             self.load_state_dict(ckpt, strict=True)
+            self.eval()
 
     def convert_to_fp16(self):
         """

--- a/deepinv/models/dncnn.py
+++ b/deepinv/models/dncnn.py
@@ -39,7 +39,6 @@ class DnCNN(nn.Module):
         bias=True,
         nf=64,
         pretrained="download",
-        train=False,
         device="cpu",
     ):
         super(DnCNN, self).__init__()
@@ -90,12 +89,7 @@ class DnCNN(nn.Module):
             else:
                 ckpt = torch.load(pretrained, map_location=lambda storage, loc: storage)
             self.load_state_dict(ckpt, strict=True)
-
-        if not train:
-            self.eval()
-            for _, v in self.named_parameters():
-                v.requires_grad = False
-        else:
+        else: 
             self.apply(weights_init_kaiming)
 
         if device is not None:

--- a/deepinv/models/dncnn.py
+++ b/deepinv/models/dncnn.py
@@ -89,7 +89,7 @@ class DnCNN(nn.Module):
             else:
                 ckpt = torch.load(pretrained, map_location=lambda storage, loc: storage)
             self.load_state_dict(ckpt, strict=True)
-        else: 
+        else:
             self.apply(weights_init_kaiming)
 
         if device is not None:

--- a/deepinv/models/dncnn.py
+++ b/deepinv/models/dncnn.py
@@ -89,6 +89,7 @@ class DnCNN(nn.Module):
             else:
                 ckpt = torch.load(pretrained, map_location=lambda storage, loc: storage)
             self.load_state_dict(ckpt, strict=True)
+            self.eval()
         else:
             self.apply(weights_init_kaiming)
 

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -149,6 +149,7 @@ class DRUNet(nn.Module):
                 )
 
             self.load_state_dict(ckpt_drunet, strict=True)
+            self.eval()
         else:
             self.apply(weights_init_drunet)
 

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -26,7 +26,7 @@ class DRUNet(nn.Module):
     :param list nc: number of convolutional layers.
     :param int nb: number of convolutional blocks per layer.
     :param int nf: number of channels per convolutional layer.
-    :param str act_mode: activation mode, "R" for ReLU, "L" for LeakyReLU "E" for ELU and "S" for Softplus.
+    :param str act_mode: activation mode, "R" for ReLU, "L" for LeakyReLU "E" for ELU and "s" for Softplus.
     :param str downsample_mode: Downsampling mode, "avgpool" for average pooling, "maxpool" for max pooling, and
         "strideconv" for convolution with stride 2.
     :param str upsample_mode: Upsampling mode, "convtranspose" for convolution transpose, "pixelsuffle" for pixel

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -153,11 +153,6 @@ class DRUNet(nn.Module):
         else:
             self.apply(weights_init_drunet)
 
-        if not train:
-            self.eval()
-            for _, v in self.named_parameters():
-                v.requires_grad = False
-
         if device is not None:
             self.to(device)
 

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -51,7 +51,6 @@ class DRUNet(nn.Module):
         downsample_mode="strideconv",
         upsample_mode="convtranspose",
         pretrained="download",
-        train=False,
         device=None,
     ):
         super(DRUNet, self).__init__()

--- a/deepinv/models/restormer.py
+++ b/deepinv/models/restormer.py
@@ -79,8 +79,7 @@ class Restormer(nn.Module):
         LayerNorm_type: str = "BiasFree",
         dual_pixel_task: bool = False,
         pretrained: Optional[str] = "denoising",
-        device: Optional[torch.device] = None,
-        train=False,
+        device: Optional[torch.device] = None
     ) -> None:
         super(Restormer, self).__init__()
 
@@ -349,8 +348,6 @@ class Restormer(nn.Module):
             self.load_state_dict(ckpt_restormer["params"], strict=True)
         elif pretrained is not None:
             raise ValueError(f"pretrained value error, {pretrained}")
-
-        self.training = train
 
         if device is not None:
             self.to(device)

--- a/deepinv/models/restormer.py
+++ b/deepinv/models/restormer.py
@@ -335,6 +335,7 @@ class Restormer(nn.Module):
                 pretrained, map_location=lambda storage, loc: storage
             )
             self.load_state_dict(ckpt_restormer["params"], strict=True)
+            self.eval()
         elif weights_pth_filename is not None:
             print(f"Loading from {weights_pth_filename}")
             url = get_weights_url(
@@ -346,6 +347,7 @@ class Restormer(nn.Module):
                 file_name=weights_pth_filename,
             )
             self.load_state_dict(ckpt_restormer["params"], strict=True)
+            self.eval()
         elif pretrained is not None:
             raise ValueError(f"pretrained value error, {pretrained}")
 

--- a/deepinv/models/restormer.py
+++ b/deepinv/models/restormer.py
@@ -79,7 +79,7 @@ class Restormer(nn.Module):
         LayerNorm_type: str = "BiasFree",
         dual_pixel_task: bool = False,
         pretrained: Optional[str] = "denoising",
-        device: Optional[torch.device] = None
+        device: Optional[torch.device] = None,
     ) -> None:
         super(Restormer, self).__init__()
 

--- a/deepinv/models/scunet.py
+++ b/deepinv/models/scunet.py
@@ -300,7 +300,6 @@ class SCUNet(nn.Module):
         drop_path_rate=0.0,
         input_resolution=256,
         pretrained="download",
-        train=False,
         device="cpu",
     ):
         super(SCUNet, self).__init__()
@@ -439,11 +438,6 @@ class SCUNet(nn.Module):
 
             self.load_state_dict(ckpt_drunet, strict=True)
 
-        if not train:
-            self.eval()
-            for _, v in self.named_parameters():
-                v.requires_grad = False
-
         if device is not None:
             self.to(device)
 
@@ -483,7 +477,7 @@ class SCUNet(nn.Module):
 
 # if __name__ == '__main__':
 #     # torch.cuda.empty_cache()
-#     net = SCUNet(pretrained='download', device='cpu', train=False)
+#     net = SCUNet(pretrained='download', device='cpu')
 #
 #     x = torch.randn((2, 3, 64, 128))
 #     x = net(x)

--- a/deepinv/models/scunet.py
+++ b/deepinv/models/scunet.py
@@ -437,6 +437,7 @@ class SCUNet(nn.Module):
                 )
 
             self.load_state_dict(ckpt_drunet, strict=True)
+            self.eval()
 
         if device is not None:
             self.to(device)

--- a/deepinv/models/swinir.py
+++ b/deepinv/models/swinir.py
@@ -1035,6 +1035,7 @@ class SwinIR(nn.Module):
                 else pretrained_weights
             )
             self.load_state_dict(pretrained_weights, strict=True)
+            self.eval()
 
     def _init_weights(self, m):
         if isinstance(m, nn.Linear):

--- a/deepinv/optim/dpir.py
+++ b/deepinv/optim/dpir.py
@@ -42,7 +42,7 @@ class DPIR(BaseOptim):
     """
 
     def __init__(self, sigma=0.1, device="cuda"):
-        prior = PnP(denoiser=DRUNet(pretrained="download", train=False, device=device))
+        prior = PnP(denoiser=DRUNet(pretrained="download", device=device))
         sigma_denoiser, stepsize, max_iter = get_DPIR_params(sigma)
         params_algo = {"stepsize": stepsize, "g_param": sigma_denoiser}
         super(DPIR, self).__init__(

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -582,7 +582,7 @@ def optim_builder(
         params_algo=params_algo,
         max_iter=max_iter,
         **kwargs,
-    )
+    ).eval()
 
 
 def str_to_class(classname):

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -183,7 +183,7 @@ class Downsampling(LinearPhysics):
         super().__init__(**kwargs)
         self.factor = factor
         assert isinstance(factor, int), "downsampling factor should be an integer"
-        assert len(img_size) == 3, "img_size should be a tuple of length 3, C x H x W"
+        # assert len(img_size) == 3, "img_size should be a tuple of length 3, C x H x W"
         self.imsize = img_size
         self.padding = padding
         if isinstance(filter, torch.nn.Parameter):

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -86,7 +86,7 @@ def choose_denoiser(name, imsize):
     else:
         raise Exception("Unknown denoiser")
 
-    return out
+    return out.eval()
 
 
 def test_TVs_adjoint():
@@ -255,7 +255,6 @@ def test_TV_models_identity():
 @pytest.mark.parametrize("denoiser", MODEL_LIST)
 def test_denoiser_color(imsize, device, denoiser):
     model = choose_denoiser(denoiser, imsize).to(device)
-
     torch.manual_seed(0)
     sigma = 0.2
     physics = dinv.physics.Denoising(dinv.physics.GaussianNoise(sigma))
@@ -287,7 +286,7 @@ def test_equivariant(imsize, device):
 
     model = dinv.models.EquivariantDenoiser(
         model, transform="rotoflips", random=True
-    ).to(device)
+    ).to(device).eval()
 
     torch.manual_seed(0)
     sigma = 0.2
@@ -341,7 +340,7 @@ def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
 def test_drunet_inputs(imsize_1_channel, device):
     f = dinv.models.DRUNet(
         in_channels=imsize_1_channel[0], out_channels=imsize_1_channel[0], device=device
-    )
+    ).eval()
 
     torch.manual_seed(0)
     sigma = 0.2

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -284,9 +284,11 @@ def test_equivariant(imsize, device):
     # 1. Check that the equivariance module is compatible with a denoiser
     model = dinv.models.DRUNet(in_channels=imsize[0], out_channels=imsize[0])
 
-    model = dinv.models.EquivariantDenoiser(
-        model, transform="rotoflips", random=True
-    ).to(device).eval()
+    model = (
+        dinv.models.EquivariantDenoiser(model, transform="rotoflips", random=True)
+        .to(device)
+        .eval()
+    )
 
     torch.manual_seed(0)
     sigma = 0.2

--- a/deepinv/unfolded/unfolded.py
+++ b/deepinv/unfolded/unfolded.py
@@ -136,7 +136,7 @@ def unfolded_builder(
         >>> model = dinv.unfolded.unfolded_builder(
         ...     iteration="PGD",
         ...     data_fidelity=dinv.optim.L2(),
-        ...     prior=dinv.optim.PnP(dinv.models.DnCNN(in_channels=1, out_channels=1, train=True)),
+        ...     prior=dinv.optim.PnP(dinv.models.DnCNN(in_channels=1, out_channels=1)),
         ...     params_algo={"stepsize": 1.0, "g_param": 1.0},
         ...     trainable_params=["stepsize", "g_param"]
         ... )

--- a/docs/source/deepinv.multigpu.rst
+++ b/docs/source/deepinv.multigpu.rst
@@ -13,7 +13,7 @@ For instance, one can simply write:
     >>> import torch
     >>> import deepinv as dinv
     >>>
-    >>> backbone = dinv.models.DRUNet(pretrained=None, train=True, device=torch.device("cuda"))
+    >>> backbone = dinv.models.DRUNet(pretrained=None, device=torch.device("cuda"))
     >>> model = dinv.models.ArtifactRemoval(backbone)
     >>> gpu_number = torch.cuda.device_count()  # number of GPUs to use
     >>> model = torch.nn.DataParallel(model, device_ids=list(range(gpu_number)))

--- a/docs/source/deepinv.unfolded.rst
+++ b/docs/source/deepinv.unfolded.rst
@@ -59,7 +59,7 @@ evaluated with any forward model (e.g., denoising, deconvolution, inpainting, et
     >>> model = dinv.unfolded.unfolded_builder(
     ...     iteration="PGD",
     ...     data_fidelity=dinv.optim.L2(),
-    ...     prior=dinv.optim.PnP(dinv.models.DnCNN(train=True)),
+    ...     prior=dinv.optim.PnP(dinv.models.DnCNN()),
     ...     params_algo={"stepsize": 1.0, "g_param": 1.0},
     ...     trainable_params=["stepsize", "g_param"]
     ... )

--- a/examples/basics/demo_phase_retrieval.py
+++ b/examples/basics/demo_phase_retrieval.py
@@ -196,7 +196,6 @@ denoiser = DRUNet(
     in_channels=n_channels,
     out_channels=n_channels,
     pretrained="download",  # automatically downloads the pretrained weights, set to a path to use custom weights.
-    train=False,
     device=device,
 )
 # The original denoiser is designed for real-valued images, so we need to convert it to a complex-valued denoiser for phase retrieval problems.

--- a/examples/plug-and-play/demo_PnP_DPIR_deblur.py
+++ b/examples/plug-and-play/demo_PnP_DPIR_deblur.py
@@ -119,7 +119,7 @@ early_stop = False  # Do not stop algorithm with convergence criteria
 data_fidelity = L2()
 
 # Specify the denoising prior
-prior = PnP(denoiser=DRUNet(pretrained="download", train=False, device=device))
+prior = PnP(denoiser=DRUNet(pretrained="download", device=device))
 
 # instantiate the algorithm class to solve the IP problem.
 model = optim_builder(

--- a/examples/plug-and-play/demo_PnP_DPIR_deblur.py
+++ b/examples/plug-and-play/demo_PnP_DPIR_deblur.py
@@ -132,6 +132,10 @@ model = optim_builder(
     params_algo=params_algo,
 )
 
+# Set the model to evaluation mode. We do not require training here.
+model.eval()
+
+
 # %%
 # Evaluate the model on the problem.
 # --------------------------------------------------------------------

--- a/examples/plug-and-play/demo_PnP_custom_optim.py
+++ b/examples/plug-and-play/demo_PnP_custom_optim.py
@@ -218,7 +218,6 @@ denoiser = DnCNN(
     in_channels=n_channels,
     out_channels=n_channels,
     pretrained="download_lipschitz",
-    train=False,
     device=device,
 )
 prior = PnP(denoiser=denoiser)

--- a/examples/plug-and-play/demo_RED_GSPnP_SR.py
+++ b/examples/plug-and-play/demo_RED_GSPnP_SR.py
@@ -142,7 +142,7 @@ method = "GSPnP"
 denoiser_name = "gsdrunet"
 # Specify the Denoising prior
 prior = GSPnP(
-    denoiser=dinv.models.GSDRUNet(pretrained="download", train=False).to(device)
+    denoiser=dinv.models.GSDRUNet(pretrained="download").to(device)
 )
 
 

--- a/examples/plug-and-play/demo_RED_GSPnP_SR.py
+++ b/examples/plug-and-play/demo_RED_GSPnP_SR.py
@@ -141,9 +141,7 @@ class GSPnP(RED):
 method = "GSPnP"
 denoiser_name = "gsdrunet"
 # Specify the Denoising prior
-prior = GSPnP(
-    denoiser=dinv.models.GSDRUNet(pretrained="download").to(device)
-)
+prior = GSPnP(denoiser=dinv.models.GSDRUNet(pretrained="download").to(device))
 
 
 # we want to output the intermediate PGD update to finish with a denoising step.

--- a/examples/plug-and-play/demo_RED_GSPnP_SR.py
+++ b/examples/plug-and-play/demo_RED_GSPnP_SR.py
@@ -165,6 +165,10 @@ model = optim_builder(
     verbose=True,
 )
 
+# Set the model to evaluation mode. We do not require training here.
+model.eval()
+
+
 # %%
 # Evaluate the model on the problem.
 # ----------------------------------------------------

--- a/examples/plug-and-play/demo_vanilla_PnP.py
+++ b/examples/plug-and-play/demo_vanilla_PnP.py
@@ -112,6 +112,10 @@ model = optim_builder(
     },
 )
 
+# Set the model to evaluation mode. We do not require training here.
+model.eval()
+
+
 # %%
 # Evaluate the model on the problem and plot the results.
 # --------------------------------------------------------------------

--- a/examples/plug-and-play/demo_vanilla_PnP.py
+++ b/examples/plug-and-play/demo_vanilla_PnP.py
@@ -89,7 +89,6 @@ denoiser = DnCNN(
     in_channels=n_channels,
     out_channels=n_channels,
     pretrained="download",  # automatically downloads the pretrained weights, set to a path to use custom weights.
-    train=False,
     device=device,
 )
 prior = PnP(denoiser=denoiser)

--- a/examples/self-supervised-learning/demo_equivariant_imaging.py
+++ b/examples/self-supervised-learning/demo_equivariant_imaging.py
@@ -112,7 +112,6 @@ prior = PnP(
         in_channels=n_channels,
         out_channels=n_channels,
         pretrained=None,
-        train=True,
         depth=7,
     ).to(device)
 )

--- a/examples/unfolded/demo_DEQ.py
+++ b/examples/unfolded/demo_DEQ.py
@@ -118,7 +118,7 @@ data_fidelity = L2()
 
 # Set up the trainable denoising prior
 denoiser = DnCNN(
-    in_channels=3, out_channels=3, depth=7, device=device, pretrained=None, train=True
+    in_channels=3, out_channels=3, depth=7, device=device, pretrained=None
 )
 
 # Here the prior model is common for all iterations

--- a/examples/unfolded/demo_DEQ.py
+++ b/examples/unfolded/demo_DEQ.py
@@ -117,9 +117,7 @@ test_dataset = dinv.datasets.HDF5Dataset(path=generated_datasets_path, train=Fal
 data_fidelity = L2()
 
 # Set up the trainable denoising prior
-denoiser = DnCNN(
-    in_channels=3, out_channels=3, depth=7, device=device, pretrained=None
-)
+denoiser = DnCNN(in_channels=3, out_channels=3, depth=7, device=device, pretrained=None)
 
 # Here the prior model is common for all iterations
 prior = PnP(denoiser=denoiser)

--- a/examples/unfolded/demo_vanilla_unfolded.py
+++ b/examples/unfolded/demo_vanilla_unfolded.py
@@ -119,7 +119,7 @@ data_fidelity = L2()
 
 # Set up the trainable denoising prior
 # Here the prior model is common for all iterations
-prior = PnP(denoiser=dinv.models.DnCNN(depth=7, pretrained=None, train=True).to(device))
+prior = PnP(denoiser=dinv.models.DnCNN(depth=7, pretrained=None).to(device))
 
 # The parameters are initialized with a list of length max_iter, so that a distinct parameter is trained for each iteration.
 stepsize = [1.0] * max_iter  # stepsize of the algorithm


### PR DESCRIPTION
Remove the train argument in the init of the models. By default the model is initialized with self.training=True. In order to only evaluate the model, the user must use model.eval() . If the model is loaded with pretrained weights, then it is set automatically to eval mode. 

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
