### PR TITLE
CLN warn user about unused parameters in Physics

### DIFF
--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -1,4 +1,5 @@
 from typing import Union
+import warnings
 
 import torch
 from torch import Tensor
@@ -343,6 +344,10 @@ class LinearPhysics(Physics):
             tol=tol,
         )
         self.A_adj = A_adjoint
+        if len(kwargs) > 0:
+            warnings.warn(
+                f"Arguments {kwargs} are pass to {self.__class__.__name__} but are ignored."
+            )
 
     def A_adjoint(self, y, **kwargs):
         r"""

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -44,6 +44,7 @@ class Physics(torch.nn.Module):  # parent class for forward models
         solver="gradient_descent",
         max_iter=50,
         tol=1e-4,
+        **kwargs
     ):
         super().__init__()
         self.noise_model = noise_model
@@ -53,6 +54,11 @@ class Physics(torch.nn.Module):  # parent class for forward models
         self.max_iter = max_iter
         self.tol = tol
         self.solver = solver
+
+        if len(kwargs) > 0:
+            warnings.warn(
+                f"Arguments {kwargs} are pass to {self.__class__.__name__} but are ignored."
+            )
 
     def __mul__(self, other):  #  physics3 = physics1 \circ physics2
         r"""
@@ -342,12 +348,9 @@ class LinearPhysics(Physics):
             max_iter=max_iter,
             solver=solver,
             tol=tol,
+            **kwars
         )
         self.A_adj = A_adjoint
-        if len(kwargs) > 0:
-            warnings.warn(
-                f"Arguments {kwargs} are pass to {self.__class__.__name__} but are ignored."
-            )
 
     def A_adjoint(self, y, **kwargs):
         r"""

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -57,7 +57,7 @@ class Physics(torch.nn.Module):  # parent class for forward models
 
         if len(kwargs) > 0:
             warnings.warn(
-                f"Arguments {kwargs} are pass to {self.__class__.__name__} but are ignored."
+                f"Arguments {kwargs} are passed to {self.__class__.__name__} but are ignored."
             )
 
     def __mul__(self, other):  #  physics3 = physics1 \circ physics2
@@ -348,7 +348,7 @@ class LinearPhysics(Physics):
             max_iter=max_iter,
             solver=solver,
             tol=tol,
-            **kwars
+            **kwargs
         )
         self.A_adj = A_adjoint
 

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1151,3 +1151,8 @@ def test_unmixing(device):
 
     assert torch.all(x_hat[:, 0].squeeze() == torch.tensor([1.0, 0.0]))
     assert torch.all(x_hat[:, 1].squeeze() == torch.tensor([0.0, 1.0]))
+
+
+def test_physics_warn_extra_kwargs():
+    with pytest.warns(UserWarning, match="Arguments {'sigma': 0.5} are passed to Denoising"):
+        dinv.physics.Denoising(sigma=0.5)


### PR DESCRIPTION
Using the lib, I tried to use `Denoising(sigma=0.01)` which gave me unexpected results.
Upon investigating, I was surprised to see that `sigma` is actually ignored here (which makes sense).

This PR adds a warning to inform the user that the parameter is ignored and move up the `kwargs` to the base `Physics` class (as discussed IRL with @matthieutrs).
Another solution would be to remove the `kwargs` to raise an error in case a parameter is passed but irrelevant but that might break some code.
