### PR TITLE
Generate dataset generator batch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,7 @@ Fixed
 - Fixed Trainer save_path timestamp problem on Windows (:gh:`245` by `Andrew Wang`_)
 - Fixed inpainting/SplittingLoss mask generation + more flexible tensor size handling + pixelwise masking (:gh:`267` by `Andrew Wang`_)
 - Fixed the `deepinv.physics.generator.ProductConvolutionBlurGenerator`, allowing for batch generation (previously does not work) by (`Minh Hai Nguyen`)
+- Fixed the generate_dataset with sigma_generator and batch_size != 1. (:gh:`315` by apolychronou) 
 Changed
 ^^^^^^^
 - Changed to Python 3.9+ (:gh:`280` by `Julian Tachella`_)

--- a/deepinv/datasets/datagenerator.py
+++ b/deepinv/datasets/datagenerator.py
@@ -155,7 +155,7 @@ def generate_dataset(
 
         # choose operator and generate measurement
         if physics_generator is not None:
-            params = physics_generator.step(batch_size=batch_size)
+            params = physics_generator.step(batch_size=1)
             y = physics[g](x, **params)
         else:
             y = physics[g](x)


### PR DESCRIPTION
when sigma_generator not None and batch_size != 1 in generate_dataset there was a dimension mismatch because x was taken from the class and not the dataloader

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
