### PR TITLE
FIX doctest run in documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,14 +26,12 @@ jobs:
           pip install -e .[dataset,denoisers,doc]
       - name: Run doctests
         run: |
-          find . \( -name '*.py' -o -name '*.rst' \) | xargs grep -l '>>>' | while read file; do
-              if [[ "$file" != *.datasets.rst && "$file" != *.multigpu.rst ]]; then
-                  echo "Running doctests in $file"
-                  python -m doctest -v "$file"
-              else
-                  echo "Skipping file: $file"
-              fi
-          done
+          # Get the RST and PY files containing `>>>`,
+          # excluding multigpu and datasets files
+          _doctest_files=$(find . \( -name '*.py' -o -name '*.rst' \) ! -name '*multigpu.rst' ! -name '*datasets.rst' -exec grep -l '>>>' {} \;)
+          # Run doctest with sphinx, to get the extra IGNORE_OUTPUT primitive
+          # using plot_gallery=0 to avoid building examples
+          sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 $_doctest_files
       - name: Sphinx build
         run: |
           sphinx-build -W docs/source _build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,21 +17,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.12
+          cache: 'pip' # caching pip dependencies
+          cache-dependency-path: setup.py
 
       - name: Install deepinv and its dependencies
         run: |
           pip install -e .[dataset,denoisers,doc]
       - name: Run doctests
         run: |
-          # Get the RST and PY files containing `>>>`,
-          # excluding multigpu and datasets files
-          _doctest_files=$(find . \( -name '*.py' -o -name '*.rst' \) ! -name '*multigpu.rst' ! -name '*datasets.rst' -exec grep -l '>>>' {} \;)
+          # Get the RST afiles containing `>>>`, excluding multigpu.rst
+          # and *datasets.rst files
+          _doctest_files=$(find . -name '*.rst' ! -name '*multigpu.rst' ! -name '*datasets.rst' -exec grep -l '>>>' {} \;)
           # Run doctest with sphinx, to get the extra IGNORE_OUTPUT primitive
           # using plot_gallery=0 to avoid building examples
-          sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 $_doctest_files
+          sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 -v $_doctest_files
+
+          # Also test *.py files directly with doctest
+          python -m doctest -v $(find . -name '*.py' -exec grep -l '>>>' {} \;)
       - name: Sphinx build
         run: |
           sphinx-build -W docs/source _build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,6 +9,11 @@ on:
     branches:
     - main
 
+# Cancel in-progress runs when pushing a new commit on the PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 
@@ -34,6 +39,9 @@ jobs:
           # Run doctest with sphinx, to get the extra IGNORE_OUTPUT primitive
           # using plot_gallery=0 to avoid building examples
           sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 -v $_doctest_files
+
+          # Rerun once all rst files have been generated, to catch the stubs
+          _doctest_files=$(find . -name '*.rst' ! -name '*multigpu.rst' ! -name '*datasets*.rst')
           sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 -v $_doctest_files
       - name: Sphinx build
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Install deepinv and its dependencies
         run: |
           pip install -e .[dataset,denoisers,doc]
-      - name: Sphinx build
-        run: |
-          sphinx-build -W docs/source _build
       - name: Run doctests
         run: |
           # Get all the RST files, excluding multigpu.rst
@@ -37,6 +34,10 @@ jobs:
           # Run doctest with sphinx, to get the extra IGNORE_OUTPUT primitive
           # using plot_gallery=0 to avoid building examples
           sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 -v $_doctest_files
+          sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 -v $_doctest_files
+      - name: Sphinx build
+        run: |
+          sphinx-build -W docs/source _build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,20 +26,17 @@ jobs:
       - name: Install deepinv and its dependencies
         run: |
           pip install -e .[dataset,denoisers,doc]
