### PR TITLE
Trainer test return unaggregated metrics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ New Features
 - Add VarNet/E2E-VarNet model and generalise ArtifactRemoval (:gh:`363` by `Andrew Wang`_)
 - Trainer now can log train progress per batch or per epoch (:gh:`388` by `Andrew Wang`_)
 - Online training with noisy physics now can repeat the same noise each epoch (:gh:`414` by `Andrew Wang`_)
+- Trainer test can return unaggregated metrics (:gh:`420` by `Andrew Wang`_)
 
 Fixed
 ^^^^^

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -922,7 +922,13 @@ class Trainer:
 
         return self.model
 
-    def test(self, test_dataloader, save_path=None, compare_no_learning=True) -> dict:
+    def test(
+        self,
+        test_dataloader,
+        save_path: Union[str, Path] = None,
+        compare_no_learning: bool = True,
+        log_raw_metrics: bool = False,
+    ) -> dict:
         r"""
         Test the model, compute metrics and plot images.
 
@@ -930,6 +936,7 @@ class Trainer:
             a signal x or a tuple of (x, y) signal/measurement pairs.
         :param str save_path: Directory in which to save the plotted images.
         :param bool compare_no_learning: If ``True``, the linear reconstruction is compared to the network reconstruction.
+        :param bool log_raw_metrics: if `True`, also return non-aggregated metrics as a list.
         :returns: dict of metrics results with means and stds.
         """
         self.compare_no_learning = compare_no_learning
@@ -971,6 +978,8 @@ class Trainer:
                 name = self.metrics[k].__class__.__name__ + " no learning"
                 out[name] = self.logs_metrics_linear[k].avg
                 out[name + "_std"] = self.logs_metrics_linear[k].std
+                if log_raw_metrics:
+                    out[name + "_vals"] = self.logs_metrics_linear[k].vals
                 if self.verbose:
                     print(
                         f"{name}: {self.logs_metrics_linear[k].avg:.3f} +- {self.logs_metrics_linear[k].std:.3f}"
@@ -979,6 +988,8 @@ class Trainer:
             name = self.metrics[k].__class__.__name__
             out[name] = l.avg
             out[name + "_std"] = l.std
+            if log_raw_metrics:
+                out[name + "_vals"] = l.vals
             if self.verbose:
                 print(f"{name}: {l.avg:.3f} +- {l.std:.3f}")
 

--- a/deepinv/utils/logger.py
+++ b/deepinv/utils/logger.py
@@ -36,7 +36,7 @@ class AverageMeter(object):
         """
         if isinstance(val, np.ndarray):
             self.val = np.mean(val)
-            self.vals += val.tolist()  # raw batch vals
+            self.vals += val.tolist() if val.ndim > 0 else [val.tolist()]
             self.sum += np.sum(val) * n
             self.sum2 += np.sum(val**2) * n
             self.count += n * np.prod(val.shape)

--- a/deepinv/utils/logger.py
+++ b/deepinv/utils/logger.py
@@ -20,6 +20,7 @@ class AverageMeter(object):
 
     def reset(self):
         """Reset meter values."""
+        self.vals = []
         self.val = 0.0
         self.avg = 0.0
         self.sum = 0.0
@@ -35,11 +36,13 @@ class AverageMeter(object):
         """
         if isinstance(val, np.ndarray):
             self.val = np.mean(val)
+            self.vals += val.tolist()  # raw batch vals
             self.sum += np.sum(val) * n
             self.sum2 += np.sum(val**2) * n
             self.count += n * np.prod(val.shape)
         else:
             self.val = val
+            self.vals += [val]
             self.sum += val * n
             self.sum2 += val**2 * n
             self.count += n


### PR DESCRIPTION
Trainer test now returns unaggregated metrics as a list. This is useful for downstream calculation where you require the unaggregated metrics, e.g. for doing a statistical test.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
