### PR TITLE
API make the device argument more consistent for denoisers

### DIFF
--- a/deepinv/models/base.py
+++ b/deepinv/models/base.py
@@ -19,10 +19,6 @@ class Denoiser(torch.nn.Module):
 
     """
 
-    def __init__(self, device="cpu"):
-        super().__init__()
-        self.to(device)
-
     def forward(self, x, sigma, **kwargs):
         r"""
         Applies denoiser :math:`\denoiser{x}{\sigma}`.
@@ -46,10 +42,6 @@ class Reconstructor(torch.nn.Module):
     The base class inherits from :class:`torch.nn.Module`.
 
     """
-
-    def __init__(self, device="cpu"):
-        super().__init__()
-        self.to(device)
 
     def forward(self, y, physics, **kwargs):
         r"""

--- a/deepinv/models/diffunet.py
+++ b/deepinv/models/diffunet.py
@@ -45,6 +45,7 @@ class DiffUNet(Denoiser):
         (only available for 3 input and output channels).
         Finally, ``pretrained`` can also be set as a path to the user's own pretrained weights.
         See :ref:`pretrained-weights <pretrained-weights>` for more details.
+    :param NoneType, torch.device device: Instruct our module to be either on cpu or on gpu. Default to ``None``, which suggests working on cpu.
     """
 
     def __init__(
@@ -54,6 +55,7 @@ class DiffUNet(Denoiser):
         large_model=False,
         use_fp16=False,
         pretrained="download",
+        device=None,
     ):
         super().__init__()
 
@@ -273,6 +275,9 @@ class DiffUNet(Denoiser):
 
             self.load_state_dict(ckpt, strict=True)
             self.eval()
+
+        if device is not None:
+            self.to(device)
 
     def convert_to_fp16(self):
         """

--- a/deepinv/models/dncnn.py
+++ b/deepinv/models/dncnn.py
@@ -28,7 +28,7 @@ class DnCNN(Denoiser):
         using ``pretrained='download_lipschitz'``.
         Finally, ``pretrained`` can also be set as a path to the user's own pretrained weights.
         See :ref:`pretrained-weights <pretrained-weights>` for more details.
-    :param str device: gpu or cpu.
+    :param NoneType, torch.device device: Instruct our module to be either on cpu or on gpu. Default to ``None``, which suggests working on cpu.
     """
 
     def __init__(

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -36,8 +36,7 @@ class DRUNet(Denoiser):
         online repository (only available for the default architecture with 3 or 1 input/output channels).
         Finally, ``pretrained`` can also be set as a path to the user's own pretrained weights.
         See :ref:`pretrained-weights <pretrained-weights>` for more details.
-    :param str device: gpu or cpu.
-
+    :param NoneType, torch.device device: Instruct our module to be either on cpu or on gpu. Default to ``None``, which suggests working on cpu.
     """
 
     def __init__(
@@ -52,7 +51,7 @@ class DRUNet(Denoiser):
         pretrained="download",
         device=None,
     ):
-        super(DRUNet, self).__init__()
+        super().__init__()
         in_channels = in_channels + 1  # accounts for the input noise channel
         self.m_head = conv(in_channels, nc[0], bias=False, mode="C")
 
