### PR TITLE
FIX pip install error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,10 @@ jobs:
 
       - name: Install deepinv and its dependencies
         run: |
-          which pip
           pip install .[${{ matrix.extra }}]
 
       - name: Test with pytest and generate coverage report
         run: |
-          which python
-          python -c "import deepinv; print(deepinv)"
           python -m pytest deepinv/tests
           pytest --cov=./ --cov-report=xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Test with pytest and generate coverage report
         run: |
           which python
+          python -c "import deepinv"
           python -m pytest deepinv/tests
           pytest --cov=./ --cov-report=xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Test with pytest and generate coverage report
         run: |
           which python
-          python -c "import deepinv"
+          python -c "import deepinv; print(deepinv)"
           python -m pytest deepinv/tests
           pytest --cov=./ --cov-report=xml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install deepinv and its dependencies
         run: |
-          pip install -e .[${{ matrix.extra }}]
+          pip install .[${{ matrix.extra }}]
 
       - name: Test with pytest and generate coverage report
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,12 @@ jobs:
 
       - name: Install deepinv and its dependencies
         run: |
+          which pip
           pip install .[${{ matrix.extra }}]
 
       - name: Test with pytest and generate coverage report
         run: |
+          which python
           python -m pytest deepinv/tests
           pytest --cov=./ --cov-report=xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 platforms = ["any"]
 
 [tool.setuptools.packages]
-find = { where = ["deepinv"] }
+find = { where = ["."] }
 
 [project.readme]
 file = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
 [tool.setuptools]
 platforms = ["any"]
 
+[tool.setuptools.packages]
+find = { where = ["deepinv"], exclude = ["results"] }
+
 [project.readme]
 file = "README.rst"
 content-type = "text/x-rst"


### PR DESCRIPTION
Because of the `results` folder at the root of the repo, `pip install -e .` fails: 
```
base) ➜  deepinv git:(main) pip install -e .
Obtaining file:///home/mathurin/workspace/deepinv
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level packages discovered in a flat-layout: ['results', 'deepinv'].
      
      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.
      
      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:
      
      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names
      
      To find more information, look for "package discovery" on setuptools docs.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.
```

The proposed line fixes it but I'm not 100% certain. Maybe @tomMoral knows if this is the way to fix?
