### PR TITLE
Patch prior bugs

### DIFF
--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -322,7 +322,7 @@ class GaussianMixtureModel(nn.Module):
                 dataloader, verbose
             )
             # stopping criterion
-            self.set_weights = weights_new
+            self.set_weights(weights_new)
             self.mu.data = mu_new
             cov_new_reg = cov_new + cov_regularization * torch.eye(self.dimension)[
                 None, :, :

--- a/examples/patch-priors/demo_patch_priors_CT.py
+++ b/examples/patch-priors/demo_patch_priors_CT.py
@@ -104,7 +104,7 @@ epll_batch_size = 10000
 #            :math:`P_Z`, data distribution :math:`P_X` and push-forward measure :math:`{\mathcal{T}_\theta}_\#P_Z`.
 
 
-retrain = False
+retrain = True
 if retrain:
     model_patchnr = PatchNR(
         pretrained=None,
@@ -120,7 +120,7 @@ if retrain:
     )
 
     class NFTrainer(Trainer):
-        def compute_loss(self, physics, x, y, train=True):
+        def compute_loss(self, physics, x, y, train=True, epoch=None):
             logs = {}
 
             self.optimizer.zero_grad()  # Zero the gradients

--- a/examples/patch-priors/demo_patch_priors_CT.py
+++ b/examples/patch-priors/demo_patch_priors_CT.py
@@ -104,7 +104,7 @@ epll_batch_size = 10000
 #            :math:`P_Z`, data distribution :math:`P_X` and push-forward measure :math:`{\mathcal{T}_\theta}_\#P_Z`.
 
 
-retrain = True
+retrain = False
 if retrain:
     model_patchnr = PatchNR(
         pretrained=None,


### PR DESCRIPTION
Fixes two bugs for the patch priors, which we recently found:
- In the EM algorithm for fitting the GMM the weight update was broken (so it used just equally weighted modes)
- In the patch prior CT demo, the `compute_loss` function is missing an argument such that setting `retrain=True ` in the demo was leading to an error (I think this happened since the trainer class changed over time).

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