-      - name: Run doctests
-        run: |
-          # Get the RST afiles containing `>>>`, excluding multigpu.rst
-          # and *datasets.rst files
-          _doctest_files=$(find . -name '*.rst' ! -name '*multigpu.rst' ! -name '*datasets.rst' -exec grep -l '>>>' {} \;)
-          # Run doctest with sphinx, to get the extra IGNORE_OUTPUT primitive
-          # using plot_gallery=0 to avoid building examples
-          sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 -v $_doctest_files
-
-          # Also test *.py files directly with doctest
-          python -m doctest -v $(find . -name '*.py' -exec grep -l '>>>' {} \;)
       - name: Sphinx build
         run: |
           sphinx-build -W docs/source _build
+      - name: Run doctests
+        run: |
+          # Get all the RST files, excluding multigpu.rst
+          # and *datasets.rst files
+          _doctest_files=$(find . -name '*.rst' ! -name '*multigpu.rst' ! -name '*datasets*.rst')
+          # Run doctest with sphinx, to get the extra IGNORE_OUTPUT primitive
+          # using plot_gallery=0 to avoid building examples
+          sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 -v $_doctest_files
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,11 +26,13 @@ jobs:
         with:
           python-version: 3.12
           cache: 'pip' # caching pip dependencies
-          cache-dependency-path: setup.py
 
       - name: Install deepinv and its dependencies
         run: |
           pip install -e .[dataset,denoisers,doc]
+      - name: Sphinx build
+        run: |
+          sphinx-build -W docs/source _build
       - name: Run doctests
         run: |
           # Get all the RST files, excluding multigpu.rst
@@ -39,13 +41,6 @@ jobs:
           # Run doctest with sphinx, to get the extra IGNORE_OUTPUT primitive
           # using plot_gallery=0 to avoid building examples
           sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 -v $_doctest_files
-
-          # Rerun once all rst files have been generated, to catch the stubs
-          _doctest_files=$(find . -name '*.rst' ! -name '*multigpu.rst' ! -name '*datasets*.rst')
-          sphinx-build -M doctest docs/source/ docs/build/ -D plot_gallery=0 -v $_doctest_files
-      - name: Sphinx build
-        run: |
-          sphinx-build -W docs/source _build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install deepinv and its dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,7 @@ jobs:
 
       - name: Test with pytest and generate coverage report
         run: |
-          python3 -m pytest --cov=deepinv --junitxml=junit.xml -o junit_family=legacy -v deepinv/tests/test_loss.py::test_losses
-
+          python3 -m pytest --cov=deepinv --junitxml=junit.xml -o junit_family=legacy -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,12 @@ jobs:
             extra: dataset,denoisers,test
             name: "windows all dependencies"
 
-    env:
-      VERSION_PYTHON: ${{ matrix.version_python }}
-
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.VERSION_PYTHON }}
+          python-version: ${{ matrix.version_python }}
+          cache: 'pip' # caching pip dependencies
 
       - name: Install deepinv and its dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 # Cancel in-progress runs when pushing a new commit on the PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,12 @@ on:
     branches:
     - main
 
+
+# Cancel in-progress runs when pushing a new commit on the PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test deep inverse ${{ matrix.name }}
@@ -39,7 +45,7 @@ jobs:
 
       - name: Test with pytest and generate coverage report
         run: |
-          python3 -m pytest --cov=deepinv --junitxml=junit.xml -o junit_family=legacy
+          python3 -m pytest --cov=deepinv --junitxml=junit.xml -o junit_family=legacy -v deepinv/tests/test_loss.py::test_losses
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/deepinv/loss/metric/metric.py
+++ b/deepinv/loss/metric/metric.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from types import ModuleType
 from typing import Optional, Callable
 
-from torch import Tensor, ones
+from torch import Tensor
 from torch.nn import Module
 
 from deepinv.loss.metric.functional import complex_abs, norm
