### PR TITLE
feat(dataset): Allow to setup cache on first call for fastmri dataset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ New Features
 
 Fixed
 ^^^^^
+- Fix cache file initialization in FastMRI Dataloader (:gh:`300` by `Pierre-Antoine Comby`_)
 
 Changed
 ^^^^^^^
@@ -213,3 +214,4 @@ Authors
 .. _Chao Tang: https://github.com/ChaoTang0330
 .. _Tobias Liaudat: https://github.com/tobias-liaudat
 .. _Andrew Wang: https://andrewwango.github.io/about/
+.. _Pierre-Antoine Comby: https://github.com/paquiteau

--- a/deepinv/datasets/fastmri.py
+++ b/deepinv/datasets/fastmri.py
@@ -12,6 +12,7 @@ import random
 from pathlib import Path
 from typing import Any, Callable, NamedTuple, Optional, Union, Tuple
 import pickle
+import warnings
 import os
 import h5py
 import torch
@@ -151,12 +152,18 @@ class FastMRISliceDataset(torch.utils.data.Dataset):
 
         # should contain all the information to load a slice from the storage
         self.sample_identifiers = []
-        if load_metadata_from_cache:  # from a cache file
-            metadata_cache_file = Path(metadata_cache_file)
-            if not metadata_cache_file.exists():
+
+        if load_metadata_from_cache and os.path.exists(
+            metadata_cache_file
+        ):  # from a cache file
+            if not os.path.exists(metadata_cache_file) and save_metadata_to_cache:
+                warnings.warn(
+                    f"`metadata_cache_file` not found, it will be created at {metadata_cache_file}."
+                )
+            else:
                 raise ValueError(
-                    "`metadata_cache_file` doesn't exist. Please either deactivate"
-                    + "`load_dataset_from_cache` OR set `metadata_cache_file` properly."
+                    "`metadata_cache_file` doesn't exist, and `save_metadata_to_cache` is set to False. "
+                    "Please either deactivate `load_dataset_from_cache` OR set `metadata_cache_file` properly."
                 )
             with open(metadata_cache_file, "rb") as f:
                 dataset_cache = pickle.load(f)


### PR DESCRIPTION
When FastMRI Dataloader is setup with both `load_dataset_from_cache=True` and `save_metadata_to_cache=True` for the first time, it raises an error. 

This PR changes this behavior, to a more sane default: 

only raising a warning when the file is not found (because it has not been created yet). If the file does not exists, and saving it disable, an error is raised. 

-------

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).