### PR TITLE
Tiny fix: import adversarial in loss + remove set14 tests

### DIFF
--- a/deepinv/datasets/set14.py
+++ b/deepinv/datasets/set14.py
@@ -41,17 +41,17 @@ class Set14HR(torch.utils.data.Dataset):
 
     :Examples:
 
-        Instantiate dataset and download raw data from the Internet
+        Instantiate dataset and download raw data from the Internet ::
 
-        >>> import shutil
-        >>> from deepinv.datasets import Set14HR
-        >>> dataset = Set14HR(root="Set14", download=True)  # download raw data at root and load dataset
-        Dataset has been successfully downloaded.
-        >>> print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
-        True
-        >>> print(len(dataset))                                  # check that we have 14 images
-        14
-        >>> shutil.rmtree("Set14")                          # remove raw data from disk
+            import shutil
+            from deepinv.datasets import Set14HR
+            dataset = Set14HR(root="Set14", download=True)  # download raw data at root and load dataset
+            Dataset has been successfully downloaded.
+            print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
+            True
+            print(len(dataset))                                  # check that we have 14 images
+            14
+            shutil.rmtree("Set14")                          # remove raw data from disk
 
     """
 

--- a/deepinv/loss/__init__.py
+++ b/deepinv/loss/__init__.py
@@ -23,6 +23,7 @@ from .scheduler import (
 )
 
 from . import metric
+from . import adversarial
 
 from .metric import (
     Metric,

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -91,6 +91,7 @@ def download_set14():
     shutil.rmtree(tmp_data_dir)
 
 
+@pytest.mark.skip(reason="Set14 dataset download is temporarily unavailable.")
 def test_load_set14_dataset(download_set14):
     """Check that dataset contains 14 PIL images."""
     dataset = Set14HR(download_set14, download=False)


### PR DESCRIPTION
Import adversarial in loss to be able to directly import `deepinv.loss.adversarial...`

Also remove set14 test


### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