@@ -51,7 +51,7 @@ class Metric(Module):
         >>> from torchmetrics.functional.image import structural_similarity_index_measure
         >>> from deepinv.loss.metric import Metric
         >>> m = Metric(metric=partial(structural_similarity_index_measure, reduction='none'))
-        >>> x = x_net = ones(2, 3, 64, 64) # B,C,H,W
+        >>> x = x_net = torch.ones(2, 3, 64, 64) # B,C,H,W
         >>> m(x_net - 0.1, x)
         tensor([0., 0.])
 

--- a/deepinv/loss/metric/perceptual.py
+++ b/deepinv/loss/metric/perceptual.py
@@ -18,8 +18,7 @@ class LPIPS(Metric):
 
     >>> from deepinv.utils.demo import get_image_url, load_url_image
     >>> from deepinv.loss.metric import LPIPS
-    >>> ();m = LPIPS();() # doctest: +ELLIPSIS
-    (...)
+    >>> m = LPIPS() # doctest: +IGNORE_RESULT
     >>> x = load_url_image(get_image_url("celeba_example.jpg"), img_size=128)
     >>> x_net = x - 0.01
     >>> m(x_net, x) # doctest: +ELLIPSIS
@@ -61,7 +60,7 @@ class NIQE(Metric):
 
     >>> from deepinv.utils.demo import get_image_url, load_url_image
     >>> from deepinv.loss.metric import NIQE
-    >>> ();m = NIQE();() # doctest: +ELLIPSIS
+    >>> m = NIQE() # doctest: +IGNORE_RESULT
     (...)
     >>> x_net = load_url_image(get_image_url("celeba_example.jpg"), img_size=128)
     >>> m(x_net) # doctest: +ELLIPSIS

--- a/deepinv/models/dynamic.py
+++ b/deepinv/models/dynamic.py
@@ -1,4 +1,4 @@
-from torch import Tensor, rand
+from torch import Tensor
 import torch.nn as nn
 from deepinv.physics import Physics, TimeMixin
 from deepinv.models.base import Reconstructor
@@ -20,7 +20,7 @@ class TimeAgnosticNet(Reconstructor, TimeMixin):
     >>> from deepinv.models import UNet, TimeAgnosticNet
     >>> model = UNet(scales=2)
     >>> model = TimeAgnosticNet(model)
-    >>> y = rand(1, 1, 4, 8, 8) # B,C,T,H,W
+    >>> y = torch.rand(1, 1, 4, 8, 8) # B,C,T,H,W
     >>> x_net = model(y, None)
     >>> x_net.shape == y.shape
     True
@@ -64,7 +64,7 @@ class TimeAveragingNet(
     >>> from deepinv.models import UNet, TimeAveragingNet
     >>> model = UNet(scales=2)
     >>> model = TimeAveragingNet(model)
-    >>> y = rand(1, 1, 4, 8, 8) # B,C,T,H,W
+    >>> y = torch.rand(1, 1, 4, 8, 8) # B,C,T,H,W
     >>> x_net = model(y, None)
     >>> x_net.shape # B,C,H,W
     torch.Size([1, 1, 8, 8])

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -130,6 +130,7 @@ class RandomPhaseRetrieval(PhaseRetrieval):
 
         Random phase retrieval operator with 10 measurements for a 3x3 image:
 
+        >>> from deepinv.physics import RandomPhaseRetrieval
         >>> seed = torch.manual_seed(0) # Random seed for reproducibility
         >>> x = torch.randn((1, 1, 3, 3),dtype=torch.cfloat) # Define random 3x3 image
         >>> physics = RandomPhaseRetrieval(m=6, img_shape=(1, 3, 3), rng=torch.Generator('cpu'))

--- a/deepinv/sampling/diffusion.py
+++ b/deepinv/sampling/diffusion.py
@@ -98,7 +98,7 @@ class DDRM(Reconstructor):
         ...   device=device,
         ... )
         >>> y = physics(x) # measurements
