### PR TITLE
Metric wraps callables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ New Features
 - Add loss schedulers (:gh:`296` by `Andrew Wang`_)
 - Add transform symmetrisation, further transform arithmetic, and new equivariant denoiser (:gh:`259` by `Andrew Wang`_)
 - New transforms: multi-axis reflect, time-shift and diffeomorphism (:gh:`259` by `Andrew Wang`_)
-- Add Metric baseclass, unified params (for complex, norm, reduce), typing, tests, L1L2 metric, QNR metric, and metrics docs section (:gh:`309` by `Andrew Wang`_)
+- Add Metric baseclass, unified params (for complex, norm, reduce), typing, tests, L1L2 metric, QNR metric, metrics docs section, Metric functional wrapper (:gh:`309`, :gh:`343` by `Andrew Wang`_)
 - generate_dataset features: complex numbers, save/load physics_generator params (:gh:`324` by `Andrew Wang`_)
 
 Fixed

--- a/docs/source/deepinv.metric.rst
+++ b/docs/source/deepinv.metric.rst
@@ -43,6 +43,8 @@ and you can use these in a loss like ``SupLoss(metric=MSE())``.
 
     For convenience, you can also import metrics directly from ``deepinv.metric`` or ``deepinv.loss``.
 
+Finally, you can also wrap existing metric functions using ``Metric(metric=f)``, see :class:`deepinv.loss.metric.Metric` for an example.
+
 Example:
 
 .. doctest::


### PR DESCRIPTION
Metric baseclass can be used directly to wrap your favourite metric functions e.g. from torchmetrics, monai etc. etc.

E.g. 

```python
def f(a, b):
    return a - b

m = Metric(metric=f)
```

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
