### PR TITLE
Clean up file system pollution in get_freer_gpu

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changed
 Fixed
 ^^^^^
 - Fix latex rendering in `deepinv.utils.plotting.config_matplotlib`  (:gh:`452` by `Romain Vo`_)
+- Get rid of unnecessary file system writes in `get_freer_gpu` (:gh:`468` by `Jérémy Scanvic`_)
 
 
 v0.3


### PR DESCRIPTION
Fixes #465

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
