### PR TITLE
Add grayscale GSPnP weights

### DIFF
--- a/deepinv/models/GSPnP.py
+++ b/deepinv/models/GSPnP.py
@@ -114,9 +114,7 @@ def GSDRUNet(
                 file_name = "GSDRUNet_torch.ckpt"
             elif in_channels == 1:
                 file_name = "GSDRUNet_grayscale_torch.ckpt"
-            url = get_weights_url(
-                model_name="gradientstep", file_name=file_name
-            )
+            url = get_weights_url(model_name="gradientstep", file_name=file_name)
             ckpt = torch.hub.load_state_dict_from_url(
                 url,
                 map_location=lambda storage, loc: storage,

--- a/deepinv/models/GSPnP.py
+++ b/deepinv/models/GSPnP.py
@@ -90,7 +90,7 @@ def GSDRUNet(
         shuffling, and "upconv" for nearest neighbour upsampling with additional convolution.
     :param bool download: use a pretrained network. If ``pretrained=None``, the weights will be initialized at random
         using Pytorch's default initialization. If ``pretrained='download'``, the weights will be downloaded from an
-        online repository (only available for the default architecture).
+        online repository (only available for the default architecture with 3 or 1 input/output channels).
         Finally, ``pretrained`` can also be set as a path to the user's own pretrained weights.
         See :ref:`pretrained-weights <pretrained-weights>` for more details.
     :param str device: gpu or cpu.
@@ -110,13 +110,17 @@ def GSDRUNet(
     GSmodel = GSPnP(denoiser, alpha=alpha)
     if pretrained:
         if pretrained == "download":
+            if in_channels == 3:
+                file_name = "GSDRUNet_torch.ckpt"
+            elif in_channels == 1:
+                file_name = "GSDRUNet_grayscale_torch.ckpt"
             url = get_weights_url(
-                model_name="gradientstep", file_name="GSDRUNet_torch.ckpt"
+                model_name="gradientstep", file_name=file_name
             )
             ckpt = torch.hub.load_state_dict_from_url(
                 url,
                 map_location=lambda storage, loc: storage,
-                file_name="GSDRUNet_torch.ckpt",
+                file_name=file_name,
             )
         else:
             ckpt = torch.load(pretrained, map_location=lambda storage, loc: storage)

--- a/docs/source/user_guide/reconstruction/weights.rst
+++ b/docs/source/user_guide/reconstruction/weights.rst
@@ -28,7 +28,7 @@ associated reference and relevant details. All pretrained weights are hosted on
        trained on noise levels in [0, 50]/255. `DRUNet original grayscale weights <https://huggingface.co/deepinv/drunet/resolve/main/drunet_gray.pth?download=true>`_, `DRUNET original color weights <https://huggingface.co/deepinv/drunet/resolve/main/drunet_color.pth?download=true>`_.
    * - :class:`deepinv.models.GSDRUNet`
      - weights from `Gradient-Step PnP <https://github.com/samuro95/GSPnP>`_, trained on noise levels in [0, 50]/255.
-       `GSDRUNet color weights <https://huggingface.co/deepinv/gradientstep/blob/main/GSDRUNet.ckpt>`_.
+       `GSDRUNet color weights <https://huggingface.co/deepinv/gradientstep/blob/main/GSDRUNet.ckpt>` and `GSDRUNet grayscale weights <https://huggingface.co/deepinv/gradientstep/blob/main/GSDRUNet_grayscale_torch.ckpt>`.
    * - :class:`deepinv.models.SCUNet`
      - from `SCUNet <https://github.com/cszn/SCUNet>`_,
        trained on images degraded with synthetic realistic noise and camera artefacts. `SCUNet color weights <https://huggingface.co/deepinv/scunet/resolve/main/scunet_color_real_psnr.pth?download=true>`_.


### PR DESCRIPTION
Add the link to the pretrained GSDRUnet weights with 1 channel.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
