### PR TITLE
param poisson

### DIFF
--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -330,7 +330,7 @@ class PoissonNoise(NoiseModel):
         self, gain=1.0, normalize=True, clip_positive=False, rng: torch.Generator = None
     ):
         super().__init__(rng=rng)
-        self.normalize = to_nn_parameter(normalize)
+        self.normalize = normalize
         self.update_parameters(gain=gain)
         self.clip_positive = clip_positive
 


### PR DESCRIPTION
Fix for #449 
1. removes a usage of `to_nn_parameter(x)` where `x` is a boolean. This works in practice but this is not the default use in the library;
2. add mini checks on Poisson nosie generation on clipping / normalization.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
