### PR TITLE
update SPC parameters in demos

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 - Fixed sequency ordering in `deepinv.physics.SinglePixelCamera` (:gh:`475` by `Brayan Monroy`_)
 - Change array operations from numpy to PyTorch in `SinglePixelCamera` (:gh:`483` by `Jérémy Scanvic`_)
 - Get rid of commented out code (:gh:`485` by `Jérémy Scanvic`_)
+- Changed `deepinv.physics.SinglePixelCamera` parameters in demos (:gh:`493` by `Brayan Monroy`_)
 
 
 v0.3

--- a/examples/basics/demo_physics_tour.py
+++ b/examples/basics/demo_physics_tour.py
@@ -217,7 +217,7 @@ plot([x, y[0], y[1]], titles=["signal", "low res rgb", "high res gray"])
 # When ``fast=True``, the patterns are generated using a fast Hadamard transform.
 
 physics = dinv.physics.SinglePixelCamera(
-    m=256, fast=True, img_shape=img_size, device=device
+    m=1024, fast=True, ordering="cake_cutting", img_shape=img_size, device=device
 )
 
 y = physics(x)

--- a/examples/plug-and-play/demo_PnP_custom_optim.py
+++ b/examples/plug-and-play/demo_PnP_custom_optim.py
@@ -182,8 +182,9 @@ operation = "single_pixel"
 noise_level_img = 0.03  # Gaussian Noise standard deviation for the degradation
 n_channels = 1  # 3 for color images, 1 for gray-scale images
 physics = dinv.physics.SinglePixelCamera(
-    m=100,
+    m=600,
     img_shape=(1, 64, 64),
+    ordering="cake_cutting",
     noise_model=dinv.physics.GaussianNoise(sigma=noise_level_img),
     device=device,
 )


### PR DESCRIPTION
In #475, a small bug in the selection of the single-pixel camera was fixed. However, the results in the PnP custom algorithm and physics tour demos are now a bit poor. I increased the `m` parameter and changed the ordering to `cake_cutting` to improve the visual results.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
