### PR TITLE
Reformat Sampling as Optim

### DIFF
--- a/deepinv/optim/optim_iterators/gradient_descent.py
+++ b/deepinv/optim/optim_iterators/gradient_descent.py
@@ -1,5 +1,5 @@
 from .optim_iterator import OptimIterator, fStep, gStep
-
+import torch
 
 class GDIteration(OptimIterator):
     r"""

--- a/deepinv/optim/optim_iterators/optim_iterator.py
+++ b/deepinv/optim/optim_iterators/optim_iterator.py
@@ -50,6 +50,7 @@ class OptimIterator(nn.Module):
         self.g_step = gStep(g_first=self.g_first)
         self.requires_grad_g = False
         self.requires_prox_g = False
+        self.sampling = False
 
     def relaxation_step(self, u, v, beta):
         r"""
@@ -85,6 +86,8 @@ class OptimIterator(nn.Module):
             z = self.g_step(x_prev, cur_prior, cur_params)
             x = self.f_step(z, cur_data_fidelity, cur_params, y, physics)
         x = self.relaxation_step(x, x_prev, cur_params["beta"])
+        if self.sampling:
+            x = x + torch.sqrt(2 * cur_params["stepsize"]) * torch.randn_like(x)
         F = (
             self.F_fn(x, cur_data_fidelity, cur_prior, cur_params, y, physics)
             if self.has_cost


### PR DESCRIPTION
Work in process. The goal of this PR is to unify the implementations of sampling and optim. The main argument is that any optim algorithm can be used for sampling by adding the right amount of noise at each iteration (i.e. a "flow" term, one step solution of the heat equation). 

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
