### PR TITLE
generate dataset save params + fix bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ New Features
 - Add transform symmetrisation, further transform arithmetic, and new equivariant denoiser (:gh:`259` by `Andrew Wang`_)
 - New transforms: multi-axis reflect, time-shift and diffeomorphism (:gh:`259` by `Andrew Wang`_)
 - Add Metric baseclass, unified params (for complex, norm, reduce), typing, tests, L1L2 metric, QNR metric, and metrics docs section (:gh:`309` by `Andrew Wang`_)
-- generate_dataset features: complex numbers, save/load physics_generator params (:gh:`316` by `Andrew Wang`_)
+- generate_dataset features: complex numbers, save/load physics_generator params (:gh:`324` by `Andrew Wang`_)
 
 Fixed
 ^^^^^
@@ -31,8 +31,9 @@ Fixed
 - Fixed prox_l2 no learning option in Trainer (:gh:`304` by `Julian Tachella`_)
 
 - Fixed SSIM to use lightweight torchmetrics function + add MSE and NMSE as metrics + allow PSNR & SSIM to set max pixel on the fly (:gh:`296` by `Andrew Wang`_)
-- Fixed generate_dataset error with physics_generator and batch_size != 1. (:gh:`315` by apolychronou) 
-- Fixed generate_dataset error not using random physics generator (:gh:`316` by `Andrew Wang`_) 
+- Fix generate_dataset error with physics_generator and batch_size != 1. (:gh:`315` by apolychronou) 
+- Fix generate_dataset error not using random physics generator (:gh:`324` by `Andrew Wang`_) 
+- Fix Scale transform rng device error (:gh:`324` by `Andrew Wang`_) 
 
 Changed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ New Features
 - Add transform symmetrisation, further transform arithmetic, and new equivariant denoiser (:gh:`259` by `Andrew Wang`_)
 - New transforms: multi-axis reflect, time-shift and diffeomorphism (:gh:`259` by `Andrew Wang`_)
 - Add Metric baseclass, unified params (for complex, norm, reduce), typing, tests, L1L2 metric, QNR metric, and metrics docs section (:gh:`309` by `Andrew Wang`_)
+- generate_dataset features: complex numbers, save/load physics_generator params (:gh:`316` by `Andrew Wang`_)
 
 Fixed
 ^^^^^
@@ -30,6 +31,8 @@ Fixed
 - Fixed prox_l2 no learning option in Trainer (:gh:`304` by `Julian Tachella`_)
 
 - Fixed SSIM to use lightweight torchmetrics function + add MSE and NMSE as metrics + allow PSNR & SSIM to set max pixel on the fly (:gh:`296` by `Andrew Wang`_)
+- Fixed generate_dataset error with physics_generator and batch_size != 1. (:gh:`315` by apolychronou) 
+- Fixed generate_dataset error not using random physics generator (:gh:`316` by `Andrew Wang`_) 
 
 Changed
 ^^^^^^^
@@ -75,7 +78,7 @@ Fixed
 - Fixed Trainer save_path timestamp problem on Windows (:gh:`245` by `Andrew Wang`_)
 - Fixed inpainting/SplittingLoss mask generation + more flexible tensor size handling + pixelwise masking (:gh:`267` by `Andrew Wang`_)
 - Fixed the `deepinv.physics.generator.ProductConvolutionBlurGenerator`, allowing for batch generation (previously does not work) by (`Minh Hai Nguyen`)
-- Fixed the generate_dataset with sigma_generator and batch_size != 1. (:gh:`315` by apolychronou) 
+
 Changed
 ^^^^^^^
 - Changed to Python 3.9+ (:gh:`280` by `Julian Tachella`_)

--- a/deepinv/datasets/datagenerator.py
+++ b/deepinv/datasets/datagenerator.py
@@ -17,12 +17,16 @@ if TYPE_CHECKING:
 
 class HDF5Dataset(data.Dataset):
     r"""
-    DeepInverse HDF5 dataset with signal/measurement pairs.
+    DeepInverse HDF5 dataset with signal/measurement pairs ``(x, y)``.
 
     If there is no training ground truth (i.e. ``x_train``) in the dataset file,
     the dataset returns the measurement again as the signal.
 
-    Optionally also return physics generator params as a dict per sample, if one was used during data generation.
+    Optionally also return physics generator params as a dict per sample ``(x, y, params)``, if one was used during data generation.
+
+    ..note::
+
+        We support all dtypes supported by ``h5py`` including complex numbers, which will be stored as complex dtype.
 
     :param str path: Path to the folder containing the dataset (one or multiple HDF5 files).
     :param bool train: Set to ``True`` for training and ``False`` for testing.
@@ -119,6 +123,12 @@ def generate_dataset(
     The generated dataset contains a train and test splits.
 
     Optionally, if random physics generator is used to generate data, also save physics generator params.
+    This is useful e.g. if you are performing a parameter estimation task and want to evaluate the learnt parameters,
+    or for measurement consistency/data fidelity, and require knowledge of the params when constructing the loss.
+
+    ..note::
+
+        We support all dtypes supported by ``h5py`` including complex numbers, which will be stored as complex dtype.
 
     :param torch.data.Dataset train_dataset: base dataset (e.g., MNIST, CelebA, etc.)
         with images used for generating associated measurements

--- a/deepinv/datasets/datagenerator.py
+++ b/deepinv/datasets/datagenerator.py
@@ -1,75 +1,124 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING, Union, Callable, Tuple
+
 from tqdm import tqdm
 import os
 import h5py
 import torch
-from torch.utils.data import DataLoader, Subset
+from torch import Tensor
+from torch.utils.data import DataLoader, Subset, Dataset
 from torch.utils import data
+
+if TYPE_CHECKING:
+    from deepinv.physics import Physics
+    from deepinv.physics.generator import PhysicsGenerator
+    from deepinv.transform import Transform
 
 
 class HDF5Dataset(data.Dataset):
     r"""
     DeepInverse HDF5 dataset with signal/measurement pairs.
 
