### PR TITLE
add test scheduling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
 on:
+  schedule:
+    # run test every day at 3:30 AM
+    - cron: "30 3 */1 * *"
   push:
     branches:
     - main


### PR DESCRIPTION
Adds a new scheduled workflow that runs our full test suite every 24 hours. Goal is to catch breaking dependency updates early.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
