### PR TITLE
Making prox of Prior L12 safe with backpropagation 

### DIFF
--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -655,13 +655,19 @@ class L12Prior(Prior):
         :return torch.Tensor: proximity operator at :math:`x`.
         """
 
-        z = torch.norm(x, p=2, dim=self.l2_axis, keepdim=True) # Compute the norm
-        z2 = torch.max(z, gamma*torch.ones_like(z)) # Compute its max w.r.t. gamma at each point
-        z3 = torch.ones_like(z) #Construct a mask of ones 
-        mask_z = z > 0 #Find locations where z (hence x) is not already zero
-        z3[mask_z] = z3[mask_z] - gamma/z2[mask_z]  #If z < gamma -> z2 = gamma -> z3 -gamma/gamma =0  (threshold below gamma)
-                                                    #Oth. z3 = 1- gamma/z2
-        z4 = torch.multiply(x, z3) # All elems of x with norm < gamma are set 0; the others are z4 = x(1-gamma/|x|)   
+        z = torch.norm(x, p=2, dim=self.l2_axis, keepdim=True)  # Compute the norm
+        z2 = torch.max(
+            z, gamma * torch.ones_like(z)
+        )  # Compute its max w.r.t. gamma at each point
+        z3 = torch.ones_like(z)  # Construct a mask of ones
+        mask_z = z > 0  # Find locations where z (hence x) is not already zero
+        z3[mask_z] = (
+            z3[mask_z] - gamma / z2[mask_z]
+        )  # If z < gamma -> z2 = gamma -> z3 -gamma/gamma =0  (threshold below gamma)
+        # Oth. z3 = 1- gamma/z2
+        z4 = torch.multiply(
+            x, z3
+        )  # All elems of x with norm < gamma are set 0; the others are z4 = x(1-gamma/|x|)
         # Creating a mask to avoid diving by zero
         # if an element of z is zero, then it is zero in x, therefore torch.multiply(z, x) is zero as well
         return z4

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -655,13 +655,13 @@ class L12Prior(Prior):
         :return torch.Tensor: proximity operator at :math:`x`.
         """
 
-        tau_gamma = torch.tensor(gamma)
-
-        z = torch.norm(x, p=2, dim=self.l2_axis, keepdim=True)
+        z = torch.norm(x, p=2, dim=self.l2_axis, keepdim=True) # Compute the norm
+        z2 = torch.max(z, gamma*torch.ones_like(z)) # Compute its max w.r.t. gamma at each point
+        z3 = torch.ones_like(z) #Construct a mask of ones 
+        mask_z = z > 0 #Find locations where z (hence x) is not already zero
+        z3[mask_z] = z3[mask_z] - gamma/z2[mask_z]  #If z < gamma -> z2 = gamma -> z3 -gamma/gamma =0  (threshold below gamma)
+                                                    #Oth. z3 = 1- gamma/z2
+        z4 = torch.multiply(x, z3) # All elems of x with norm < gamma are set 0; the others are z4 = x(1-gamma/|x|)   
         # Creating a mask to avoid diving by zero
         # if an element of z is zero, then it is zero in x, therefore torch.multiply(z, x) is zero as well
-        mask_z = z > 0
-        z[mask_z] = torch.max(z[mask_z], tau_gamma)
-        z[mask_z] = torch.tensor(1.0) - tau_gamma / z[mask_z]
-
-        return torch.multiply(z, x)
+        return z4


### PR DESCRIPTION

Hi,  
Here is a modified implementation of the prox of the L12 prior so that it does not produce an error when computing gradients. 

I think that the older implementation fails at "z[mask_z] = torch.tensor(1.0) - tau_gamma / z[mask_z]", this new one gives the same output as the already existing one. As this new implementation is a bit more involved I have put comments detailing what is going on.
Let me know what you think of this implementation and if I should make any modification. Below is some code showing that the new implementation has the same output as the old one, but it does not fail when calling grad_fn.
Thanks,
Leo


```

import torch 
import deepinv as dinv


class L12(dinv.optim.L12Prior):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
    def prox(self, x, *args, gamma, **kwargs):

        z = torch.norm(x, p=2, dim=self.l2_axis, keepdim=True) # Compute the norm
        z2 = torch.max(z, gamma*torch.ones_like(z)) # Compute its max w.r.t. gamma at each point
        z3 = torch.ones_like(z) #Construct a mask of ones 
        mask_z = z > 0 #Find locations where z (hence x) is not already zero
        z3[mask_z] = z3[mask_z] - gamma/z2[mask_z]  #If z < gamma -> z2 = gamma -> z3 -gamma/gamma =0  (threshold below gamma)
                                                    #Oth. z3 = 1- gamma/z2
        z4 = torch.multiply(x, z3) # All elems of x with norm < gamma are set 0; the others are z4 = x(1-gamma/|x|)   
        # Creating a mask to avoid diving by zero
        # if an element of z is zero, then it is zero in x, therefore torch.multiply(z, x) is zero as well
        return z4

L12_new = L12(l2_axis=(1,-1)) ##New implementation of L12 prior
x = torch.randn((2,3,20,20,2))
gamma = torch.nn.Parameter(torch.tensor(1.0),requires_grad = True)
p_x = L12_new.prox(x, gamma= gamma)

print(f'new grad is {p_x.grad_fn(x)}')




L12_std = dinv.optim.L12Prior(l2_axis=(1,-1)) ## Already implemented prior
gamma = torch.nn.Parameter(torch.tensor(1.0),requires_grad = True)
std_p_x = L12_std.prox(x, gamma= gamma)

print(torch.sum(torch.square(p_x - std_p_x))) ## Should be zero
print(f'old grad is {std_p_x.grad_fn(x)}') ## This fails

```


### Checks to be done before submitting your PR
- [ ✅] `python3 -m pytest tests/` runs successfully.
- [ ✅] `black .` runs successfully.
- [ ✅] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