+    If there is no training ground truth (i.e. ``x_train``) in the dataset file,
+    the dataset returns the measurement again as the signal.
+
+    Optionally also return physics generator params as a dict per sample, if one was used during data generation.
+
     :param str path: Path to the folder containing the dataset (one or multiple HDF5 files).
     :param bool train: Set to ``True`` for training and ``False`` for testing.
-    :param transform: A torchvision transform to apply to the data.
+    :param Transform, Callable transform: A deepinv or torchvision transform to apply to the data.
+    :param bool load_physics_generator_params: load physics generator params from dataset if they exist (e.g. if dataset created with :meth:`deepinv.datasets.generate_dataset`)
+    :param torch.dtype, str dtype: cast all real-valued data to this dtype.
+    :param torch.dtype, str complex_dtype: cast all complex-valued data to this dtype.
     """
 
-    def __init__(self, path, train=True, transform=None):
+    def __init__(
+        self,
+        path: str,
+        train: bool = True,
+        transform: Union[Transform, Callable] = None,
+        load_physics_generator_params: bool = False,
+        dtype: torch.dtype = torch.float,
+        complex_dtype: torch.dtype = torch.cfloat,
+    ):
         super().__init__()
         self.data_info = []
         self.data_cache = {}
         self.unsupervised = False
         self.transform = transform
+        self.load_physics_generator_params = load_physics_generator_params
+        self.cast = lambda x: x.type(complex_dtype if x.is_complex() else dtype)
+
         hd5 = h5py.File(path, "r")
+        suffix = "_train" if train else "_test"
+        self.y = hd5[f"y{suffix}"]
+
         if train:
             if "x_train" in hd5:
-                self.x = hd5["x_train"]
+                self.x = hd5[f"x{suffix}"]
             else:
                 self.unsupervised = True
-            self.y = hd5["y_train"]
         else:
-            self.x = hd5["x_test"]
-            self.y = hd5["y_test"]
+            self.x = hd5[f"x{suffix}"]
+
+        if self.load_physics_generator_params:
+            self.params = {}
+            for k in hd5:
+                if suffix in k and k not in (f"x{suffix}", f"y{suffix}"):
+                    self.params[k.replace(suffix, "")] = hd5[k]
 
     def __getitem__(self, index):
-        y = torch.from_numpy(self.y[index]).type(torch.float)
+        y = self.cast(torch.from_numpy(self.y[index]))
 
         x = y
         if not self.unsupervised:
-            x = torch.from_numpy(self.x[index]).type(torch.float)
+            x = self.cast(torch.from_numpy(self.x[index]))
 
         if self.transform is not None:
             x = self.transform(x)
 
-        return x, y
+        if self.load_physics_generator_params:
+            params = {
+                k: self.cast(
+                    torch.from_numpy(param[index])
+                    if param.ndim > 1
+                    else torch.tensor(param[index])
+                )
+                for (k, param) in self.params.items()
+            }
+            return x, y, params
+        else:
+            return x, y
 
     def __len__(self):
         return len(self.y)
 
 
 def generate_dataset(
-    train_dataset,
-    physics,
-    save_dir,
-    test_dataset=None,
-    device="cpu",
-    train_datapoints=None,
-    test_datapoints=None,
-    physics_generator=None,
-    dataset_filename="dinv_dataset",
-    batch_size=4,
-    num_workers=0,
-    supervised=True,
-    verbose=True,
-    show_progress_bar=False,
+    train_dataset: Dataset,
+    physics: Physics,
+    save_dir: str,
+    test_dataset: Dataset = None,
+    device: Union[torch.device, str] = "cpu",
+    train_datapoints: int = None,
+    test_datapoints: int = None,
+    physics_generator: PhysicsGenerator = None,
+    save_physics_generator_params: bool = True,
+    dataset_filename: str = "dinv_dataset",
+    batch_size: int = 4,
+    num_workers: int = 0,
+    supervised: bool = True,
+    verbose: bool = True,
+    show_progress_bar: bool = False,
 ):
     r"""
     Generates dataset of signal/measurement pairs from base dataset.
 
     It generates the measurement data using the forward operator provided by the user.
-    The dataset is saved in HD5 format and can be easily loaded using the HD5Dataset class.
+    The dataset is saved in HD5 format and can be easily loaded using the :class:`deepinv.datasets.HD5Dataset` class.
     The generated dataset contains a train and test splits.
+
+    Optionally, if random physics generator is used to generate data, also save physics generator params.
 
     :param torch.data.Dataset train_dataset: base dataset (e.g., MNIST, CelebA, etc.)
         with images used for generating associated measurements
