### PR TITLE
Solve non-backward compatible changed in data-fidelity

### DIFF
--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -54,6 +54,15 @@ class DataFidelity(Potential):
         """
         return physics.A_vjp(x, self.d.grad(physics.A(x), y, *args, **kwargs))
 
+    def grad_d(self, x, y, *args, **kwargs):
+        return self.d.grad(x, y, *args, **kwargs)
+
+    def prox_d(self, x, y, *args, **kwargs):
+        return self.d.prox(x, y, *args, **kwargs)
+
+    def prox_d_conjugate(self, x, y, *args, **kwargs):
+        return self.d.prox_conjugate(x, y, *args, **kwargs)
+
 
 class L2(DataFidelity):
     r"""

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -54,14 +54,36 @@ class DataFidelity(Potential):
         """
         return physics.A_vjp(x, self.d.grad(physics.A(x), y, *args, **kwargs))
 
-    def grad_d(self, x, y, *args, **kwargs):
-        return self.d.grad(x, y, *args, **kwargs)
+    def grad_d(self, u, y, *args, **kwargs):
+        r"""
+        Computes the gradient :math:`\nabla_u\distance{u}{y}`, computed in :math:`u`. Note that this is the gradient of
+        :math:`\distancename` and not :math:`\datafidname`. This function direclty calls :meth:`deepinv.optim.Distance.grad` for the
+        speficic distance function :math:`\distance`.
+        :param torch.Tensor u: Variable :math:`u` at which the gradient is computed.
+        :param torch.Tensor y: Data :math:`y` of the same dimension as :math:`u`.
+        :return: (torch.Tensor) gradient of :math:`d` in :math:`u`, i.e. :math:`\nabla_u\distance{u}{y}`.
+        """
+        return self.d.grad(u, y, *args, **kwargs)
 
-    def prox_d(self, x, y, *args, **kwargs):
-        return self.d.prox(x, y, *args, **kwargs)
+    def prox_d(self, u, y, *args, **kwargs):
+        r"""
+        Computes the proximity operator :math:`\operatorname{prox}_{\gamma\distance{\cdot}{y}}(u)`, computed in :math:`u`. Note
+        that this is the proximity operator of :math:`\distancename` and not :math:`\datafidname`.
+        This function direclty calls :meth:`deepinv.optim.Distance.prox` for the
+        speficic distance function :math:`\distance`.
+        :param torch.Tensor u: Variable :math:`u` at which the gradient is computed.
+        :param torch.Tensor y: Data :math:`y` of the same dimension as :math:`u`.
+        :return: (torch.Tensor) gradient of :math:`d` in :math:`u`, i.e. :math:`\nabla_u\distance{u}{y}`.
+        """
+        return self.d.prox(u, y, *args, **kwargs)
 
-    def prox_d_conjugate(self, x, y, *args, **kwargs):
-        return self.d.prox_conjugate(x, y, *args, **kwargs)
+    def prox_d_conjugate(self, u, y, *args, **kwargs):
+        r"""
+        Computes the proximity operator of the convex conjugate of the distance function :math:`\distance{u}{y}`.
+        This function direclty calls :meth:`deepinv.optim.Distance.prox_conjugate` for the
+        speficic distance function :math:`\distance`.
+        """
+        return self.d.prox_conjugate(u, y, *args, **kwargs)
 
 
 class L2(DataFidelity):

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -44,6 +44,9 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         tensor_size: Tuple[int],
         split_ratio: float,
         pixelwise: bool = True,
+        random_split_ratio: bool = False,
+        min_split_ratio: float = 0.0,
+        max_split_ratio: float = 1.0,
         device: torch.device = torch.device("cpu"),
         dtype: torch.dtype = torch.float32,
         rng: torch.Generator = None,
@@ -54,6 +57,9 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         self.tensor_size = tensor_size
         self.split_ratio = split_ratio
         self.pixelwise = pixelwise
+        self.random_split_ratio = random_split_ratio
+        self.min_split_ratio = min_split_ratio
+        self.max_split_ratio = max_split_ratio
 
     def step(
         self, batch_size=1, input_mask: torch.Tensor = None, seed: int = None, **kwargs
@@ -144,6 +150,13 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         :param torch.Tensor, None input_mask: optional mask to be split. If ``None``, all pixels are considered. If not ``None``, only pixels where ``mask==1`` are considered. Batch dimension should not be included in shape.
         """
         pixelwise = self.check_pixelwise(input_mask)
+
+        if self.random_split_ratio:
+            self.split_ratio = (
+                torch.rand(batch_size, generator=self.rng, **self.factory_kwargs)
+                * (self.sigma_max - self.sigma_min)
+                + self.sigma_min
+            )
 
         if isinstance(input_mask, torch.Tensor) and input_mask.numel() > 1:
             input_mask = input_mask.to(self.device)

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -99,6 +99,19 @@ def test_data_fidelity_l2(device):
 
     assert torch.allclose(torch_loss_prox, manual_prox)
 
+    # 7. Testing that d.prox / d.grad and prox_d / grad_d are consistent
+    assert torch.allclose(
+        data_fidelity.d.prox(x, y, gamma=1.0),
+        data_fidelity.prox_d(x, y, physics, gamma=1.0),
+    )
+    assert torch.allclose(
+        data_fidelity.d.grad(x, y),
+        data_fidelity.grad_d(
+            x,
+            y,
+        ),
+    )
+
 
 def test_data_fidelity_indicator(device):
     # Define two points
@@ -144,6 +157,12 @@ def test_data_fidelity_indicator(device):
     assert torch.allclose(x_proj, dfb_proj, atol=1e-4)
     assert torch.norm(A_forward(dfb_proj) - y) <= radius + 1e-06
 
+    # 4. Testing that d.prox / d.grad and prox_d / grad_d are consistent
+    assert torch.allclose(
+        data_fidelity.d.prox(x, y, gamma=1.0),
+        data_fidelity.prox_d(x, y, physics, gamma=1.0),
+    )
+
 
 def test_data_fidelity_l1(device):
     # Define two points
@@ -170,6 +189,19 @@ def test_data_fidelity_l1(device):
     threshold = 0.5
     prox_manual = torch.Tensor([[[1.0], [3.5], [0.0]]]).to(device)
     assert torch.allclose(data_fidelity.d.prox(x, y, gamma=threshold), prox_manual)
+
+    # Testing that d.prox / d.grad and prox_d / grad_d are consistent
+    assert torch.allclose(
+        data_fidelity.d.prox(x, y, gamma=1.0),
+        data_fidelity.prox_d(x, y, physics, gamma=1.0),
+    )
+    assert torch.allclose(
+        data_fidelity.d.grad(x, y),
+        data_fidelity.grad_d(
+            x,
+            y,
+        ),
+    )
 
 
 def test_zero_prior():


### PR DESCRIPTION
Add the grad_d, prox_d and prox_d_conjugate function removed with the last reformat of the DataFidelity class? 


### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
