### PR TITLE
Trainer log train batch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ New Features
 - Add SimpleFastMRISliceDataset, simplify FastMRISliceDataset, add FastMRI tests (:gh:`363` by `Andrew Wang`_)
 - FastMRI now compatible with MRI and MultiCoilMRI physics (:gh:`363` by `Andrew Wang`_)
 - Add VarNet/E2E-VarNet model and generalise ArtifactRemoval (:gh:`363` by `Andrew Wang`_)
-
+- Trainer now can log train progress per batch or per epoch (:gh:`387` by `Andrew Wang`_)
 
 Fixed
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ New Features
 - Add SimpleFastMRISliceDataset, simplify FastMRISliceDataset, add FastMRI tests (:gh:`363` by `Andrew Wang`_)
 - FastMRI now compatible with MRI and MultiCoilMRI physics (:gh:`363` by `Andrew Wang`_)
 - Add VarNet/E2E-VarNet model and generalise ArtifactRemoval (:gh:`363` by `Andrew Wang`_)
-- Trainer now can log train progress per batch or per epoch (:gh:`387` by `Andrew Wang`_)
+- Trainer now can log train progress per batch or per epoch (:gh:`388` by `Andrew Wang`_)
 
 Fixed
 ^^^^^
@@ -35,6 +35,7 @@ Changed
 - Added single backquotes default to code mode in docs (:gh:`379` by `Julian Tachella`_)
 - Changed the __add__ method for stack method for stacking physics (:gh:`371` by `Julian Tachella`_ and `Andrew Wang`_)
 - Changed the R2R loss to handle multiple noise distributions (:gh:`380` by `Brayan Monroy`_)
+- Deprecate Trainer freq_plot in favour of plot_interval (:gh:`388` by `Andrew Wang`_)
 
 v0.2.2
 ----------------

--- a/deepinv/tests/test_loss.py
+++ b/deepinv/tests/test_loss.py
@@ -10,7 +10,8 @@ import deepinv as dinv
 from deepinv.loss.regularisers import JacobianSpectralNorm, FNEJacobianSpectralNorm
 from deepinv.loss.scheduler import RandomLossScheduler, InterleavedLossScheduler
 
-LOSSES = ["sup", "mcei", "mcei-scale", "mcei-homography", "r2r"]
+LOSSES = ["sup", "sup_log_train_batch", "mcei", "mcei-scale", "mcei-homography", "r2r"]
+
 LIST_SURE = [
     "Gaussian",
     "Poisson",
@@ -68,7 +69,7 @@ def choose_loss(loss_name, rng=None):
         loss.append(dinv.loss.TVLoss())
     elif loss_name == "score":
         loss.append(dinv.loss.ScoreLoss(dinv.physics.GaussianNoise(0.1), 100))
-    elif loss_name == "sup":
+    elif loss_name in ("sup", "sup_log_train_batch"):
         loss.append(dinv.loss.SupLoss())
     elif loss_name == "r2r":
         loss.append(dinv.loss.R2RLoss())
@@ -252,6 +253,7 @@ def test_losses(loss_name, tmp_path, dataset, physics, imsize, device, rng):
     trainer = dinv.Trainer(
         model=model,
         train_dataloader=dataloader,
+        eval_dataloader=test_dataloader,
         epochs=epochs,
         scheduler=scheduler,
         losses=loss,
@@ -262,6 +264,7 @@ def test_losses(loss_name, tmp_path, dataset, physics, imsize, device, rng):
         save_path=save_dir / "dinv_test",
         plot_images=False,
         verbose=False,
+        log_train_batch=(loss_name == "sup_log_train_batch"),
     )
 
     # test the untrained model


### PR DESCRIPTION
Add new option `log_train_batch` to `Trainer`:

If ``True``, log train batch and eval-set metrics and losses for each train batch during training. This is useful for visualising train progress inside an epoch, not just over epochs.  If ``False`` (default), log average over dataset per epoch (standard training).

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