@@ -65,26 +64,26 @@ class DRUNet(Denoiser):
             downsample_block = downsample_strideconv
         else:
             raise NotImplementedError(
-                "downsample mode [{:s}] is not found".format(downsample_mode)
+                f"downsample mode [{downsample_mode}] is not found"
             )
 
         self.m_down1 = sequential(
             *[
-                ResBlock(nc[0], nc[0], bias=False, mode="C" + act_mode + "C")
+                ResBlock(nc[0], nc[0], bias=False, mode=f"C{act_mode}C")
                 for _ in range(nb)
             ],
             downsample_block(nc[0], nc[1], bias=False, mode="2"),
         )
         self.m_down2 = sequential(
             *[
-                ResBlock(nc[1], nc[1], bias=False, mode="C" + act_mode + "C")
+                ResBlock(nc[1], nc[1], bias=False, mode=f"C{act_mode}C")
                 for _ in range(nb)
             ],
             downsample_block(nc[1], nc[2], bias=False, mode="2"),
         )
         self.m_down3 = sequential(
             *[
-                ResBlock(nc[2], nc[2], bias=False, mode="C" + act_mode + "C")
+                ResBlock(nc[2], nc[2], bias=False, mode=f"C{act_mode}C")
                 for _ in range(nb)
             ],
             downsample_block(nc[2], nc[3], bias=False, mode="2"),
@@ -92,7 +91,7 @@ class DRUNet(Denoiser):
 
         self.m_body = sequential(
             *[
-                ResBlock(nc[3], nc[3], bias=False, mode="C" + act_mode + "C")
+                ResBlock(nc[3], nc[3], bias=False, mode=f"C{act_mode}C")
                 for _ in range(nb)
             ]
         )
@@ -112,21 +111,21 @@ class DRUNet(Denoiser):
         self.m_up3 = sequential(
             upsample_block(nc[3], nc[2], bias=False, mode="2"),
             *[
-                ResBlock(nc[2], nc[2], bias=False, mode="C" + act_mode + "C")
+                ResBlock(nc[2], nc[2], bias=False, mode=f"C{act_mode}C")
                 for _ in range(nb)
             ],
         )
         self.m_up2 = sequential(
             upsample_block(nc[2], nc[1], bias=False, mode="2"),
             *[
-                ResBlock(nc[1], nc[1], bias=False, mode="C" + act_mode + "C")
+                ResBlock(nc[1], nc[1], bias=False, mode=f"C{act_mode}C")
                 for _ in range(nb)
             ],
         )
         self.m_up1 = sequential(
             upsample_block(nc[1], nc[0], bias=False, mode="2"),
             *[
-                ResBlock(nc[0], nc[0], bias=False, mode="C" + act_mode + "C")
+                ResBlock(nc[0], nc[0], bias=False, mode=f"C{act_mode}C")
                 for _ in range(nb)
             ],
         )

--- a/deepinv/models/epll.py
+++ b/deepinv/models/epll.py
@@ -25,7 +25,7 @@ class EPLLDenoiser(Denoiser):
         See :ref:`pretrained-weights <pretrained-weights>` for more details.
     :param int patch_size: patch size.
     :param int channels: number of color channels (e.g. 1 for gray-valued images and 3 for RGB images)
-    :param str device: defines device (``cpu`` or ``cuda``)
+    :param NoneType, torch.device device: Instruct our module to be either on cpu or on gpu. Default to ``None``, which suggests working on cpu.
     """
 
     def __init__(
@@ -35,13 +35,14 @@ class EPLLDenoiser(Denoiser):
         pretrained="download",
         patch_size=6,
         channels=1,
-        device="cpu",
+        device=None,
     ):
-        super(EPLLDenoiser, self).__init__()
-        self.PatchGMM = EPLL(
-            GMM, n_components, pretrained, patch_size, channels, device
-        )
+        super().__init__()
+        self.PatchGMM = EPLL(GMM, n_components, pretrained, patch_size, channels)
         self.denoising_operator = Denoising(GaussianNoise(0))
+
+        if device is not None:
+            self.to(device)
 
     def forward(self, x, sigma, betas=None, batch_size=-1):
         r"""

--- a/deepinv/models/restormer.py
+++ b/deepinv/models/restormer.py
@@ -51,11 +51,10 @@ class Restormer(Denoiser):
     :param str LayerNorm_type: Add bias or not in each of the LayerNorm inside of the ``TransformerBlock``.
         ``LayerNorm_type = 'BiasFree' / 'WithBias'``.
     :param bool dual_pixel_task: Should be true if dual-pixel defocus deblurring is enabled, false for single-pixel deblurring and other tasks.
-    :param NoneType, torch.device device: Instruct our module to be either on cpu or on gpu. Default to ``None``, which suggests working on cpu.
     :param NoneType, str pretrained: Default to ``'denoising'``.
         ``if pretrained = 'denoising' / 'denoising_gray' / 'denoising_color' / 'denoising_real' / 'deraining' / 'defocus_deblurring'``, will download weights from the HuggingFace Hub.
         ``if pretrained = '\*.pth'``, will load weights from a local pth file.
-    :param bool train: training or testing mode.
+    :param NoneType, torch.device device: Instruct our module to be either on cpu or on gpu. Default to ``None``, which suggests working on cpu.
 
     .. note::
         To obtain good performance on a broad range of noise levels, even with limited noise levels during training, it is recommended to remove all additive constants by setting :

--- a/deepinv/models/scunet.py
+++ b/deepinv/models/scunet.py
@@ -23,7 +23,7 @@ class WMSA(nn.Module):
             raise ImportError(
                 "timm is needed to use the SCUNet class. Please install it with `pip install timm`"
             ) from timm
-        super(WMSA, self).__init__()
+        super().__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.head_dim = head_dim
@@ -173,7 +173,7 @@ class Block(nn.Module):
         input_resolution=None,
     ):
         """SwinTransformer Block"""
-        super(Block, self).__init__()
+        super().__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         assert type in ["W", "SW"]
@@ -289,8 +289,7 @@ class SCUNet(Denoiser):
         Finally, ``pretrained`` can also be set as a path to the user's own pretrained weights. Default: 'download'.
         See :ref:`pretrained-weights <pretrained-weights>` for more details.
     :param bool train: training or testing mode. Default: False.
-    :param str device: gpu or cpu. Default: 'cpu'.
-
+    :param NoneType, torch.device device: Instruct our module to be either on cpu or on gpu. Default to ``None``, which suggests working on cpu.
     """
 
     def __init__(
@@ -301,9 +300,9 @@ class SCUNet(Denoiser):
         drop_path_rate=0.0,
         input_resolution=256,
         pretrained="download",
-        device="cpu",
+        device=None,
     ):
-        super(SCUNet, self).__init__()
+        super().__init__()
         self.config = config
         self.dim = dim
         self.head_dim = 32

--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -122,9 +122,9 @@ class WaveletDenoiser(Denoiser):
         :param float, torch.Tensor ths: threshold.
         """
         return torch.maximum(
-            torch.tensor([0], device=x.device).type(x.dtype), x - abs(ths)
+            torch.tensor([0], device=x.device, dtype=x.dtype), x - abs(ths)
         ) + torch.minimum(
-            torch.tensor([0], device=x.device).type(x.dtype), x + abs(ths)
+            torch.tensor([0], device=x.device, dtype=x.dtype), x + abs(ths)
         )
 
     def prox_l0(self, x, ths=0.1):


### PR DESCRIPTION
This PR intends to make the `device` argument of the `Denoiser` more consistent.
If you are okay with the idea that all denoisers should take in the `device` argument, we can also add some unit tests to make sure this is the case.

Fixes #381 