-        >>> denoiser = dinv.models.DRUNet(pretrained="download").to(device)
+        >>> denoiser = dinv.models.DRUNet(pretrained="download").to(device)  # doctest: +IGNORE_RESULT
         >>> model = dinv.sampling.DDRM(denoiser=denoiser, sigmas=np.linspace(1, 0, 10), verbose=True) # define the DDRM model
         >>> xhat = model(y, physics) # sample from the posterior distribution
         >>> dinv.metric.PSNR()(xhat, x) > dinv.metric.PSNR()(y, x) # Should be closer to the original

--- a/deepinv/sampling/diffusion.py
+++ b/deepinv/sampling/diffusion.py
@@ -245,7 +245,7 @@ class DiffPIR(Reconstructor):
         between 3.0 and 25.0 depending on the problem). Default: ``7.0``.
     :param bool verbose: if ``True``, print progress
     :param str device: the device to use for the computations
-    
+
     |sep|
 
     :Examples:
@@ -253,7 +253,7 @@ class DiffPIR(Reconstructor):
         Denoising diffusion restoration model using a pretrained DRUNet denoiser:
 
         >>> import deepinv as dinv
-        >>> device = dinv.utils.get_freer_gpu(verbose=False) if torch.cuda.is_available() else 'cpu' 
+        >>> device = dinv.utils.get_freer_gpu(verbose=False) if torch.cuda.is_available() else 'cpu'
         >>> x = 0.5 * torch.ones(1, 3, 32, 32, device=device) # Define a plain gray 32x32 image
         >>> physics = dinv.physics.Inpainting(
         ...   mask=0.5, tensor_size=(3, 32, 32),
@@ -262,14 +262,14 @@ class DiffPIR(Reconstructor):
         ... )
         >>> y = physics(x) # Measurements
         >>> denoiser = dinv.models.DRUNet(pretrained="download").to(device)