@@ -89,9 +138,10 @@ def generate_dataset(
         number of datapoints in the base test dataset.
     :param None, deepinv.physics.generator.PhysicsGenerator physics_generator: Optional physics generator for generating
             the physics operators. If not None, the physics operators are randomly sampled at each iteration using the generator.
+    :param bool save_physics_generator_params: save physics generator params too, ignored if ``physics_generator`` not used.
     :param str dataset_filename: desired filename of the dataset.
     :param int batch_size: batch size for generating the measurement data
-        (it only affects the speed of the generating process)
+        (it affects the speed of the generating process, and the physics generator batch size)
     :param int num_workers: number of workers for generating the measurement data
         (it only affects the speed of the generating process)
     :param bool supervised: Generates supervised pairs (x,y) of measurements and signals.
@@ -119,6 +169,10 @@ def generate_dataset(
     else:
         G = len(physics)
 
+    save_physics_generator_params = (
+        save_physics_generator_params and physics_generator is not None
+    )
+
     if train_dataset is not None:
         if train_datapoints is not None:
             datapoints = int(train_datapoints)
@@ -145,28 +199,45 @@ def generate_dataset(
 
         hf.attrs["operator"] = physics[g].__class__.__name__
 
+        # get initial image for image size
         if train_dataset is not None:
-            x = train_dataset[0]
+            x0 = train_dataset[0]
         elif test_dataset is not None:
-            x = test_dataset[0]
+            x0 = test_dataset[0]
 
-        x = x[0] if isinstance(x, list) or isinstance(x, tuple) else x
-        x = x.to(device).unsqueeze(0)
+        x0 = x0[0] if isinstance(x0, (list, tuple)) else x0
+        x0 = x0.to(device).unsqueeze(0)
 
-        # choose operator and generate measurement
+        # get initial measurement for initial image
+        def measure(x: Tensor, b: int, g: int) -> Tuple[Tensor, Union[dict, None]]:
+            if physics_generator is None:
+                return physics[g](x), None
+            else:
+                params = physics_generator.step(batch_size=b)
+                return physics[g](x, **params), params
+
+        y0, params0 = measure(x0, b=1, g=g)
+
         if physics_generator is not None:
-            params = physics_generator.step(batch_size=1)
-            y = physics[g](x, **params)
-        else:
-            y = physics[g](x)
+            # Reset physics generator so it starts again at initial rng
+            physics_generator.reset_rng()
 
-        # TODO save params if physics_generator is not None
+        # save physics
         torch.save(physics[g].state_dict(), f"{save_dir}/physics{g}.pt")
 
         if train_dataset is not None:
-            hf.create_dataset("y_train", (n_train_g,) + y.shape[1:], dtype="float")
+            hf.create_dataset(
+                "y_train", (n_train_g,) + y0.shape[1:], dtype=y0.numpy().dtype
+            )
             if supervised:
-                hf.create_dataset("x_train", (n_train_g,) + x.shape[1:], dtype="float")
+                hf.create_dataset(
+                    "x_train", (n_train_g,) + x0.shape[1:], dtype=x0.numpy().dtype
+                )
+            if save_physics_generator_params:
+                for k, p in params0.items():
+                    hf.create_dataset(
+                        f"{k}_train", (n_train_g,) + p.shape[1:], dtype=p.numpy().dtype
+                    )
 
             index = 0
 
@@ -202,15 +273,18 @@ def generate_dataset(
                     x = x[0] if isinstance(x, list) or isinstance(x, tuple) else x
                     x = x.to(device)
 
-                    # choose operator and generate measurement
-                    y = physics[g](x)
-
-                    # Add new data to it
+                    # calculate batch size
                     bsize = x.size()[0]
-
                     if bsize + index > n_train_g:
                         bsize = n_train_g - index
 
+                    if bsize == 0:
+                        continue
+
+                    # choose operator and generate measurement
+                    y, params = measure(x, b=bsize, g=g)
+
+                    # Add new data to it
                     hf["y_train"][index : index + bsize] = (
                         y[:bsize, :].to("cpu").numpy()
                     )
@@ -218,6 +292,11 @@ def generate_dataset(
                         hf["x_train"][index : index + bsize] = (
                             x[:bsize, ...].to("cpu").numpy()
                         )
+                    if save_physics_generator_params:
+                        for p in params.keys():
+                            hf[f"{p}_train"][index : index + bsize] = (
+                                params[p][:bsize, ...].to("cpu").numpy()
+                            )
                     index = index + bsize
 
         if test_dataset is not None:
@@ -238,21 +317,35 @@ def generate_dataset(
                 x = x[0] if isinstance(x, list) or isinstance(x, tuple) else x
                 x = x.to(device)
 
-                # choose operator
-                y = physics[g](x)
+                # Calculate batch size
+                bsize = x.size()[0]
+
+                # choose operator and generate measurement
+                y, params = measure(x, b=bsize, g=g)
 
                 if i == 0:  # create dict
                     hf.create_dataset(
-                        "x_test", (n_test_g,) + x.shape[1:], dtype="float"
+                        "x_test", (n_test_g,) + x.shape[1:], dtype=x.numpy().dtype
                     )
                     hf.create_dataset(
-                        "y_test", (n_test_g,) + y.shape[1:], dtype="float"
+                        "y_test", (n_test_g,) + y.shape[1:], dtype=y.numpy().dtype
                     )
+                    if save_physics_generator_params:
+                        for k, p in params.items():
+                            hf.create_dataset(
+                                f"{k}_test",
+                                (n_test_g,) + p.shape[1:],
+                                dtype=p.numpy().dtype,
+                            )
 
-                # Add new data to it
-                bsize = x.size()[0]
                 hf["x_test"][index : index + bsize] = x.to("cpu").numpy()
                 hf["y_test"][index : index + bsize] = y.to("cpu").numpy()
+
+                if save_physics_generator_params:
+                    for p in params.keys():
+                        hf[f"{p}_test"][index : index + bsize] = (
+                            params[p].to("cpu").numpy()
+                        )
                 index = index + bsize
         hf.close()
 

--- a/deepinv/datasets/lsdir.py
+++ b/deepinv/datasets/lsdir.py
@@ -39,6 +39,10 @@ class LsdirHR(torch.utils.data.Dataset):
                    |        -- X4
                    -- val1.tar.gz
 
+    .. warning::
+        The official site hosting the dataset is unavailable : https://data.vision.ee.ethz.ch/yawli/.
+        Thus the download argument isn't working for now.
+
     :param str root: Root directory of dataset. Directory path from where we load and save the dataset.
     :param str mode: Select a split of the dataset between 'train' or 'val'. Default at 'train'.
     :param bool download: If ``True``, downloads the dataset from the internet and puts it in root directory.
@@ -116,6 +120,10 @@ class LsdirHR(torch.utils.data.Dataset):
 
         # download a split of the dataset, we check first that this split isn't already downloaded
         if download:
+            raise ValueError(
+                f"""The official site hosting the dataset is unavailable : https://data.vision.ee.ethz.ch/yawli/.\n
+                    Thus the download argument isn't working for now."""
+            )
             if not os.path.isdir(self.root):
                 os.makedirs(self.root)
             # if a folder image exists, we stop the download

--- a/deepinv/loss/metric/perceptual.py
+++ b/deepinv/loss/metric/perceptual.py
@@ -30,12 +30,15 @@ class LPIPS(Metric):
         the data must either be of complex dtype or have size 2 in the channel dimension (usually the second dimension after batch).
     :param str reduction: a method to reduce metric score over individual batch scores. ``mean``: takes the mean, ``sum`` takes the sum, ``none`` or None no reduction will be applied (default).
     :param str norm_inputs: normalize images before passing to metric. ``l2``normalizes by L2 spatial norm, ``min_max`` normalizes by min and max of each input.
+    :param bool check_input_range: if True, ``pyiqa`` will raise error if inputs aren't in the appropriate range ``[0, 1]``.
     """
 
-    def __init__(self, device="cpu", **kwargs):
+    def __init__(self, device="cpu", check_input_range=False, **kwargs):
         super().__init__(**kwargs)
         pyiqa = import_pyiqa()
-        self.lpips = pyiqa.create_metric("lpips", check_input_range=False).to(device)
+        self.lpips = pyiqa.create_metric(
+            "lpips", check_input_range=check_input_range
+        ).to(device)
         self.lower_better = self.lpips.lower_better
 
     def metric(self, x_net, x, *args, **kwargs):
@@ -69,12 +72,15 @@ class NIQE(Metric):
         the data must either be of complex dtype or have size 2 in the channel dimension (usually the second dimension after batch).
     :param str reduction: a method to reduce metric score over individual batch scores. ``mean``: takes the mean, ``sum`` takes the sum, ``none`` or None no reduction will be applied (default).
     :param str norm_inputs: normalize images before passing to metric. ``l2``normalizes by L2 spatial norm, ``min_max`` normalizes by min and max of each input.
+    :param bool check_input_range: if True, ``pyiqa`` will raise error if inputs aren't in the appropriate range ``[0, 1]``.
     """
 
-    def __init__(self, device="cpu", **kwargs):
+    def __init__(self, device="cpu", check_input_range=False, **kwargs):
         super().__init__(**kwargs)
         pyiqa = import_pyiqa()
-        self.niqe = pyiqa.create_metric("niqe", check_input_range=False).to(device)
+        self.niqe = pyiqa.create_metric("niqe", check_input_range=check_input_range).to(
+            device
+        )
         self.lower_better = self.niqe.lower_better
 
     def metric(self, x_net, *args, **kwargs):

--- a/deepinv/loss/metric/perceptual.py
+++ b/deepinv/loss/metric/perceptual.py
@@ -21,9 +21,9 @@ class LPIPS(Metric):
     >>> ();m = LPIPS();() # doctest: +ELLIPSIS
     (...)
     >>> x = load_url_image(get_image_url("celeba_example.jpg"), img_size=128)
-    >>> x_net = x + 0.01
-    >>> m(x_net, x)
-    tensor([0.0005])
+    >>> x_net = x - 0.01
+    >>> m(x_net, x) # doctest: +ELLIPSIS
+    tensor([...])
 
     :param str device: device to use for the metric computation. Default: 'cpu'.
     :param bool complex_abs: perform complex magnitude before passing data to metric function. If ``True``,
@@ -61,8 +61,8 @@ class NIQE(Metric):
     >>> ();m = NIQE();() # doctest: +ELLIPSIS
     (...)
     >>> x_net = load_url_image(get_image_url("celeba_example.jpg"), img_size=128)
-    >>> m(x_net)
-    tensor([8.1880])
+    >>> m(x_net) # doctest: +ELLIPSIS
+    tensor([...])
 
     :param str device: device to use for the metric computation. Default: 'cpu'.
     :param bool complex_abs: perform complex magnitude before passing data to metric function. If ``True``,

--- a/deepinv/loss/metric/perceptual.py
+++ b/deepinv/loss/metric/perceptual.py
@@ -35,7 +35,7 @@ class LPIPS(Metric):
     def __init__(self, device="cpu", **kwargs):
         super().__init__(**kwargs)
         pyiqa = import_pyiqa()
-        self.lpips = pyiqa.create_metric("lpips").to(device)
+        self.lpips = pyiqa.create_metric("lpips", check_input_range=False).to(device)
         self.lower_better = self.lpips.lower_better
 
     def metric(self, x_net, x, *args, **kwargs):
@@ -74,7 +74,7 @@ class NIQE(Metric):
     def __init__(self, device="cpu", **kwargs):
         super().__init__(**kwargs)
         pyiqa = import_pyiqa()
-        self.niqe = pyiqa.create_metric("niqe").to(device)
+        self.niqe = pyiqa.create_metric("niqe", check_input_range=False).to(device)
         self.lower_better = self.niqe.lower_better
 
     def metric(self, x_net, *args, **kwargs):

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -139,6 +139,7 @@ def download_lsdir():
     shutil.rmtree(tmp_data_dir)
 
 
+@pytest.mark.skip(reason="Skipping this test for now, url links are not working")
 def test_load_lsdir_dataset(download_lsdir):
     """Check that dataset contains 250 PIL images."""
     dataset = LsdirHR(download_lsdir, mode="val", download=False)

--- a/deepinv/tests/test_loss_train.py
+++ b/deepinv/tests/test_loss_train.py
@@ -2,13 +2,19 @@ import pytest
 from pathlib import Path
 
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Dataset
 
 import deepinv as dinv
 from deepinv.optim.data_fidelity import L2
 from deepinv.optim.prior import PnP
 from deepinv.tests.dummy_datasets.datasets import DummyCircles
 from deepinv.unfolded import unfolded_builder
+from deepinv.physics import Inpainting, GaussianNoise, Blur
+from deepinv.physics.generator import (
+    BernoulliSplittingMaskGenerator,
+    SigmaGenerator,
+    DiffractionBlurGenerator,
+)
 
 
 def test_generate_dataset(tmp_path, imsize, device):
@@ -17,7 +23,7 @@ def test_generate_dataset(tmp_path, imsize, device):
     train_dataset = DummyCircles(samples=N, imsize=imsize)
     test_dataset = DummyCircles(samples=N, imsize=imsize)
 
-    physics = dinv.physics.Inpainting(mask=0.5, tensor_size=imsize, device=device)
+    physics = Inpainting(mask=0.5, tensor_size=imsize, device=device)
 
     dinv.datasets.generate_dataset(
         train_dataset,
@@ -35,6 +41,131 @@ def test_generate_dataset(tmp_path, imsize, device):
 
     x, y = dataset[0]
     assert x.shape == imsize
+
+
+@pytest.mark.parametrize(
+    "physics_combo",
+    ["single_physics_no_gen", "single_physics_with_gen", "multi_physics_no_gen"],
+)
+@pytest.mark.parametrize("bsize", [1, 4])
+@pytest.mark.parametrize(
+    "phys_gen",
+    [
+        "bernoulli_mask",
+        "sigma",
+        "diffraction",
+    ],
+)
+def test_generate_dataset_physics_generator(
+    physics_combo, tmp_path, imsize, bsize, phys_gen
+):
+    N = 10
+
+    class DummyDataset(Dataset):
+        def __getitem__(self, i):
+            return torch.ones(imsize)
+
+        def __len__(self):
+            return N
+
+    x_dataset = DummyDataset()
+
+    match physics_combo:
+        case "single_physics_no_gen":
+            physics = Inpainting(tensor_size=imsize)
+            physics_generator = None
+        case "single_physics_with_gen":
+            match phys_gen:
+                case "bernoulli_mask":
+                    physics = Inpainting(tensor_size=imsize)
+                    physics_generator = BernoulliSplittingMaskGenerator(imsize, 0.6)
+                case "sigma":
+                    physics = GaussianNoise()
+                    physics_generator = SigmaGenerator()
+                case "diffraction":
+                    physics = Blur()
+                    physics_generator = DiffractionBlurGenerator((3, 3), num_channels=3)
+        case "multi_physics_no_gen":
+            physics = [Inpainting(imsize, mask=0.1), Inpainting(imsize, mask=0.9)]
+            physics_generator = None
+
+    _ = dinv.datasets.generate_dataset(
+        x_dataset,
+        physics,
+        physics_generator=physics_generator,
+        save_physics_generator_params=True,
+        test_dataset=x_dataset,
+        save_dir=tmp_path,
+        train_datapoints=N,
+        test_datapoints=N,
+        batch_size=bsize,
+    )
+
+    train_dataset = dinv.datasets.HDF5Dataset(
+        path=f"{tmp_path}/dinv_dataset0.h5", train=True
+    )
+    test_dataset = dinv.datasets.HDF5Dataset(
+        path=f"{tmp_path}/dinv_dataset0.h5", train=False
+    )
+
+    match physics_combo:
+        case "single_physics_no_gen":
+            # test physics remains constant
+            x0, y0 = train_dataset[0]
+            x1, y1 = train_dataset[1]
+            x9, y9 = train_dataset[9]
+            assert torch.all(y0 == y1)
+            assert torch.all(y0 == y9)
+
+            x0t, y0t = test_dataset[0]
+            x1t, y1t = test_dataset[1]
+            x9t, y9t = test_dataset[9]
+            assert torch.all(y0t == y1t)
+            assert torch.all(y0t == y9t)
+        case "single_physics_with_gen":
+            # test physics random generated
+            x0, y0 = train_dataset[0]
+            x1, y1 = train_dataset[1]
+            assert not torch.all(y0 == y1)
+
+            x0t, y0t = test_dataset[0]
+            x1t, y1t = test_dataset[1]
+            assert not torch.all(y0t == y1t)
+            assert not torch.all(y0 == y0t)
+
+            # test load physics generator params
+            d = dinv.datasets.HDF5Dataset(
+                path=f"{tmp_path}/dinv_dataset0.h5",
+                train=True,
+                load_physics_generator_params=True,
+            )
+            x, y, params = d[0]
+            match phys_gen:
+                case "bernoulli_mask":
+                    assert torch.all(y == params["mask"])
+                case "sigma":
+                    assert params["sigma"].ndim == 0
+                case "diffraction":
+                    _ = params["filter"], params["coeff"], params["pupil"]
+
+        case "multi_physics_no_gen":
+            # test each dataset has different physics
+            train_dataset1 = dinv.datasets.HDF5Dataset(
+                path=f"{tmp_path}/dinv_dataset1.h5", train=True
+            )
+            x0, y0 = train_dataset[0]
+            x1, y1 = train_dataset1[0]
+            assert y0.mean() < 0.5
+            assert y1.mean() > 0.5
+            assert len(train_dataset) == len(train_dataset1) == N // 2
+
+    # test dataloader
+    b = 3
+    batch = next(iter(DataLoader(train_dataset, batch_size=b)))
+    x, y, params = (*batch, {}) if len(batch) == 2 else batch
+
+    for t in [x, y] + list(params.values()):
+        assert t.shape[0] == b
 
 
 # optim_algos = [

--- a/deepinv/tests/test_loss_train.py
+++ b/deepinv/tests/test_loss_train.py
@@ -123,12 +123,14 @@ def test_generate_dataset_physics_generator(
         # test physics random generated
         x0, y0 = train_dataset[0]
         x1, y1 = train_dataset[1]
-        assert not torch.all(y0 == y1)
 
         x0t, y0t = test_dataset[0]
         x1t, y1t = test_dataset[1]
-        assert not torch.all(y0t == y1t)
-        assert not torch.all(y0 == y0t)
+
+        if phys_gen != "diffraction":
+            assert not torch.all(y0 == y1)
+            assert not torch.all(y0t == y1t)
+            assert not torch.all(y0 == y0t)
 
         # test load physics generator params
         d = dinv.datasets.HDF5Dataset(

--- a/deepinv/transform/scale.py
+++ b/deepinv/transform/scale.py
@@ -11,12 +11,7 @@ def sample_from(values, shape=(1,), dtype=torch.float32, device="cpu", generator
     values = torch.tensor(values, device=device, dtype=dtype)
     N = torch.tensor(len(values), device=device, dtype=dtype)
     indices = (
-        torch.floor(
-            N
-            * torch.rand(
-                shape, device=generator.device, dtype=dtype, generator=generator
-            )
-        )
+        torch.floor(N * torch.rand(shape, dtype=dtype, generator=generator))
         .to(torch.long)
         .to(device)
     )
@@ -66,13 +61,11 @@ class Scale(Transform):
         # Sample a random scale factor for each batch element
         factor = sample_from(
             self.factors, shape=(b,), device=x.device, generator=self.rng
-        )
+        ).to(x.device)
 
         # Sample a random transformation center for each batch element
         # with coordinates in [-1, 1]
-        center = torch.rand(
-            (b, 2), dtype=x.dtype, device=self.rng.device, generator=self.rng
-        ).to(x.device)
+        center = torch.rand((b, 2), dtype=x.dtype, generator=self.rng).to(x.device)
 
         # Scale params override negation
         return {

--- a/deepinv/transform/scale.py
+++ b/deepinv/transform/scale.py
@@ -10,9 +10,16 @@ def sample_from(values, shape=(1,), dtype=torch.float32, device="cpu", generator
     """Sample a random tensor from a list of values"""
     values = torch.tensor(values, device=device, dtype=dtype)
     N = torch.tensor(len(values), device=device, dtype=dtype)
-    indices = torch.floor(
-        N * torch.rand(shape, device=device, dtype=dtype, generator=generator)
-    ).to(torch.long)
+    indices = (
+        torch.floor(
+            N
+            * torch.rand(
+                shape, device=generator.device, dtype=dtype, generator=generator
+            )
+        )
+        .to(torch.long)
+        .to(device)
+    )
     return values[indices]
 
 
@@ -63,7 +70,9 @@ class Scale(Transform):
 
         # Sample a random transformation center for each batch element
         # with coordinates in [-1, 1]
-        center = torch.rand((b, 2), dtype=x.dtype, device=x.device, generator=self.rng)
+        center = torch.rand(
+            (b, 2), dtype=x.dtype, device=self.rng.device, generator=self.rng
+        ).to(x.device)
 
         # Scale params override negation
         return {

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -212,6 +212,12 @@ def plot(
         img = torch.rand(4, 3, 256, 256)
         plot([img, img, img], titles=["img1", "img2", "img3"], save_dir="test.png")
 
+    .. note::
+
+        Using ``show=True`` calls ``plt.show()`` with blocking (outside notebook environments).
+        If this is undesired simply use ``fig = plot(..., show=False, return_fig=True)``
+        and plot at your desired location using ``fig.show()``.
+
     :param list[torch.Tensor], torch.Tensor img_list: list of images to plot or single image.
     :param list[str] titles: list of titles for each image, has to be same length as img_list.
     :param None, str, Path save_fn: path to save the plot as a single image (i.e. side-by-side).

--- a/docs/source/deepinv.datasets.rst
+++ b/docs/source/deepinv.datasets.rst
@@ -77,8 +77,8 @@ and save and load the physics params into the dataset:
 
     >>> physics_generator = dinv.physics.generator.SigmaGenerator()
     >>> pth = dinv.datasets.generate_dataset(train_dataset=data_train, test_dataset=data_test,
-    >>>                                physics=physics, physics_generator=physics_generator,
-                                       device=dinv.device, save_dir=save_dir)
+    >>>                                      physics=physics, physics_generator=physics_generator,
+    >>>                                      device=dinv.device, save_dir=save_dir)
     >>> dataset = dinv.datasets.HDF5Dataset(path=pth, load_physics_generator_params=True, train=True)
     >>> dataloader = DataLoader(dataset, batch_size=4, shuffle=True)
     >>> x, y, params = next(iter(dataloader))

--- a/docs/source/deepinv.datasets.rst
+++ b/docs/source/deepinv.datasets.rst
@@ -19,7 +19,11 @@ HD5Dataset
 
 
 Generating a dataset associated with a certain forward operator is done via :func:`deepinv.datasets.generate_dataset`
-using a base dataset (in this case MNIST). For example, here we generate a compressed sensing MNIST dataset:
+using a base PyTorch dataset (:class:`torch.utils.data.Dataset`, in this case MNIST). For example, here we generate a compressed sensing MNIST dataset:
+
+.. note::
+
+    We support all data types supported by ``h5py``, including complex numbers.
 
 .. doctest::
 
@@ -55,6 +59,7 @@ and ``is_valid_file`` arguments of :meth:`torchvision.datasets.ImageFolder``):
     >>> dinv.datasets.generate_dataset(train_dataset=data_train, test_dataset=data_test,
     >>>                                physics=physics, device=dinv.device, save_dir=save_dir)
 
+
 The datasets are saved in ``.h5`` (HDF5) format, and can be easily loaded to pytorch's standard
 :class:`torch.utils.data.DataLoader`:
 
@@ -64,6 +69,23 @@ The datasets are saved in ``.h5`` (HDF5) format, and can be easily loaded to pyt
     >>>
     >>> dataset = dinv.datasets.HDF5Dataset(path=generated_dataset_path, train=True)
     >>> dataloader = DataLoader(dataset, batch_size=4, shuffle=True)
+
+We can also use physics generators to randomly generate physics params for data,
+and save and load the physics params into the dataset:
+
+.. doctest::
+
+    >>> physics_generator = dinv.physics.generator.SigmaGenerator()
+    >>> pth = dinv.datasets.generate_dataset(train_dataset=data_train, test_dataset=data_test,
+    >>>                                physics=physics, physics_generator=physics_generator,
+                                       device=dinv.device, save_dir=save_dir)
+    >>> dataset = dinv.datasets.HDF5Dataset(path=pth, load_physics_generator_params=True, train=True)
+    >>> dataloader = DataLoader(dataset, batch_size=4, shuffle=True)
+    >>> x, y, params = next(iter(dataloader))
+    >>> print(params['sigma'].shape)
+    torch.Size([4])
+
+
 
 PatchDataset
 ------------

--- a/docs/source/deepinv.transform.rst
+++ b/docs/source/deepinv.transform.rst
@@ -17,6 +17,7 @@ They can also be used for equivariant imaging (EI) using the :class:`deepinv.los
 See :ref:`sphx_glr_auto_examples_self-supervised-learning_demo_ei_transforms.py` and :ref:`sphx_glr_auto_examples_self-supervised-learning_demo_equivariant_imaging.py` for examples.
 
 If needed, transforms can also be made deterministic by passing in specified parameters to the forward method.
+This allows every transform to have its own deterministic inverse using ``transform.inverse()``.
 Transforms can also be seamlessly integrated with existing ``torchvision`` transforms.
 Transforms can also accept video (5D) input.
 

--- a/examples/adversarial-learning/demo_gan_imaging.py
+++ b/examples/adversarial-learning/demo_gan_imaging.py
@@ -163,10 +163,21 @@ loss_d = adversarial.SupAdversarialDiscriminatorLoss(device=device)
 
 
 # %%
-# We are now ready to train the networks using :meth:`deepinv.training.AdversarialTrainer`. We only train for 2
-# epochs for speed, but below we also show results with a pretrained model
-# trained in the exact same way after 50 epochs.
+# We are now ready to train the networks using :meth:`deepinv.training.AdversarialTrainer`.
+# We load the pretrained models that were trained in the exact same way after 50 epochs,
+# and fine-tune the model for 1 epoch for a quick demo.
+# You can find the pretrained models on HuggingFace https://huggingface.co/deepinv/adversarial-demo.
+# To train from scratch, simply comment out the model loading code and increase the number of epochs.
 #
+
+ckpt = torch.hub.load_state_dict_from_url(
+    dinv.models.utils.get_weights_url("adversarial-demo", "deblurgan_model.pth"),
+    map_location=lambda s, _: s,
+)
+
+G.load_state_dict(ckpt["state_dict"])
+D.load_state_dict(ckpt["state_dict_D"])
+optimizer.load_state_dict(ckpt["optimizer"])
 
 trainer = dinv.training.AdversarialTrainer(
     model=G,
@@ -174,7 +185,7 @@ trainer = dinv.training.AdversarialTrainer(
     physics=physics,
     train_dataloader=train_dataloader,
     eval_dataloader=test_dataloader,
-    epochs=2,
+    epochs=1,
     losses=loss_g,
     losses_d=loss_d,
     optimizer=optimizer,
@@ -187,21 +198,12 @@ trainer = dinv.training.AdversarialTrainer(
 
 G = trainer.train()
 
-
 # %%
-# Show pretrained model results:
+# Test the trained model and plot the results. We compare to the pseudo-inverse as a baseline.
 #
 
-ckpt = torch.hub.load_state_dict_from_url(
-    dinv.models.utils.get_weights_url("deblurgan-demo", "deblurgan_model.pth"),
-    map_location=lambda s, _: s,
-)
-
-G.load_state_dict(ckpt["state_dict"])
-
-x, _ = next(iter(test_dataloader))
-y = physics(x, **blur_generator.step())
-dinv.utils.plot([x, y, G(y)], titles=["GT", "Measurement", "Reconstruction"])
+trainer.plot_images = True
+trainer.test(test_dataloader)
 
 
 # %%
@@ -234,7 +236,18 @@ loss_d = adversarial.UnsupAdversarialDiscriminatorLoss(device=device)
 
 # %%
 # We are now ready to train the networks using :meth:`deepinv.training.AdversarialTrainer`.
+# Like above, we load a pretrained model trained in the exact same way for 50 epochs,
+# and fine-tune here for a quick demo with 1 epoch.
 #
+
+ckpt = torch.hub.load_state_dict_from_url(
+    dinv.models.utils.get_weights_url("adversarial-demo", "uair_model.pth"),
+    map_location=lambda s, _: s,
+)
+
+G.load_state_dict(ckpt["state_dict"])
+D.load_state_dict(ckpt["state_dict_D"])
+optimizer.load_state_dict(ckpt["optimizer"])
 
 trainer = dinv.training.AdversarialTrainer(
     model=G,
@@ -242,7 +255,7 @@ trainer = dinv.training.AdversarialTrainer(
     physics=physics,
     train_dataloader=train_dataloader,
     eval_dataloader=test_dataloader,
-    epochs=2,
+    epochs=1,
     losses=loss_g,
     losses_d=loss_d,
     optimizer=optimizer,
@@ -253,6 +266,13 @@ trainer = dinv.training.AdversarialTrainer(
     device=device,
 )
 G = trainer.train()
+
+# %%
+# Test the trained model and plot the results:
+#
+
+trainer.plot_images = True
+trainer.test(test_dataloader)
 
 
 # %%
@@ -310,14 +330,25 @@ loss_d = adversarial.SupAdversarialDiscriminatorLoss(device=device)
 # slow for CSGM/AmbientGAN as it requires an optimisation, we only do one
 # evaluation at the end. Note the train PSNR is meaningless as this
 # generative model is trained on random latents.
+# Like above, we load a pretrained model trained in the exact same way for 50 epochs,
+# and fine-tune here for a quick demo with 1 epoch.
 #
+
+ckpt = torch.hub.load_state_dict_from_url(
+    dinv.models.utils.get_weights_url("adversarial-demo", "csgm_model.pth"),
+    map_location=lambda s, _: s,
+)
+
+G.load_state_dict(ckpt["state_dict"])
+D.load_state_dict(ckpt["state_dict_D"])
+optimizer.load_state_dict(ckpt["optimizer"])
 
 trainer = dinv.training.AdversarialTrainer(
     model=G,
     D=D,
     physics=physics,
     train_dataloader=train_dataloader,
-    epochs=2,
+    epochs=1,
     losses=loss_g,
     losses_d=loss_d,
     optimizer=optimizer,
@@ -334,7 +365,8 @@ G = trainer.train()
 # Eventually, we run evaluation of the generative model by running test-time optimisation
 # using test measurements. Note that we do not get great results as CSGM /
 # AmbientGAN relies on large datasets of diverse samples, and we run the
-# optimisation to a relatively high tolerance for speed.
+# optimisation to a relatively high tolerance for speed. Improve the results by
+# running the optimisation for longer.
 #
 
 trainer.test(test_dataloader)

--- a/examples/basics/demo_transforms.py
+++ b/examples/basics/demo_transforms.py
@@ -29,6 +29,7 @@ transforms are customisable and offer some group-theoretic properties.
 
 We demonstrate a random roto-scale combined with a random masking, and a
 constrained pixel-shift with a random colour jitter.
+Note that all our transforms can easily be inverted using the method ``transform.inverse()``.
 
 First, load a sample image.
 


### PR DESCRIPTION
Fixes #319: fix error where generate dataset not stepping physics generator params

Closes #201:  now generate dataset can save and load physics generator params for better reproducibility. (+ lots of tests)

Fixes #323 

re-train adversarial training example as it was affected by #319

Add small explanation to `plot` to close #318

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
