### PR TITLE
fix demo_wavelet_prior.py

### DIFF
--- a/examples/optimization/demo_wavelet_prior.py
+++ b/examples/optimization/demo_wavelet_prior.py
@@ -33,7 +33,7 @@ DEG_DIR = BASE_DIR / "degradations"
 # %%
 # Load base image datasets and degradation operators.
 # ----------------------------------------------------------------------------------------
-# In this example, we use the Set3C dataset 
+# In this example, we use the Set3C dataset
 #
 
 # Set the global random seed from pytorch to ensure reproducibility of the example.

--- a/examples/optimization/demo_wavelet_prior.py
+++ b/examples/optimization/demo_wavelet_prior.py
@@ -33,8 +33,7 @@ DEG_DIR = BASE_DIR / "degradations"
 # %%
 # Load base image datasets and degradation operators.
 # ----------------------------------------------------------------------------------------
-# In this example, we use the Set3C dataset and a motion blur kernel from
-# `Levin et al. (2009) <https://ieeexplore.ieee.org/abstract/document/5206815/>`_.
+# In this example, we use the Set3C dataset 
 #
 
 # Set the global random seed from pytorch to ensure reproducibility of the example.
@@ -49,12 +48,6 @@ val_transform = transforms.Compose(
     [transforms.CenterCrop(img_size), transforms.ToTensor()]
 )
 
-# Generate a motion blur operator.
-kernel_index = 1  # which kernel to chose among the 8 motion kernels from 'Levin09.mat'
-kernel_torch = load_degradation("Levin09.npy", DEG_DIR / "kernels", index=kernel_index)
-kernel_torch = kernel_torch.unsqueeze(0).unsqueeze(
-    0
-)  # add batch and channel dimensions
 dataset = load_dataset(dataset_name, ORIGINAL_DATA_DIR, transform=val_transform)
 
 


### PR DESCRIPTION
fixes an unnecessary loading of a motion blur kernel in the wavelet prior example. 

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