-        >>> model = DiffPIR(
+        >>> model = dinv.sampling.DiffPIR(
         ...   model=denoiser,
         ...   data_fidelity=dinv.optim.data_fidelity.L2()
         ... ) # Define the DiffPIR model
         >>> xhat = model(y, physics) # Run the DiffPIR algorithm
         >>> dinv.metric.PSNR()(xhat, x) > dinv.metric.PSNR()(y, x) # Should be closer to the original
         tensor([True])
-        
+
     """
 
     def __init__(

--- a/deepinv/tests/test_loss.py
+++ b/deepinv/tests/test_loss.py
@@ -281,14 +281,14 @@ def test_losses(loss_name, tmp_path, dataset, physics, imsize, device, rng):
     save_dir = tmp_path / "dataset"
     # choose backbone denoiser
     backbone = dinv.models.AutoEncoder(
-        dim_input=imsize[0] * imsize[1] * imsize[2], dim_mid=128, dim_hid=32
+        dim_input=imsize[0] * imsize[1] * imsize[2], dim_mid=64, dim_hid=16
     ).to(device)
 
     # choose a reconstruction architecture
     model = dinv.models.ArtifactRemoval(backbone)
 
     # choose optimizer and scheduler
-    epochs = 50
+    epochs = 10
     optimizer = torch.optim.Adam(model.parameters(), lr=5e-4, weight_decay=1e-8)
     scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=int(epochs * 0.8))
 

--- a/deepinv/unfolded/unfolded.py
+++ b/deepinv/unfolded/unfolded.py
@@ -164,7 +164,7 @@ def unfolded_builder(
         >>> import deepinv as dinv
         >>>
         >>> # Create a trainable unfolded architecture
-        >>> model = dinv.unfolded.unfolded_builder(
+        >>> model = dinv.unfolded.unfolded_builder(  # doctest: +IGNORE_RESULT
         ...     iteration="PGD",
         ...     data_fidelity=dinv.optim.data_fidelity.L2(),
         ...     prior=dinv.optim.PnP(dinv.models.DnCNN(in_channels=1, out_channels=1)),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -141,6 +141,11 @@ class CustomOutputChecker(OutputChecker):
 
 doctest.OutputChecker = CustomOutputChecker
 
+doctest_global_setup = """
+import torch
+import numpy as np
+"""
+
 
 #############################
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,8 @@ from sphinx.util import logging
 
 logger = logging.getLogger(__name__)
 
+import doctest
+
 basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, basedir)
 
@@ -119,6 +121,22 @@ class TolerantImageSg(ImageSg):
 def setup(app):
     app.add_directive("userguide", UserGuideMacro)
     app.add_directive("image-sg-ignore", TolerantImageSg)
+
+
+# ---------- doctest configuration -----------------------------------------
+# Add a IGNORE_RESULT option to skip some line output
+# From: https://stackoverflow.com/a/69780437/2642845
+
+IGNORE_RESULT = doctest.register_optionflag('IGNORE_RESULT')
+
+OutputChecker = doctest.OutputChecker
+class CustomOutputChecker(OutputChecker):
+    def check_output(self, want, got, optionflags):
+        if IGNORE_RESULT & optionflags:
+            return True
+        return OutputChecker.check_output(self, want, got, optionflags)
+
+doctest.OutputChecker = CustomOutputChecker
 
 
 #############################

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -127,14 +127,17 @@ def setup(app):
 # Add a IGNORE_RESULT option to skip some line output
 # From: https://stackoverflow.com/a/69780437/2642845
 
-IGNORE_RESULT = doctest.register_optionflag('IGNORE_RESULT')
+IGNORE_RESULT = doctest.register_optionflag("IGNORE_RESULT")
 
 OutputChecker = doctest.OutputChecker
+
+
 class CustomOutputChecker(OutputChecker):
     def check_output(self, want, got, optionflags):
         if IGNORE_RESULT & optionflags:
             return True
         return OutputChecker.check_output(self, want, got, optionflags)
+
 
 doctest.OutputChecker = CustomOutputChecker
 

--- a/docs/source/user_guide/reconstruction/denoisers.rst
+++ b/docs/source/user_guide/reconstruction/denoisers.rst
@@ -13,7 +13,7 @@ as input and returns a denoised image:
 
     >>> import torch
     >>> import deepinv as dinv
-    >>> denoiser = dinv.models.DRUNet()
+    >>> denoiser = dinv.models.DRUNet()  # doctest: +IGNORE_RESULT
     >>> sigma = 0.1
     >>> image = torch.ones(1, 3, 32, 32) * .5
     >>> noisy_image =  image + torch.randn(1, 3, 32, 32) * sigma

--- a/docs/source/user_guide/reconstruction/unfolded.rst
+++ b/docs/source/user_guide/reconstruction/unfolded.rst
@@ -43,7 +43,7 @@ evaluated with any forward model (e.g., denoising, deconvolution, inpainting, et
     >>> import deepinv as dinv
     >>>
     >>> # Create a trainable unfolded architecture
-    >>> model = dinv.unfolded.unfolded_builder(
+    >>> model = dinv.unfolded.unfolded_builder(  # doctest: +IGNORE_RESULT
     ...     iteration="PGD",
     ...     data_fidelity=dinv.optim.L2(),
     ...     prior=dinv.optim.PnP(dinv.models.DnCNN()),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "matplotlib",
     "hdf5storage",
     "tqdm",
-    "torch",
+    "torch<2.7",
     "torchvision",
     "torchmetrics",
     "einops",


### PR DESCRIPTION
- Add a `IGNORE_OUTPUT` primitive to skip check in doctest when the output depends on the context
- Move doctest check to only `rst` files, using generated stubs for each classes.
- Add cache to `pip` dependencies
- Add concurrency to cancel some runs when pushing to the same PR
- Pin torch to version before `2.7` as it seems the latest release broke something for the homography.