### PR TITLE
Add MINRES for solving linear systems

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Current
 
 New Features
 ^^^^^^^^^^^^
+- Add minres least squared solver (:gh:`` by `Sebastian Neumayer`_ and `Johannes Hertrich`_)
 - New least squared solvers (BiCGStab & LSQR) (:gh:`393` by `Julian Tachella`_)
 - Typehints are used automatically in the documentation (:gh:`379` by `Julian Tachella`_)
 - Add Ptychography operator in physics.phase_retrieval (:gh:`351` by `Victor Sechaud`_)
@@ -289,3 +290,4 @@ Authors
 .. _Andrew Wang: https://andrewwango.github.io/about/
 .. _Pierre-Antoine Comby: https://github.com/paquiteau
 .. _Victor Sechaud: https://github.com/vsechaud
+.. _Sebastian Neumayer: https://www.tu-chemnitz.de/mathematik/invimg/index.en.php

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Current
 
 New Features
 ^^^^^^^^^^^^
-- Add minres least squared solver (:gh:`` by `Sebastian Neumayer`_ and `Johannes Hertrich`_)
+- Add minres least squared solver (:gh:`425` by `Sebastian Neumayer`_ and `Johannes Hertrich`_)
 - New least squared solvers (BiCGStab & LSQR) (:gh:`393` by `Julian Tachella`_)
 - Typehints are used automatically in the documentation (:gh:`379` by `Julian Tachella`_)
 - Add Ptychography operator in physics.phase_retrieval (:gh:`351` by `Victor Sechaud`_)

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -55,6 +55,7 @@ def least_squares(
     - `'CG'`: `Conjugate Gradient <https://en.wikipedia.org/wiki/Conjugate_gradient_method>`_.
     - `'BiCGStab'`: `Biconjugate Gradient Stabilized method <https://en.wikipedia.org/wiki/Biconjugate_gradient_stabilized_method>`_
     - `'lsqr'`: `Least Squares QR <https://www-leland.stanford.edu/group/SOL/software/lsqr/lsqr-toms82a.pdf>`_
+    - `'minres'`: `Minimal Residual Method <https://en.wikipedia.org/wiki/Minimal_residual_method>`_
 
     .. note::
 
@@ -140,6 +141,16 @@ def least_squares(
             )
         elif solver == "BiCGStab":
             x = bicgstab(
+                A=H,
+                b=b,
+                init=init,
+                max_iter=max_iter,
+                tol=tol,
+                parallel_dim=parallel_dim,
+                **kwargs,
+            )
+        elif solver == "minres":
+            x = minres(
                 A=H,
                 b=b,
                 init=init,
@@ -564,6 +575,278 @@ def lsqr(
         print("LSQR did not converge")
 
     return x, acond.sqrt()
+
+
+def minres(
+    A,
+    b,
+    init=None,
+    max_iter=1e2,
+    tol=1e-5,
+    eps=1e-8,
+    parallel_dim=0,
+    verbose=False,
+    precon=lambda x: x.clone(),
+):
+    """
+    Minimal Residual Method for solving symmetric equations.
+
+    Solves :math:`Ax=b` with :math:`A` symmetric using the MINRES algorithm:
+
+    Christopher C. Paige, Michael A. Saunders (1975). "Solution of sparse indefinite systems of linear equations". SIAM Journal on Numerical Analysis. 12 (4): 617–629.
+
+    For more details see: https://en.wikipedia.org/wiki/Minimal_residual_method
+
+    MIT-licensed code imported from https://github.com/cornellius-gp/linear_operator
+    Modifications and simplifications for compatibility with deepinverse
+
+    :param Callable A: Linear operator as a callable function.
+    :param torch.Tensor b: input tensor of shape (B, ...)
+    :param torch.Tensor init: Optional initial guess.
+    :param int max_iter: maximum number of MINRES iterations.
+    :param float tol: absolute tolerance for stopping the MINRES algorithm.
+    :param None, int, List[int] parallel_dim: dimensions to be considered as batch dimensions. If None, all dimensions are considered as batch dimensions.
+    :param bool verbose: Output progress information in the console.
+    :param Callable precon: preconditioner is a callable function (not tested).
+    :return: (:class:`torch.Tensor`) :math:`x` of shape (B, ...)
+    """
+
+    if isinstance(parallel_dim, int):
+        parallel_dim = [parallel_dim]
+    if parallel_dim is None:
+        parallel_dim = []
+
+    if isinstance(b, TensorList):
+        dim = [i for i in range(b[0].ndim) if i not in parallel_dim]
+    else:
+        dim = [i for i in range(b.ndim) if i not in parallel_dim]
+
+    if init is not None:
+        x = init
+    else:
+        x = zeros_like(b)
+
+    # Scale the b
+    squeeze = False
+    if b.dim() == 1:
+        b = b.unsqueeze(-1)
+        squeeze = True
+
+    b_norm = b.norm(2, dim=-2, keepdim=True)
+    b_is_zero = b_norm.lt(1e-10)
+    b_norm = b_norm.masked_fill_(b_is_zero, 1)
+    b = b.div(b_norm)
+
+    # Create space for matmul product, solution
+    prod = A(b)
+    solution = torch.zeros(prod.unsqueeze(0).shape, dtype=b.dtype, device=b.device)
+
+    # Variables for Lanczos terms
+    zvec_prev2 = torch.zeros_like(prod)
+    zvec_prev1 = b.clone().expand_as(prod).contiguous()
+    qvec_prev1 = precon(zvec_prev1)
+    alpha_curr = torch.empty(
+        prod.shape[:-2] + (1, prod.size(-1)), dtype=b.dtype, device=b.device
+    )
+    alpha_shifted_curr = torch.empty(
+        alpha_curr.unsqueeze(0).shape, dtype=b.dtype, device=b.device
+    )
+    beta_prev = (zvec_prev1 * qvec_prev1).sum(dim=-2, keepdim=True).sqrt_()
+    beta_curr = torch.empty_like(beta_prev)
+    tmpvec = torch.empty_like(qvec_prev1)
+
+    # Divide by beta_prev
+    zvec_prev1.div_(beta_prev)
+    qvec_prev1.div_(beta_prev)
+
+    # Variables for the QR rotation
+    # 1) Components of the Givens rotations
+    cos_prev2 = torch.ones(
+        solution.shape[:-2] + (1, b.size(-1)), dtype=b.dtype, device=b.device
+    )
+    sin_prev2 = torch.zeros(
+        solution.shape[:-2] + (1, b.size(-1)), dtype=b.dtype, device=b.device
+    )
+    cos_prev1 = torch.ones_like(cos_prev2)
+    sin_prev1 = torch.zeros_like(sin_prev2)
+    radius_curr = torch.empty_like(cos_prev1)
+    cos_curr = torch.empty_like(cos_prev1)
+    sin_curr = torch.empty_like(cos_prev1)
+    # 2) Terms QR decomposition of T
+    subsub_diag_term = torch.empty_like(alpha_shifted_curr)
+    sub_diag_term = torch.empty_like(alpha_shifted_curr)
+    diag_term = torch.empty_like(alpha_shifted_curr)
+
+    # Variables for the solution updates
+    # 1) The "search" vectors of the solution
+    # Equivalent to the vectors of Q R^{-1}, where Q is the matrix of Lanczos vectors and
+    # R is the QR factor of the tridiagonal Lanczos matrix.
+    search_prev2 = torch.zeros_like(solution)
+    search_prev1 = torch.zeros_like(solution)
+    search_curr = torch.empty_like(search_prev1)
+    search_update = torch.empty_like(search_prev1)
+    # 2) The "scaling" terms of the search vectors
+    # Equivalent to the terms of V^T Q^T b, where Q is the matrix of Lanczos vectors and
+    # V is the QR orthonormal of the tridiagonal Lanczos matrix.
+    scale_prev = beta_prev.repeat(1, *([1] * beta_prev.dim()))
+    scale_curr = torch.empty_like(scale_prev)
+
+    # Terms for checking for convergence
+    solution_norm = torch.zeros(
+        *solution.shape[:-2],
+        solution.size(-1),
+        dtype=solution.dtype,
+        device=solution.device,
+    )
+    search_update_norm = torch.zeros_like(solution_norm)
+
+    # Perform iterations
+    for i in range(int(max_iter)):
+        # Perform matmul
+        prod = A(qvec_prev1)
+
+        # Get next Lanczos terms
+        # --> alpha_curr, beta_curr, qvec_curr
+        torch.mul(prod, qvec_prev1, out=tmpvec)
+        torch.sum(tmpvec, -2, keepdim=True, out=alpha_curr)
+
+        zvec_curr = prod.addcmul_(alpha_curr, zvec_prev1, value=-1).addcmul_(
+            beta_prev, zvec_prev2, value=-1
+        )
+
+        qvec_curr = precon(zvec_curr)
+        torch.mul(zvec_curr, qvec_curr, out=tmpvec)
+        torch.sum(tmpvec, -2, keepdim=True, out=beta_curr)
+        beta_curr.sqrt_()
+        beta_curr.clamp_min_(eps)
+
+        zvec_curr.div_(beta_curr)
+        qvec_curr.div_(beta_curr)
+
+        # Perform JIT-ted update
+        conv = _jit_minres_updates(
+            solution,
+            eps,
+            qvec_prev1,
+            alpha_curr,
+            beta_prev,
+            beta_curr,
+            cos_prev2,
+            cos_prev1,
+            cos_curr,
+            sin_prev2,
+            sin_prev1,
+            sin_curr,
+            radius_curr,
+            subsub_diag_term,
+            sub_diag_term,
+            diag_term,
+            search_prev2,
+            search_prev1,
+            search_curr,
+            search_update,
+            scale_prev,
+            scale_curr,
+            search_update_norm,
+            solution_norm,
+        )
+
+        # Check convergence criterion
+        if (i + 1) % 10 == 0:
+            torch.norm(search_update, dim=-2, out=search_update_norm)
+            torch.norm(solution, dim=-2, out=solution_norm)
+            conv = search_update_norm.div_(solution_norm).mean().item()
+            if conv < tol:
+                break
+
+        # Update terms for next iteration
+        # Lanczos terms
+        zvec_prev2, zvec_prev1 = zvec_prev1, prod
+        qvec_prev1 = qvec_curr
+        beta_prev, beta_curr = beta_curr, beta_prev
+        # Givens rotations terms
+        cos_prev2, cos_prev1, cos_curr = cos_prev1, cos_curr, cos_prev2
+        sin_prev2, sin_prev1, sin_curr = sin_prev1, sin_curr, sin_prev2
+        # Search vector terms)
+        search_prev2, search_prev1, search_curr = (
+            search_prev1,
+            search_curr,
+            search_prev2,
+        )
+        scale_prev, scale_curr = scale_curr, scale_prev
+
+    # For b-s that are close to zero, set them to zero
+    solution.masked_fill_(b_is_zero, 0)
+
+    if squeeze:
+        solution = solution.squeeze(-1)
+        b = b.squeeze(-1)
+        b_norm = b_norm.squeeze(-1)
+
+    solution = solution.squeeze(0)
+    return solution.mul_(b_norm)
+
+
+def _jit_minres_updates(
+    solution,
+    eps,
+    qvec_prev1,
+    alpha_curr,
+    beta_prev,
+    beta_curr,
+    cos_prev2,
+    cos_prev1,
+    cos_curr,
+    sin_prev2,
+    sin_prev1,
+    sin_curr,
+    radius_curr,
+    subsub_diag_term,
+    sub_diag_term,
+    diag_term,
+    search_prev2,
+    search_prev1,
+    search_curr,
+    search_update,
+    scale_prev,
+    scale_curr,
+    search_update_norm,
+    solution_norm,
+):
+    # Start givens rotation
+    # Givens rotation from 2 steps ago
+    torch.mul(sin_prev2, beta_prev, out=subsub_diag_term)
+    torch.mul(cos_prev2, beta_prev, out=sub_diag_term)
+
+    # Givens rotation from 1 step ago
+    torch.mul(alpha_curr, cos_prev1, out=diag_term).addcmul_(
+        sin_prev1, sub_diag_term, value=-1
+    )
+    sub_diag_term.mul_(cos_prev1).addcmul_(sin_prev1, alpha_curr)
+
+    # 3) Compute next Givens terms
+    torch.mul(diag_term, diag_term, out=radius_curr).addcmul_(
+        beta_curr, beta_curr
+    ).sqrt_()
+    cos_curr = torch.div(diag_term, radius_curr, out=cos_curr)
+    sin_curr = torch.div(beta_curr, radius_curr, out=sin_curr)
+    # 4) Apply current Givens rotation
+    diag_term.mul_(cos_curr).addcmul_(sin_curr, beta_curr)
+
+    # Update the solution
+    # --> search_curr, scale_curr solution
+    # 1) Apply the latest Givens rotation to the Lanczos-b ( ||b|| e_1 )
+    # This is getting the scale terms for the "search" vectors
+    torch.mul(scale_prev, sin_curr, out=scale_curr).mul_(-1)
+    scale_prev.mul_(cos_curr)
+    # 2) Get the new search vector
+    torch.addcmul(qvec_prev1, sub_diag_term, search_prev1, value=-1, out=search_curr)
+    search_curr.addcmul_(subsub_diag_term, search_prev2, value=-1)
+    search_curr.div_(diag_term)
+
+    # 3) Update the solution
+    torch.mul(search_curr, scale_prev, out=search_update)
+    solution.add_(search_update)
 
 
 def gradient_descent(grad_f, x, step_size=1.0, max_iter=1e2, tol=1e-5):

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -108,7 +108,7 @@ def least_squares(
         complete = Aty.shape == y.shape
         overcomplete = Aty.flatten().shape[0] < y.flatten().shape[0]
 
-        if complete and solver == "BiCGStab":
+        if complete and (solver == "BiCGStab" or solver == "minres"):
             H = lambda x: A(x)
             b = y
         else:

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -595,6 +595,7 @@ def minres(
 
     Christopher C. Paige, Michael A. Saunders (1975). "Solution of sparse indefinite systems of linear equations". SIAM Journal on Numerical Analysis. 12 (4): 617–629.
 
+    The method assumes that :math:`A` is hermite.
     For more details see: https://en.wikipedia.org/wiki/Minimal_residual_method
 
     Based on https://github.com/cornellius-gp/linear_operator
@@ -639,9 +640,7 @@ def minres(
     qvec_prev1 = precon(zvec_prev1)
     alpha_curr = torch.zeros(b.shape, dtype=b.dtype, device=b.device)
     alpha_curr = alpha_curr.norm(2, dim=dim, keepdim=True)
-    beta_prev = (
-        (zvec_prev1 * qvec_prev1).sum(dim=dim, keepdim=True).sqrt().clamp_min(eps)
-    )
+    beta_prev = dot(zvec_prev1, qvec_prev1, dim=dim).sqrt()
 
     # Divide by beta_prev
     zvec_prev1 = zvec_prev1 / beta_prev
@@ -676,11 +675,11 @@ def minres(
 
         # Get next Lanczos terms
         # --> alpha_curr, beta_curr, qvec_curr
-        alpha_curr = torch.sum(prod * qvec_prev1, dim, keepdim=True)
+        alpha_curr = dot(prod, qvec_prev1, dim=dim)
         prod = prod - alpha_curr * zvec_prev1 - beta_prev * zvec_prev2
         qvec_curr = precon(prod)
 
-        beta_curr = torch.sum(prod * qvec_curr, dim, keepdim=True).sqrt().clamp_min(eps)
+        beta_curr = dot(prod, qvec_curr, dim=dim).sqrt()
 
         prod = prod / beta_curr
         qvec_curr = qvec_curr / beta_curr

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -597,7 +597,7 @@ def minres(
 
     For more details see: https://en.wikipedia.org/wiki/Minimal_residual_method
 
-    MIT-licensed code imported from https://github.com/cornellius-gp/linear_operator
+    Based on https://github.com/cornellius-gp/linear_operator
     Modifications and simplifications for compatibility with deepinverse
 
     :param Callable A: Linear operator as a callable function.

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -190,7 +190,7 @@ class Physics(torch.nn.Module):  # parent class for forward models
             x^* \in \underset{x}{\arg\min} \quad \|\forw{x}-y\|^2.
 
         :param str solver: solver to use. If the physics are non-linear, the only available solver is `'gradient_descent'`.
-            For linear operators, the options are `'CG'`, `'lsqr'` and `'BiCGStab'` (see :func:`deepinv.optim.utils.least_squares` for more details).
+            For linear operators, the options are `'CG'`, `'lsqr'`, `'BiCGStab'` and `'minres'` (see :func:`deepinv.optim.utils.least_squares` for more details).
         :param int max_iter: maximum number of iterations for the solver.
         :param float tol: relative tolerance for the solver, stopping when :math:`\|A(x) - y\| < \text{tol} \|y\|`.
         """
@@ -270,7 +270,7 @@ class LinearPhysics(Physics):
         is used for computing it, and this parameter fixes the maximum number of conjugate gradient iterations.
     :param float tol: If the operator does not have a closed form pseudoinverse, a least squares algorithm
         is used for computing it, and this parameter fixes the relative tolerance of the least squares algorithm.
-    :param str solver: least squares solver to use. Choose between `'CG'`, `'lsqr'` and `'BiCGStab'`. See :func:`deepinv.optim.utils.least_squares` for more details.
+    :param str solver: least squares solver to use. Choose between `'CG'`, `'lsqr'`, `'BiCGStab'` and `'minres'`. See :func:`deepinv.optim.utils.least_squares` for more details.
 
     |sep|
 

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -840,7 +840,7 @@ def test_datafid_stacking(imsize, device):
     assert data_fid.grad(x, y2, physics) == -(y2[0] - y[0]) / 4 - (y2[1] - y[1])
 
 
-solvers = ["CG", "BiCGStab", "lsqr"]
+solvers = ["CG", "BiCGStab", "lsqr", "minres"]
 least_squares_physics = ["fftdeblur", "inpainting", "MRI", "super_resolution_circular"]
 
 

--- a/docs/source/api/deepinv.optim.rst
+++ b/docs/source/api/deepinv.optim.rst
@@ -156,6 +156,7 @@ Utils
     deepinv.optim.utils.least_squares
     deepinv.optim.utils.lsqr
     deepinv.optim.utils.bicgstab
+    deepinv.optim.utils.minres
     deepinv.optim.utils.conjugate_gradient
     deepinv.optim.utils.gradient_descent
     deepinv.optim.phase_retrieval.correct_global_phase


### PR DESCRIPTION
We add the minimal residual method (https://en.wikipedia.org/wiki/Minimal_residual_method) for solving linear systems (having mainly hypergradient computations for bilevel methods in mind, but it can also be used for solving least-squares problems).

The implementation is based on https://github.com/cornellius-gp/linear_operator. However, we simplified and modified this implementation a bit such that it can handle tensors with general shapes (in particular the image format B x C x H x W), complex linear systems and allows backprop (even though it is probably not a good idea to backprop through an iterative solver of a linear system).

Additionally, we added a unit-test for testing the linear system solvers for random matrices. As a side note: the bicgstab implementation doesn't work for complex or non-hermite matrices.

@Zeppo1994

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
