### PR TITLE
Unify argument name by adding aliases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,8 +70,8 @@ Fixed
 - Fix offline training with noise generator not updating noise params (:gh:`414` by `Andrew Wang`_)
 - Fix wrong reference link in auto examples (:gh:`432` by `Minh Hai Nguyen`_)
 - Fix paths in LidcIdriSliceDataset (:gh:`446` by `Jérémy Scanvic`_)
-- Fix Ptychography can not handle multi-channels input (:gh:`TODO` by `Minh Hai Nguyen`_)
-- Fix argument name inconsistency (:gh:`TODO` by `Minh Hai Nguyen`_)
+- Fix Ptychography can not handle multi-channels input (:gh:`494` by `Minh Hai Nguyen`_)
+- Fix argument name (img_size, in_shape, ...) inconsistency  (:gh:`494` by `Minh Hai Nguyen`_)
 
 Changed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,8 @@ Fixed
 - Fix offline training with noise generator not updating noise params (:gh:`414` by `Andrew Wang`_)
 - Fix wrong reference link in auto examples (:gh:`432` by `Minh Hai Nguyen`_)
 - Fix paths in LidcIdriSliceDataset (:gh:`446` by `Jérémy Scanvic`_)
+- Fix Ptychography can not handle multi-channels input (:gh:`TODO` by `Minh Hai Nguyen`_)
+- Fix argument name inconsistency (:gh:`TODO` by `Minh Hai Nguyen`_)
 
 Changed
 ^^^^^^^

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -255,10 +255,10 @@ class SplittingLoss(Loss):
 
             if (
                 self.mask_generator is None
-                or self.mask_generator.tensor_size != y.size()[1:]
+                or self.mask_generator.img_size != y.size()[1:]
             ):
                 self.mask_generator = BernoulliSplittingMaskGenerator(
-                    tensor_size=y.size()[1:],
+                    img_size=y.size()[1:],
                     split_ratio=self.split_ratio,
                     pixelwise=self.pixelwise,
                     device=y.device,
@@ -431,7 +431,7 @@ class Phase2PhaseLoss(SplittingLoss):
         self.metric = metric
         self.device = device
         self.mask_generator = Phase2PhaseSplittingMaskGenerator(
-            tensor_size=self.tensor_size, device=self.device
+            img_size=self.tensor_size, device=self.device
         )
         if not self.dynamic_model:
             # Metric wrapper to flatten dynamic inputs
@@ -617,7 +617,7 @@ class Artifact2ArtifactLoss(Phase2PhaseLoss):
         )
         self.name = "artifact2artifact"
         self.mask_generator = Artifact2ArtifactSplittingMaskGenerator(
-            tensor_size=self.tensor_size, split_size=split_size, device=self.device
+            img_size=self.tensor_size, split_size=split_size, device=self.device
         )
 
     def forward(self, x_net, y, physics, model, **kwargs):

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -83,7 +83,7 @@ class SplittingLoss(Loss):
 
     >>> import torch
     >>> import deepinv as dinv
-    >>> physics = dinv.physics.Inpainting(tensor_size=(1, 8, 8), mask=0.5)
+    >>> physics = dinv.physics.Inpainting(img_size=(1, 8, 8), mask=0.5)
     >>> model = dinv.models.MedianFilter()
     >>> loss = dinv.loss.SplittingLoss(split_ratio=0.9, eval_n_samples=2)
     >>> model = loss.adapt_model(model) # important step!

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -8,6 +8,7 @@ from deepinv.loss.metric.metric import Metric
 from deepinv.physics.generator import BernoulliSplittingMaskGenerator
 from deepinv.models.base import Reconstructor
 
+
 class SplittingLoss(Loss):
     r"""
     Measurement splitting loss.
@@ -277,9 +278,9 @@ class SplittingLoss(Loss):
                     device=y.device,
                 )
 
-            if self.mask_generator.tensor_size[-2:] != y.shape[-2:]:
+            if self.mask_generator.img_size[-2:] != y.shape[-2:]:
                 raise ValueError(
-                    f"Mask generator should be same shape as y in last 2 dims, but mask has {self.mask_generator.tensor_size[-2:]} and y has {y.shape[-2:]}"
+                    f"Mask generator should be same shape as y in last 2 dims, but mask has {self.mask_generator.img_size[-2:]} and y has {y.shape[-2:]}"
                 )
 
             with torch.set_grad_enabled(self.training):
@@ -350,6 +351,7 @@ class SplittingLoss(Loss):
                     "Mask not generated during forward pass - use model(y, physics, update_parameters=True)"
                 )
             return self.mask
+
 
 class Neighbor2Neighbor(Loss):
     r"""

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -15,6 +15,7 @@ from deepinv.models.dynamic import TimeAveragingNet
 from deepinv.physics.time import TimeMixin
 from deepinv.models.base import Reconstructor
 from deepinv.loss.measplit import SplittingLoss
+from deepinv.utils.decorators import _deprecated_alias
 
 
 class WeightedSplittingLoss(SplittingLoss):
@@ -256,7 +257,7 @@ class Phase2PhaseLoss(SplittingLoss):
 
     By default, the error is computed using the MSE metric, however any appropriate metric can be used.
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
     :param bool dynamic_model: set ``True`` if using with a model that inputs and outputs time-data i.e. ``x`` of shape (B,C,T,H,W). Set ``False`` if ``x`` are static images (B,C,H,W).
 
     :param Metric, torch.nn.Module metric: metric used for computing data consistency, which is set as the mean squared error by default.
@@ -305,21 +306,22 @@ class Phase2PhaseLoss(SplittingLoss):
 
     """
 
+    @_deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         dynamic_model: bool = True,
         metric: Union[Metric, torch.nn.Module] = torch.nn.MSELoss(),
         device="cpu",
     ):
         super().__init__()
         self.name = "phase2phase"
-        self.tensor_size = tensor_size
+        self.img_size = img_size
         self.dynamic_model = dynamic_model
         self.metric = metric
         self.device = device
         self.mask_generator = Phase2PhaseSplittingMaskGenerator(
-            tensor_size=self.tensor_size, device=self.device
+            img_size=self.img_size, device=self.device
         )
         if not self.dynamic_model:
             # Metric wrapper to flatten dynamic inputs
@@ -442,8 +444,8 @@ class Artifact2ArtifactLoss(Phase2PhaseLoss):
 
     By default, the error is computed using the MSE metric, however any appropriate metric can be used.
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
-    :param int, tuple[int] split_size: time-length of chunk. Must divide ``tensor_size[1]`` exactly. If ``tuple``, one is randomly selected each time.
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param int, tuple[int] split_size: time-length of chunk. Must divide ``img_size[1]`` exactly. If ``tuple``, one is randomly selected each time.
     :param bool dynamic_model: set True if using with a model that inputs and outputs time-data i.e. x of shape (B,C,T,H,W). Set False if x are static images (B,C,H,W).
     :param Metric, torch.nn.Module metric: metric used for computing data consistency, which is set as the mean squared error by default.
     :param str, torch.device device: torch device.
@@ -491,23 +493,24 @@ class Artifact2ArtifactLoss(Phase2PhaseLoss):
 
     """
 
+    @_deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         split_size: Union[int, Tuple[int]] = 2,
         dynamic_model: bool = True,
         metric: Union[Metric, torch.nn.Module] = torch.nn.MSELoss(),
         device="cpu",
     ):
         super().__init__(
-            tensor_size=tensor_size,
+            img_size=img_size,
             dynamic_model=dynamic_model,
             metric=metric,
             device=device,
         )
         self.name = "artifact2artifact"
         self.mask_generator = Artifact2ArtifactSplittingMaskGenerator(
-            tensor_size=self.tensor_size, split_size=split_size, device=self.device
+            img_size=self.img_size, split_size=split_size, device=self.device
         )
 
     def forward(self, x_net, y, physics, model, **kwargs):

--- a/deepinv/models/gan.py
+++ b/deepinv/models/gan.py
@@ -8,6 +8,7 @@ from torch.optim import Adam
 from deepinv.physics import Physics
 from deepinv.loss import MCLoss
 from .base import Reconstructor
+from deepinv.utils.decorators import _deprecated_alias
 
 
 class PatchGANDiscriminator(nn.Module):
@@ -109,13 +110,14 @@ class ESRGANDiscriminator(nn.Module):
 
     See :ref:`sphx_glr_auto_examples_adversarial-learning_demo_gan_imaging.py` for how to use this for adversarial training.
 
-    :param tuple input_shape: shape of input image
+    :param tuple img_size: shape of input image
     """
 
-    def __init__(self, input_shape: tuple):
+    @_deprecated_alias(input_shape="img_size")
+    def __init__(self, img_size: tuple):
         super().__init__()
-        self.input_shape = input_shape
-        in_channels, in_height, in_width = self.input_shape
+        self.img_size = img_size
+        in_channels, in_height, in_width = self.img_size
         patch_h, patch_w = int(in_height / 2**4), int(in_width / 2**4)
         self.output_shape = (1, patch_h, patch_w)
 

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -235,7 +235,7 @@ class L2(DataFidelity):
         >>> x = torch.ones(1, 1, 3, 3)
         >>> mask = torch.ones_like(x)
         >>> mask[0, 0, 1, 1] = 0
-        >>> physics = dinv.physics.Inpainting(tensor_size=(1, 3, 3), mask=mask)
+        >>> physics = dinv.physics.Inpainting(img_size=(1, 3, 3), mask=mask)
         >>> y = physics(x)
         >>>
         >>> # Compute the data fidelity f(Ax, y)

--- a/deepinv/optim/phase_retrieval.py
+++ b/deepinv/optim/phase_retrieval.py
@@ -152,7 +152,7 @@ def spectral_methods(
     if x is None:
         # always use randn for initial guess, never use rand!
         x = torch.randn(
-            (y.shape[0],) + physics.input_shape,
+            (y.shape[0],) + physics.img_size,
             dtype=physics.dtype,
             device=physics.device,
         )

--- a/deepinv/physics/cassi.py
+++ b/deepinv/physics/cassi.py
@@ -162,7 +162,7 @@ class CompressiveSpectralImaging(LinearPhysics):
         :return: (:class:`torch.Tensor`) output measurements
         """
         if x.shape[1:] != self.img_size:
-            raise ValueError("Input must be same shape as img_shape.")
+            raise ValueError("Input must be same shape as img_size.")
 
         self.update_parameters(mask=mask)
 

--- a/deepinv/physics/compressed_sensing.py
+++ b/deepinv/physics/compressed_sensing.py
@@ -2,7 +2,7 @@ from deepinv.physics.forward import LinearPhysics
 import torch
 import numpy as np
 from deepinv.physics.functional import random_choice
-from deepinv.utils.decorators import deprecated_alias
+from deepinv.utils.decorators import _deprecated_alias
 
 
 def dst1(x):
@@ -96,7 +96,7 @@ class CompressedSensing(LinearPhysics):
 
     """
 
-    @deprecated_alias(img_shape="img_size")
+    @_deprecated_alias(img_shape="img_size")
     def __init__(
         self,
         m,

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -643,7 +643,7 @@ class DecomposablePhysics(LinearPhysics):
 
         >>> from deepinv.physics import DecomposablePhysics
         >>> seed = torch.manual_seed(0)  # Random seed for reproducibility
-        >>> tensor_size = (1, 1, 3, 3)  # Input size
+        >>> img_size = (1, 1, 3, 3)  # Input size
         >>> mask = torch.tensor([[1, 0, 1], [1, 0, 1], [1, 0, 1]])  # Binary mask
         >>> U = lambda x: x  # U is the identity operation
         >>> U_adjoint = lambda x: x  # U_adjoint is the identity operation
@@ -654,7 +654,7 @@ class DecomposablePhysics(LinearPhysics):
 
         Apply the operator to a random tensor:
 
-        >>> x = torch.randn(tensor_size)
+        >>> x = torch.randn(img_size)
         >>> with torch.no_grad():
         ...     physics.A(x)  # Apply the masking
         tensor([[[[ 1.5410, -0.0000, -2.1788],

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -3,6 +3,7 @@ from warnings import warn
 import torch
 from deepinv.physics.generator import PhysicsGenerator
 from deepinv.physics.functional import random_choice
+from deepinv.utils.decorators import deprecated_alias
 
 
 class BernoulliSplittingMaskGenerator(PhysicsGenerator):
@@ -40,7 +41,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         >>> (mask[1] == 0).sum()/mask[1].numel()  # 0.1 < split_ratio < 0.9
         tensor(0.2905)
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, M) or (M,)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, M) or (M,)
     :param float split_ratio: ratio of values to be kept.
     :param bool pixelwise: Apply the mask in a pixelwise fashion, i.e., zero all channels in a given pixel simultaneously.
     :param bool random_split_ratio: if True, split_ratio is randomly sampled from [min_split_ratio, max_split_ratio] at each step.
@@ -50,9 +51,10 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
     :param torch.Generator rng: torch random number generator.
     """
 
+    @deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         split_ratio: float,
         pixelwise: bool = True,
         random_split_ratio: bool = False,
@@ -65,7 +67,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         **kwargs,
     ):
         super().__init__(*args, device=device, dtype=dtype, rng=rng, **kwargs)
-        self.tensor_size = tensor_size
+        self.img_size = img_size
         self.split_ratio = split_ratio
         self.pixelwise = pixelwise
         self.random_split_ratio = random_split_ratio
@@ -85,13 +87,13 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         :param torch.Tensor, None input_mask: optional mask to be split. If None, all pixels are considered. If not None, only pixels where mask==1 are considered. input_mask shape can optionally include a batch dimension.
         :param int seed: the seed for the random number generator.
 
-        :return: dictionary with key **'mask'**: tensor of size ``(batch_size, *tensor_size)`` with values in {0, 1}.
+        :return: dictionary with key **'mask'**: tensor of size ``(batch_size, *img_size)`` with values in {0, 1}.
         :rtype: dict
         """
         self.rng_manual_seed(seed)
 
         if isinstance(input_mask, torch.Tensor) and len(input_mask.shape) > len(
-            self.tensor_size
+            self.img_size
         ):
             input_mask = input_mask.to(self.device)
             if input_mask.shape[0] > 1:
@@ -107,7 +109,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
             for b in range(batch_size):
                 inp = None
                 if isinstance(input_mask, torch.Tensor) and len(input_mask.shape) > len(
-                    self.tensor_size
+                    self.img_size
                 ):
                     inp = input_mask[b]
                 elif isinstance(input_mask, torch.Tensor):
@@ -120,15 +122,15 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         return {"mask": mask}
 
     def check_pixelwise(self, input_mask=None) -> bool:
-        r"""Check if pixelwise can be used given input_mask dimensions and tensor_size dimensions"""
+        r"""Check if pixelwise can be used given input_mask dimensions and img_size dimensions"""
         pixelwise = self.pixelwise
 
-        if pixelwise and len(self.tensor_size) == 2:
+        if pixelwise and len(self.img_size) == 2:
             warn(
-                "Generating pixelwise mask assumes channel in first dimension. For 2D images (i.e. of shape (H,W)) ensure tensor_size is at least 3D (i.e. C,H,W). However, for tensor_size of shape (C,M), this will work as expected."
+                "Generating pixelwise mask assumes channel in first dimension. For 2D images (i.e. of shape (H,W)) ensure img_size is at least 3D (i.e. C,H,W). However, for img_size of shape (C,M), this will work as expected."
             )
-        elif pixelwise and len(self.tensor_size) == 1:
-            warn("For 1D tensor_size, pixelwise must be False.")
+        elif pixelwise and len(self.img_size) == 1:
+            warn("For 1D img_size, pixelwise must be False.")
             pixelwise = False
 
         if (
@@ -139,11 +141,11 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
                     warn("input_mask is only 1D so pixelwise cannot be used.")
                     return False
                 elif len(input_mask.shape) == 2 and len(input_mask.shape) < len(
-                    self.tensor_size
+                    self.img_size
                 ):
                     # When input_mask 2D, this can either be shape C,M or H,W.
-                    # When input_mask C,M, tensor_size will also be C,M (as passed in from SplittingLoss) and pixelwise can be used safely.
-                    # When input_mask H,W but tensor_size higher-dimensional e.g. C,H,W, then pixelwise should be set to False as it will happen anyway.
+                    # When input_mask C,M, img_size will also be C,M (as passed in from SplittingLoss) and pixelwise can be used safely.
+                    # When input_mask H,W but img_size higher-dimensional e.g. C,H,W, then pixelwise should be set to False as it will happen anyway.
                     return False
                 elif not all(
                     torch.equal(input_mask[i], input_mask[0])
@@ -193,8 +195,8 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
 
         else:
             # Sample pixels from a uniform distribution as input_mask is not given
-            mask = torch.ones(self.tensor_size, device=self.device)
-            aux = torch.rand(self.tensor_size, generator=self.rng, device=self.device)
+            mask = torch.ones(self.img_size, device=self.device)
+            aux = torch.rand(self.img_size, generator=self.rng, device=self.device)
             if not pixelwise:
                 mask[aux > self.split_ratio] = 0
             else:
@@ -228,7 +230,7 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         >>> gen.step(batch_size=2, input_mask=physics.mask)["mask"].shape
         torch.Size([2, 1, 3, 3])
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
     :param float split_ratio: ratio of values to be kept (i.e. ones).
     :param bool pixelwise: Apply the mask in a pixelwise fashion, i.e., zero all channels in a given pixel simultaneously.
     :param float std_scale: scale parameter of 2D Gaussian, in pixels.
@@ -237,9 +239,10 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     :param torch.Generator rng: random number generator.
     """
 
+    @deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         split_ratio: float,
         pixelwise: bool = True,
         std_scale: float = 4.0,
@@ -251,16 +254,16 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     ):
         super().__init__(
             *args,
-            tensor_size=tensor_size,
+            img_size=img_size,
             split_ratio=split_ratio,
             pixelwise=pixelwise,
             device=device,
             rng=rng,
             **kwargs,
         )
-        if len(tensor_size) < 3:
+        if len(img_size) < 3:
             raise ValueError(
-                "tensor_size should be at least of shape (C, H, W). Gaussian splitting mask does not support signals of shape (C, M)."
+                "img_size should be at least of shape (C, H, W). Gaussian splitting mask does not support signals of shape (C, M)."
             )
         self.std_scale = std_scale
         self.center_block = (
@@ -278,14 +281,14 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         :param torch.Tensor, None input_mask: optional mask to be split. If None, all pixels are considered. If not None, only pixels where mask==1 are considered. No batch dim in shape.
         """
         pixelwise = self.check_pixelwise()
-        _T = self.tensor_size[1] if len(self.tensor_size) > 3 else 1
-        _C = self.tensor_size[0] if not pixelwise else 1
+        _T = self.img_size[1] if len(self.img_size) > 3 else 1
+        _C = self.img_size[0] if not pixelwise else 1
 
         # Create blank input mask if not specified. Create with time dim even if we only want static mask
         if not isinstance(input_mask, torch.Tensor) or input_mask.numel() <= 1:
-            input_mask = torch.ones(_C, _T, *self.tensor_size[-2:], device=self.device)
+            input_mask = torch.ones(_C, _T, *self.img_size[-2:], device=self.device)
 
-        if len(input_mask.shape) < len(self.tensor_size):
+        if len(input_mask.shape) < len(self.img_size):
             # Missing channel dim, so create it
             no_channel_dim = True
             input_mask = input_mask.unsqueeze(0)
@@ -347,11 +350,11 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         # Invert mask for output and handle dimensions
         mask_out = input_mask - mask_out.unflatten(-1, (nx, ny))
 
-        if len(self.tensor_size) == 3:
+        if len(self.img_size) == 3:
             mask_out = mask_out[:, 0, ...]  # no actual time dim
 
         if self.pixelwise and not no_channel_dim:
-            mask_out = torch.cat([mask_out] * self.tensor_size[0], dim=0)
+            mask_out = torch.cat([mask_out] * self.img_size[0], dim=0)
 
         return mask_out
 
@@ -367,19 +370,20 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
 
     If input_mask not passed, a blank input mask is used instead.
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: unused.
     """
 
+    @deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         device: torch.device = "cpu",
         rng: torch.Generator = None,
     ):
         super().__init__(
-            tensor_size=tensor_size,
+            img_size=img_size,
             split_ratio=None,
             pixelwise=None,
             device=device,
@@ -387,14 +391,14 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         )
 
     def batch_step(self, input_mask: torch.Tensor = None) -> dict:
-        if len(self.tensor_size) != 4:
-            raise ValueError("tensor_size must be of shape (C, T, H, W)")
+        if len(self.img_size) != 4:
+            raise ValueError("img_size must be of shape (C, T, H, W)")
 
         if not isinstance(input_mask, torch.Tensor) or input_mask.numel() <= 1:
-            input_mask = torch.ones(self.tensor_size, device=self.device)
+            input_mask = torch.ones(self.img_size, device=self.device)
 
-        if tuple(input_mask.shape) != self.tensor_size:
-            raise ValueError("input_mask must be same shape as tensor_size")
+        if tuple(input_mask.shape) != self.img_size:
+            raise ValueError("input_mask must be same shape as img_size")
 
         mask_out = torch.zeros_like(input_mask)
         mask_out[:, ::2] = input_mask[:, ::2]
@@ -415,20 +419,21 @@ class Artifact2ArtifactSplittingMaskGenerator(Phase2PhaseSplittingMaskGenerator)
 
     If input_mask not passed, a blank input mask is used instead.
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
-    :param int, tuple[int] split_size: time-length of chunk. Must divide ``tensor_size[1]`` exactly. If ``tuple``, one is randomly selected each time.
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param int, tuple[int] split_size: time-length of chunk. Must divide ``img_size[1]`` exactly. If ``tuple``, one is randomly selected each time.
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: torch random number generator.
     """
 
+    @deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         split_size: Union[int, Tuple[int]] = 2,
         device: torch.device = "cpu",
         rng: torch.Generator = None,
     ):
-        super().__init__(tensor_size, device, rng=rng)
+        super().__init__(img_size, device, rng=rng)
         self.split_size = split_size
         self.prev_idx = None
         self.prev_split_size = None

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -3,6 +3,7 @@ from warnings import warn
 import torch
 from deepinv.physics.generator import PhysicsGenerator
 from deepinv.physics.functional import random_choice
+from deepinv.utils.decorators import _deprecated_alias
 
 
 class BernoulliSplittingMaskGenerator(PhysicsGenerator):
@@ -40,7 +41,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         >>> (mask[1] == 0).sum()/mask[1].numel()  # 0.1 < split_ratio < 0.9
         tensor(0.2905)
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, M) or (M,)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, M) or (M,)
     :param float split_ratio: ratio of values to be kept.
     :param bool pixelwise: Apply the mask in a pixelwise fashion, i.e., zero all channels in a given pixel simultaneously.
     :param bool random_split_ratio: if True, split_ratio is randomly sampled from [min_split_ratio, max_split_ratio] at each step.
@@ -50,9 +51,10 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
     :param torch.Generator rng: torch random number generator.
     """
 
+    @_deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         split_ratio: float,
         pixelwise: bool = True,
         random_split_ratio: bool = False,
@@ -65,7 +67,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         **kwargs,
     ):
         super().__init__(*args, device=device, dtype=dtype, rng=rng, **kwargs)
-        self.tensor_size = tensor_size
+        self.img_size = img_size
         self.split_ratio = split_ratio
         self.pixelwise = pixelwise
         self.random_split_ratio = random_split_ratio
@@ -85,13 +87,13 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         :param torch.Tensor, None input_mask: optional mask to be split. If None, all pixels are considered. If not None, only pixels where mask==1 are considered. input_mask shape can optionally include a batch dimension.
         :param int seed: the seed for the random number generator.
 
-        :return: dictionary with key **'mask'**: tensor of size ``(batch_size, *tensor_size)`` with values in {0, 1}.
+        :return: dictionary with key **'mask'**: tensor of size ``(batch_size, *img_size)`` with values in {0, 1}.
         :rtype: dict
         """
         self.rng_manual_seed(seed)
 
         if isinstance(input_mask, torch.Tensor) and len(input_mask.shape) > len(
-            self.tensor_size
+            self.img_size
         ):
             input_mask = input_mask.to(self.device)
             if input_mask.shape[0] > 1:
@@ -107,7 +109,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
             for b in range(batch_size):
                 inp = None
                 if isinstance(input_mask, torch.Tensor) and len(input_mask.shape) > len(
-                    self.tensor_size
+                    self.img_size
                 ):
                     inp = input_mask[b]
                 elif isinstance(input_mask, torch.Tensor):
@@ -120,15 +122,15 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         return {"mask": mask}
 
     def check_pixelwise(self, input_mask=None) -> bool:
-        r"""Check if pixelwise can be used given input_mask dimensions and tensor_size dimensions"""
+        r"""Check if pixelwise can be used given input_mask dimensions and img_size dimensions"""
         pixelwise = self.pixelwise
 
-        if pixelwise and len(self.tensor_size) == 2:
+        if pixelwise and len(self.img_size) == 2:
             warn(
-                "Generating pixelwise mask assumes channel in first dimension. For 2D images (i.e. of shape (H,W)) ensure tensor_size is at least 3D (i.e. C,H,W). However, for tensor_size of shape (C,M), this will work as expected."
+                "Generating pixelwise mask assumes channel in first dimension. For 2D images (i.e. of shape (H,W)) ensure img_size is at least 3D (i.e. C,H,W). However, for img_size of shape (C,M), this will work as expected."
             )
-        elif pixelwise and len(self.tensor_size) == 1:
-            warn("For 1D tensor_size, pixelwise must be False.")
+        elif pixelwise and len(self.img_size) == 1:
+            warn("For 1D img_size, pixelwise must be False.")
             pixelwise = False
 
         if (
@@ -139,11 +141,11 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
                     warn("input_mask is only 1D so pixelwise cannot be used.")
                     return False
                 elif len(input_mask.shape) == 2 and len(input_mask.shape) < len(
-                    self.tensor_size
+                    self.img_size
                 ):
                     # When input_mask 2D, this can either be shape C,M or H,W.
-                    # When input_mask C,M, tensor_size will also be C,M (as passed in from SplittingLoss) and pixelwise can be used safely.
-                    # When input_mask H,W but tensor_size higher-dimensional e.g. C,H,W, then pixelwise should be set to False as it will happen anyway.
+                    # When input_mask C,M, img_size will also be C,M (as passed in from SplittingLoss) and pixelwise can be used safely.
+                    # When input_mask H,W but img_size higher-dimensional e.g. C,H,W, then pixelwise should be set to False as it will happen anyway.
                     return False
                 elif not all(
                     torch.equal(input_mask[i], input_mask[0])
@@ -193,8 +195,8 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
 
         else:
             # Sample pixels from a uniform distribution as input_mask is not given
-            mask = torch.ones(self.tensor_size, device=self.device)
-            aux = torch.rand(self.tensor_size, generator=self.rng, device=self.device)
+            mask = torch.ones(self.img_size, device=self.device)
+            aux = torch.rand(self.img_size, generator=self.rng, device=self.device)
             if not pixelwise:
                 mask[aux > self.split_ratio] = 0
             else:
@@ -228,7 +230,7 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         >>> gen.step(batch_size=2, input_mask=physics.mask)["mask"].shape
         torch.Size([2, 1, 3, 3])
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
     :param float split_ratio: ratio of values to be kept (i.e. ones).
     :param bool pixelwise: Apply the mask in a pixelwise fashion, i.e., zero all channels in a given pixel simultaneously.
     :param float std_scale: scale parameter of 2D Gaussian, in pixels.
@@ -237,9 +239,10 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     :param torch.Generator rng: random number generator.
     """
 
+    @_deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         split_ratio: float,
         pixelwise: bool = True,
         std_scale: float = 4.0,
@@ -251,16 +254,16 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     ):
         super().__init__(
             *args,
-            tensor_size=tensor_size,
+            img_size=img_size,
             split_ratio=split_ratio,
             pixelwise=pixelwise,
             device=device,
             rng=rng,
             **kwargs,
         )
-        if len(tensor_size) < 3:
+        if len(img_size) < 3:
             raise ValueError(
-                "tensor_size should be at least of shape (C, H, W). Gaussian splitting mask does not support signals of shape (C, M)."
+                "img_size should be at least of shape (C, H, W). Gaussian splitting mask does not support signals of shape (C, M)."
             )
         self.std_scale = std_scale
         self.center_block = (
@@ -278,14 +281,14 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         :param torch.Tensor, None input_mask: optional mask to be split. If None, all pixels are considered. If not None, only pixels where mask==1 are considered. No batch dim in shape.
         """
         pixelwise = self.check_pixelwise()
-        _T = self.tensor_size[1] if len(self.tensor_size) > 3 else 1
-        _C = self.tensor_size[0] if not pixelwise else 1
+        _T = self.img_size[1] if len(self.img_size) > 3 else 1
+        _C = self.img_size[0] if not pixelwise else 1
 
         # Create blank input mask if not specified. Create with time dim even if we only want static mask
         if not isinstance(input_mask, torch.Tensor) or input_mask.numel() <= 1:
-            input_mask = torch.ones(_C, _T, *self.tensor_size[-2:], device=self.device)
+            input_mask = torch.ones(_C, _T, *self.img_size[-2:], device=self.device)
 
-        if len(input_mask.shape) < len(self.tensor_size):
+        if len(input_mask.shape) < len(self.img_size):
             # Missing channel dim, so create it
             no_channel_dim = True
             input_mask = input_mask.unsqueeze(0)
@@ -347,11 +350,11 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         # Invert mask for output and handle dimensions
         mask_out = input_mask - mask_out.unflatten(-1, (nx, ny))
 
-        if len(self.tensor_size) == 3:
+        if len(self.img_size) == 3:
             mask_out = mask_out[:, 0, ...]  # no actual time dim
 
         if self.pixelwise and not no_channel_dim:
-            mask_out = torch.cat([mask_out] * self.tensor_size[0], dim=0)
+            mask_out = torch.cat([mask_out] * self.img_size[0], dim=0)
 
         return mask_out
 
@@ -367,19 +370,20 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
 
     If input_mask not passed, a blank input mask is used instead.
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: unused.
     """
 
+    @_deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         device: torch.device = "cpu",
         rng: torch.Generator = None,
     ):
         super().__init__(
-            tensor_size=tensor_size,
+            img_size=img_size,
             split_ratio=None,
             pixelwise=None,
             device=device,
@@ -387,14 +391,14 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         )
 
     def batch_step(self, input_mask: torch.Tensor = None) -> dict:
-        if len(self.tensor_size) != 4:
-            raise ValueError("tensor_size must be of shape (C, T, H, W)")
+        if len(self.img_size) != 4:
+            raise ValueError("img_size must be of shape (C, T, H, W)")
 
         if not isinstance(input_mask, torch.Tensor) or input_mask.numel() <= 1:
-            input_mask = torch.ones(self.tensor_size, device=self.device)
+            input_mask = torch.ones(self.img_size, device=self.device)
 
-        if tuple(input_mask.shape) != self.tensor_size:
-            raise ValueError("input_mask must be same shape as tensor_size")
+        if tuple(input_mask.shape) != self.img_size:
+            raise ValueError("input_mask must be same shape as img_size")
 
         mask_out = torch.zeros_like(input_mask)
         mask_out[:, ::2] = input_mask[:, ::2]
@@ -415,20 +419,21 @@ class Artifact2ArtifactSplittingMaskGenerator(Phase2PhaseSplittingMaskGenerator)
 
     If input_mask not passed, a blank input mask is used instead.
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
-    :param int, tuple[int] split_size: time-length of chunk. Must divide ``tensor_size[1]`` exactly. If ``tuple``, one is randomly selected each time.
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param int, tuple[int] split_size: time-length of chunk. Must divide ``img_size[1]`` exactly. If ``tuple``, one is randomly selected each time.
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: torch random number generator.
     """
 
+    @_deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         split_size: Union[int, Tuple[int]] = 2,
         device: torch.device = "cpu",
         rng: torch.Generator = None,
     ):
-        super().__init__(tensor_size, device, rng=rng)
+        super().__init__(img_size, device, rng=rng)
         self.split_size = split_size
         self.prev_idx = None
         self.prev_split_size = None

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -238,22 +238,23 @@ class MultiplicativeSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         >>> mask_generator.step(batch_size=2, input_mask=orig_mask)["mask"].shape
         torch.Size([2, 1, 128, 128])
 
-    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
     :param deepinv.physics.generator.BaseMaskGenerator split_generator: mask generator used for multiplicative splitting
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: torch random number generator.
     :param torch.dtype dtype: the data type of the generated parameters
     """
 
+    @_deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size: Tuple[int],
+        img_size: Tuple[int],
         split_generator: BaseMaskGenerator,
         *args,
         **kwargs,
     ):
         super().__init__(
-            tensor_size=tensor_size,
+            img_size=img_size,
             split_ratio=0.0,
             pixelwise=True,
             *args,

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -3,7 +3,6 @@ from warnings import warn
 import torch
 from deepinv.physics.generator import PhysicsGenerator
 from deepinv.physics.functional import random_choice
-from deepinv.utils.decorators import deprecated_alias
 
 
 class BernoulliSplittingMaskGenerator(PhysicsGenerator):
@@ -41,7 +40,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         >>> (mask[1] == 0).sum()/mask[1].numel()  # 0.1 < split_ratio < 0.9
         tensor(0.2905)
 
-    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, M) or (M,)
+    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, M) or (M,)
     :param float split_ratio: ratio of values to be kept.
     :param bool pixelwise: Apply the mask in a pixelwise fashion, i.e., zero all channels in a given pixel simultaneously.
     :param bool random_split_ratio: if True, split_ratio is randomly sampled from [min_split_ratio, max_split_ratio] at each step.
@@ -51,10 +50,9 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
     :param torch.Generator rng: torch random number generator.
     """
 
-    @deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        img_size: Tuple[int],
+        tensor_size: Tuple[int],
         split_ratio: float,
         pixelwise: bool = True,
         random_split_ratio: bool = False,
@@ -67,7 +65,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         **kwargs,
     ):
         super().__init__(*args, device=device, dtype=dtype, rng=rng, **kwargs)
-        self.img_size = img_size
+        self.tensor_size = tensor_size
         self.split_ratio = split_ratio
         self.pixelwise = pixelwise
         self.random_split_ratio = random_split_ratio
@@ -87,13 +85,13 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         :param torch.Tensor, None input_mask: optional mask to be split. If None, all pixels are considered. If not None, only pixels where mask==1 are considered. input_mask shape can optionally include a batch dimension.
         :param int seed: the seed for the random number generator.
 
-        :return: dictionary with key **'mask'**: tensor of size ``(batch_size, *img_size)`` with values in {0, 1}.
+        :return: dictionary with key **'mask'**: tensor of size ``(batch_size, *tensor_size)`` with values in {0, 1}.
         :rtype: dict
         """
         self.rng_manual_seed(seed)
 
         if isinstance(input_mask, torch.Tensor) and len(input_mask.shape) > len(
-            self.img_size
+            self.tensor_size
         ):
             input_mask = input_mask.to(self.device)
             if input_mask.shape[0] > 1:
@@ -109,7 +107,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
             for b in range(batch_size):
                 inp = None
                 if isinstance(input_mask, torch.Tensor) and len(input_mask.shape) > len(
-                    self.img_size
+                    self.tensor_size
                 ):
                     inp = input_mask[b]
                 elif isinstance(input_mask, torch.Tensor):
@@ -122,15 +120,15 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         return {"mask": mask}
 
     def check_pixelwise(self, input_mask=None) -> bool:
-        r"""Check if pixelwise can be used given input_mask dimensions and img_size dimensions"""
+        r"""Check if pixelwise can be used given input_mask dimensions and tensor_size dimensions"""
         pixelwise = self.pixelwise
 
-        if pixelwise and len(self.img_size) == 2:
+        if pixelwise and len(self.tensor_size) == 2:
             warn(
-                "Generating pixelwise mask assumes channel in first dimension. For 2D images (i.e. of shape (H,W)) ensure img_size is at least 3D (i.e. C,H,W). However, for img_size of shape (C,M), this will work as expected."
+                "Generating pixelwise mask assumes channel in first dimension. For 2D images (i.e. of shape (H,W)) ensure tensor_size is at least 3D (i.e. C,H,W). However, for tensor_size of shape (C,M), this will work as expected."
             )
-        elif pixelwise and len(self.img_size) == 1:
-            warn("For 1D img_size, pixelwise must be False.")
+        elif pixelwise and len(self.tensor_size) == 1:
+            warn("For 1D tensor_size, pixelwise must be False.")
             pixelwise = False
 
         if (
@@ -141,11 +139,11 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
                     warn("input_mask is only 1D so pixelwise cannot be used.")
                     return False
                 elif len(input_mask.shape) == 2 and len(input_mask.shape) < len(
-                    self.img_size
+                    self.tensor_size
                 ):
                     # When input_mask 2D, this can either be shape C,M or H,W.
-                    # When input_mask C,M, img_size will also be C,M (as passed in from SplittingLoss) and pixelwise can be used safely.
-                    # When input_mask H,W but img_size higher-dimensional e.g. C,H,W, then pixelwise should be set to False as it will happen anyway.
+                    # When input_mask C,M, tensor_size will also be C,M (as passed in from SplittingLoss) and pixelwise can be used safely.
+                    # When input_mask H,W but tensor_size higher-dimensional e.g. C,H,W, then pixelwise should be set to False as it will happen anyway.
                     return False
                 elif not all(
                     torch.equal(input_mask[i], input_mask[0])
@@ -195,8 +193,8 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
 
         else:
             # Sample pixels from a uniform distribution as input_mask is not given
-            mask = torch.ones(self.img_size, device=self.device)
-            aux = torch.rand(self.img_size, generator=self.rng, device=self.device)
+            mask = torch.ones(self.tensor_size, device=self.device)
+            aux = torch.rand(self.tensor_size, generator=self.rng, device=self.device)
             if not pixelwise:
                 mask[aux > self.split_ratio] = 0
             else:
@@ -230,7 +228,7 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         >>> gen.step(batch_size=2, input_mask=physics.mask)["mask"].shape
         torch.Size([2, 1, 3, 3])
 
-    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
+    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
     :param float split_ratio: ratio of values to be kept (i.e. ones).
     :param bool pixelwise: Apply the mask in a pixelwise fashion, i.e., zero all channels in a given pixel simultaneously.
     :param float std_scale: scale parameter of 2D Gaussian, in pixels.
@@ -239,10 +237,9 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     :param torch.Generator rng: random number generator.
     """
 
-    @deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        img_size: Tuple[int],
+        tensor_size: Tuple[int],
         split_ratio: float,
         pixelwise: bool = True,
         std_scale: float = 4.0,
@@ -254,16 +251,16 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     ):
         super().__init__(
             *args,
-            img_size=img_size,
+            tensor_size=tensor_size,
             split_ratio=split_ratio,
             pixelwise=pixelwise,
             device=device,
             rng=rng,
             **kwargs,
         )
-        if len(img_size) < 3:
+        if len(tensor_size) < 3:
             raise ValueError(
-                "img_size should be at least of shape (C, H, W). Gaussian splitting mask does not support signals of shape (C, M)."
+                "tensor_size should be at least of shape (C, H, W). Gaussian splitting mask does not support signals of shape (C, M)."
             )
         self.std_scale = std_scale
         self.center_block = (
@@ -281,14 +278,14 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         :param torch.Tensor, None input_mask: optional mask to be split. If None, all pixels are considered. If not None, only pixels where mask==1 are considered. No batch dim in shape.
         """
         pixelwise = self.check_pixelwise()
-        _T = self.img_size[1] if len(self.img_size) > 3 else 1
-        _C = self.img_size[0] if not pixelwise else 1
+        _T = self.tensor_size[1] if len(self.tensor_size) > 3 else 1
+        _C = self.tensor_size[0] if not pixelwise else 1
 
         # Create blank input mask if not specified. Create with time dim even if we only want static mask
         if not isinstance(input_mask, torch.Tensor) or input_mask.numel() <= 1:
-            input_mask = torch.ones(_C, _T, *self.img_size[-2:], device=self.device)
+            input_mask = torch.ones(_C, _T, *self.tensor_size[-2:], device=self.device)
 
-        if len(input_mask.shape) < len(self.img_size):
+        if len(input_mask.shape) < len(self.tensor_size):
             # Missing channel dim, so create it
             no_channel_dim = True
             input_mask = input_mask.unsqueeze(0)
@@ -350,11 +347,11 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         # Invert mask for output and handle dimensions
         mask_out = input_mask - mask_out.unflatten(-1, (nx, ny))
 
-        if len(self.img_size) == 3:
+        if len(self.tensor_size) == 3:
             mask_out = mask_out[:, 0, ...]  # no actual time dim
 
         if self.pixelwise and not no_channel_dim:
-            mask_out = torch.cat([mask_out] * self.img_size[0], dim=0)
+            mask_out = torch.cat([mask_out] * self.tensor_size[0], dim=0)
 
         return mask_out
 
@@ -370,20 +367,19 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
 
     If input_mask not passed, a blank input mask is used instead.
 
-    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: unused.
     """
 
-    @deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        img_size: Tuple[int],
+        tensor_size: Tuple[int],
         device: torch.device = "cpu",
         rng: torch.Generator = None,
     ):
         super().__init__(
-            img_size=img_size,
+            tensor_size=tensor_size,
             split_ratio=None,
             pixelwise=None,
             device=device,
@@ -391,14 +387,14 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         )
 
     def batch_step(self, input_mask: torch.Tensor = None) -> dict:
-        if len(self.img_size) != 4:
-            raise ValueError("img_size must be of shape (C, T, H, W)")
+        if len(self.tensor_size) != 4:
+            raise ValueError("tensor_size must be of shape (C, T, H, W)")
 
         if not isinstance(input_mask, torch.Tensor) or input_mask.numel() <= 1:
-            input_mask = torch.ones(self.img_size, device=self.device)
+            input_mask = torch.ones(self.tensor_size, device=self.device)
 
-        if tuple(input_mask.shape) != self.img_size:
-            raise ValueError("input_mask must be same shape as img_size")
+        if tuple(input_mask.shape) != self.tensor_size:
+            raise ValueError("input_mask must be same shape as tensor_size")
 
         mask_out = torch.zeros_like(input_mask)
         mask_out[:, ::2] = input_mask[:, ::2]
@@ -419,21 +415,20 @@ class Artifact2ArtifactSplittingMaskGenerator(Phase2PhaseSplittingMaskGenerator)
 
     If input_mask not passed, a blank input mask is used instead.
 
-    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
-    :param int, tuple[int] split_size: time-length of chunk. Must divide ``img_size[1]`` exactly. If ``tuple``, one is randomly selected each time.
+    :param tuple[int] tensor_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param int, tuple[int] split_size: time-length of chunk. Must divide ``tensor_size[1]`` exactly. If ``tuple``, one is randomly selected each time.
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: torch random number generator.
     """
 
-    @deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        img_size: Tuple[int],
+        tensor_size: Tuple[int],
         split_size: Union[int, Tuple[int]] = 2,
         device: torch.device = "cpu",
         rng: torch.Generator = None,
     ):
-        super().__init__(img_size, device, rng=rng)
+        super().__init__(tensor_size, device, rng=rng)
         self.split_size = split_size
         self.prev_idx = None
         self.prev_split_size = None

--- a/deepinv/physics/inpainting.py
+++ b/deepinv/physics/inpainting.py
@@ -1,6 +1,7 @@
 from deepinv.physics.forward import DecomposablePhysics
 from deepinv.physics.mri import MRI
 from deepinv.physics.generator import BernoulliSplittingMaskGenerator
+from deepinv.utils.decorators import deprecated_alias
 import torch
 
 
@@ -26,11 +27,11 @@ class Inpainting(DecomposablePhysics):
     :class:`BernoulliSplittingMaskGenerator <deepinv.physics.generator.BernoulliSplittingMaskGenerator>`, see example below.
 
     :param torch.Tensor, float mask: If the input is a float, the entries of the mask will be sampled from a bernoulli
-        distribution with probability equal to ``mask``. If the input is a :class:`torch.Tensor` matching `tensor_size`,
+        distribution with probability equal to ``mask``. If the input is a :class:`torch.Tensor` matching `img_size`,
         the mask will be set to this tensor. If ``mask`` is :class:`torch.Tensor`, it must be shape that is broadcastable
         to input shape and will be broadcast during forward call.
         If ``None``, it must be set during forward pass or using ``update`` method.
-    :param tuple tensor_size: size of the input images without batch dimension e.g. of shape ``(C, H, W)`` or ``(C, M)`` or ``(M,)``.
+    :param tuple img_size: size of the input images without batch dimension e.g. of shape ``(C, H, W)`` or ``(C, M)`` or ``(M,)``.
     :param torch.device device: gpu or cpu.
     :param bool pixelwise: Apply the mask in a pixelwise fashion, i.e., zero all channels in a given pixel simultaneously.
         If existing mask passed (i.e. mask is :class:`torch.Tensor`), this has no effect.
@@ -47,7 +48,7 @@ class Inpainting(DecomposablePhysics):
         >>> x = torch.randn(1, 1, 3, 3) # Define random 3x3 image
         >>> mask = torch.zeros(1, 3, 3) # Define empty mask
         >>> mask[:, 2, :] = 1 # Keeping last line only
-        >>> physics = Inpainting(mask=mask, tensor_size=x.shape[1:])
+        >>> physics = Inpainting(mask=mask, img_size=x.shape[1:])
         >>> physics(x)
         tensor([[[[ 0.0000, -0.0000, -0.0000],
                   [ 0.0000, -0.0000, -0.0000],
@@ -58,7 +59,7 @@ class Inpainting(DecomposablePhysics):
         >>> from deepinv.physics import Inpainting
         >>> seed = torch.manual_seed(0) # Random seed for reproducibility
         >>> x = torch.randn(1, 1, 3, 3) # Define random 3x3 image
-        >>> physics = Inpainting(mask=0.7, tensor_size=x.shape[1:])
+        >>> physics = Inpainting(mask=0.7, img_size=x.shape[1:])
         >>> physics(x)
         tensor([[[[ 1.5410, -0.0000, -2.1788],
                   [ 0.5684, -0.0000, -1.3986],
@@ -69,7 +70,7 @@ class Inpainting(DecomposablePhysics):
         >>> from deepinv.physics import Inpainting
         >>> from deepinv.physics.generator import BernoulliSplittingMaskGenerator
         >>> x = torch.randn(1, 1, 3, 3) # Define random 3x3 image
-        >>> physics = Inpainting(tensor_size=x.shape[1:])
+        >>> physics = Inpainting(img_size=x.shape[1:])
         >>> gen = BernoulliSplittingMaskGenerator(x.shape[1:], split_ratio=0.7)
         >>> params = gen.step(batch_size=1, seed = 0) # Generate random mask
         >>> physics(x, **params) # Set mask on-the-fly
@@ -84,9 +85,10 @@ class Inpainting(DecomposablePhysics):
 
     """
 
+    @deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
-        tensor_size,
+        img_size,
         mask=None,
         pixelwise=True,
         device="cpu",
@@ -99,7 +101,7 @@ class Inpainting(DecomposablePhysics):
             mask = mask.to(device)
         elif isinstance(mask, float):
             gen = BernoulliSplittingMaskGenerator(
-                tensor_size=tensor_size,
+                img_size=img_size,
                 split_ratio=mask,
                 pixelwise=pixelwise,
                 device=device,
@@ -113,10 +115,10 @@ class Inpainting(DecomposablePhysics):
                 "mask should either be torch.nn.Parameter, torch.Tensor, float or None."
             )
 
-        if mask is not None and len(mask.shape) == len(tensor_size):
+        if mask is not None and len(mask.shape) == len(img_size):
             mask = mask.unsqueeze(0)
 
-        self.tensor_size = tensor_size
+        self.img_size = img_size
         self.update_parameters(mask=mask)
 
     def noise(self, x, **kwargs):
@@ -147,7 +149,7 @@ class Inpainting(DecomposablePhysics):
 
         if isinstance(other, self.__class__):
             return self.__class__(
-                tensor_size=self.tensor_size,
+                img_size=self.img_size,
                 mask=self.mask * other.mask,
                 noise_model=self.noise_model,
                 device=self.mask.device,
@@ -206,5 +208,5 @@ class Demosaicing(Inpainting):
         else:
             raise ValueError(f"The {pattern} pattern is not implemented")
         super().__init__(
-            tensor_size=mask.shape, mask=mask, pixelwise=False, device=device, **kwargs
+            img_size=mask.shape, mask=mask, pixelwise=False, device=device, **kwargs
         )

--- a/deepinv/physics/inpainting.py
+++ b/deepinv/physics/inpainting.py
@@ -100,14 +100,14 @@ class Inpainting(DecomposablePhysics):
         if isinstance(mask, torch.nn.Parameter) or isinstance(mask, torch.Tensor):
             mask = mask.to(device)
         elif isinstance(mask, float):
-            gen = BernoulliSplittingMaskGenerator(
+            self.gen = BernoulliSplittingMaskGenerator(
                 img_size=img_size,
                 split_ratio=mask,
                 pixelwise=pixelwise,
                 device=device,
                 rng=rng,
             )
-            mask = gen.step(batch_size=None)["mask"]
+            mask = self.gen.step(batch_size=None)["mask"]
         elif mask is None:
             pass
         else:

--- a/deepinv/physics/inpainting.py
+++ b/deepinv/physics/inpainting.py
@@ -1,7 +1,7 @@
 from deepinv.physics.forward import DecomposablePhysics
 from deepinv.physics.mri import MRI
 from deepinv.physics.generator import BernoulliSplittingMaskGenerator
-from deepinv.utils.decorators import deprecated_alias
+from deepinv.utils.decorators import _deprecated_alias
 import torch
 
 
@@ -85,7 +85,7 @@ class Inpainting(DecomposablePhysics):
 
     """
 
-    @deprecated_alias(tensor_size="img_size")
+    @_deprecated_alias(tensor_size="img_size")
     def __init__(
         self,
         img_size,
@@ -101,7 +101,7 @@ class Inpainting(DecomposablePhysics):
             mask = mask.to(device)
         elif isinstance(mask, float):
             gen = BernoulliSplittingMaskGenerator(
-                img_size=img_size,
+                tensor_size=img_size,
                 split_ratio=mask,
                 pixelwise=pixelwise,
                 device=device,

--- a/deepinv/physics/inpainting.py
+++ b/deepinv/physics/inpainting.py
@@ -100,19 +100,14 @@ class Inpainting(DecomposablePhysics):
         if isinstance(mask, torch.nn.Parameter) or isinstance(mask, torch.Tensor):
             mask = mask.to(device)
         elif isinstance(mask, float):
-<<<<<<< HEAD
             gen = BernoulliSplittingMaskGenerator(
-                tensor_size=img_size,
-=======
-            self.gen = BernoulliSplittingMaskGenerator(
-                tensor_size=tensor_size,
->>>>>>> main
+                img_size=img_size,
                 split_ratio=mask,
                 pixelwise=pixelwise,
                 device=device,
                 rng=rng,
             )
-            mask = self.gen.step(batch_size=None)["mask"]
+            mask = gen.step(batch_size=None)["mask"]
         elif mask is None:
             pass
         else:

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -10,7 +10,7 @@ from deepinv.physics.structured_random import (
     generate_diagonal,
     StructuredRandom,
 )
-from deepinv.utils.decorators import deprecated_alias
+from deepinv.utils.decorators import _deprecated_alias
 
 
 class PhaseRetrieval(Physics):
@@ -140,7 +140,7 @@ class RandomPhaseRetrieval(PhaseRetrieval):
 
     """
 
-    @deprecated_alias(img_shape="img_size")
+    @_deprecated_alias(img_shape="img_size")
     def __init__(
         self,
         m,
@@ -459,7 +459,7 @@ class Ptychography(PhaseRetrieval):
     :param torch.device, str device: Device "cpu" or "gpu".
     """
 
-    @deprecated_alias(in_shape="img_size")
+    @_deprecated_alias(in_shape="img_size")
     def __init__(
         self,
         img_size=None,

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -201,7 +201,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
     The phase of the diagonal elements of the matrices :math:`D_i` are drawn from a uniform distribution in the interval :math:`[0, 2\pi]`.
 
     :param tuple img_size: shape (C, H, W) of inputs.
-    :param tuple output_shape: shape (C, H, W) of outputs.
+    :param tuple output_size: shape (C, H, W) of outputs.
     :param float n_layers: number of layers :math:`N`. If ``layers=N + 0.5``, a first :math:`F` transform is included, i.e., :math:`A(x)=|\prod_{i=1}^N (F D_i) F x|^2`.
     :param str transform: structured transform to use. Default is 'fft'.
     :param str diagonal_mode: sampling distribution for the diagonal elements. Default is 'uniform_phase'.
@@ -210,11 +210,11 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
     :param str device: Device for computation. Default is `cpu`.
     """
 
-    @_deprecated_alias(input_shape="img_size")
+    @_deprecated_alias(input_shape="img_size", output_shape="output_size")
     def __init__(
         self,
         img_size: tuple,
-        output_shape: tuple,
+        output_size: tuple,
         n_layers: int,
         transform="fft",
         diagonal_mode="uniform_phase",
@@ -223,13 +223,13 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
         device="cpu",
         **kwargs,
     ):
-        if output_shape is None:
-            output_shape = img_size
+        if output_size is None:
+            output_size = img_size
 
         self.img_size = img_size
-        self.output_shape = output_shape
+        self.output_size = output_size
         self.n = torch.prod(torch.tensor(self.img_size))
-        self.m = torch.prod(torch.tensor(self.output_shape))
+        self.m = torch.prod(torch.tensor(self.output_size))
         self.oversampling_ratio = self.m / self.n
         assert (
             n_layers % 1 == 0.5 or n_layers % 1 == 0
@@ -241,7 +241,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
         self.dtype = dtype
         self.device = device
 
-        self.mode = compare(img_size, output_shape)
+        self.mode = compare(img_size, output_size)
 
         # generate diagonal matrices
         self.diagonals = []
@@ -250,7 +250,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
             for _ in range(math.floor(self.n_layers)):
                 if self.mode == "oversampling":
                     diagonal = generate_diagonal(
-                        shape=self.output_shape,
+                        shape=self.output_size,
                         mode=diagonal_mode,
                         dtype=self.dtype,
                         device=self.device,
@@ -266,7 +266,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
         else:
             if self.mode == "oversampling":
                 diagonal = generate_diagonal(
-                    shape=self.output_shape,
+                    shape=self.output_size,
                     mode=diagonal_mode,
                     dtype=self.dtype,
                     device=self.device,
@@ -289,7 +289,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
 
         B = StructuredRandom(
             img_size=self.img_size,
-            output_shape=self.output_shape,
+            output_size=self.output_size,
             mode=self.mode,
             n_layers=self.n_layers,
             transform_func=transform_func,

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -200,7 +200,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
 
     The phase of the diagonal elements of the matrices :math:`D_i` are drawn from a uniform distribution in the interval :math:`[0, 2\pi]`.
 
-    :param tuple input_shape: shape (C, H, W) of inputs.
+    :param tuple img_size: shape (C, H, W) of inputs.
     :param tuple output_shape: shape (C, H, W) of outputs.
     :param float n_layers: number of layers :math:`N`. If ``layers=N + 0.5``, a first :math:`F` transform is included, i.e., :math:`A(x)=|\prod_{i=1}^N (F D_i) F x|^2`.
     :param str transform: structured transform to use. Default is 'fft'.
@@ -210,9 +210,10 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
     :param str device: Device for computation. Default is `cpu`.
     """
 
+    @_deprecated_alias(input_shape="img_size")
     def __init__(
         self,
-        input_shape: tuple,
+        img_size: tuple,
         output_shape: tuple,
         n_layers: int,
         transform="fft",
@@ -223,11 +224,11 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
         **kwargs,
     ):
         if output_shape is None:
-            output_shape = input_shape
+            output_shape = img_size
 
-        self.input_shape = input_shape
+        self.img_size = img_size
         self.output_shape = output_shape
-        self.n = torch.prod(torch.tensor(self.input_shape))
+        self.n = torch.prod(torch.tensor(self.img_size))
         self.m = torch.prod(torch.tensor(self.output_shape))
         self.oversampling_ratio = self.m / self.n
         assert (
@@ -240,7 +241,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
         self.dtype = dtype
         self.device = device
 
-        self.mode = compare(input_shape, output_shape)
+        self.mode = compare(img_size, output_shape)
 
         # generate diagonal matrices
         self.diagonals = []
@@ -256,7 +257,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
                     )
                 else:
                     diagonal = generate_diagonal(
-                        shape=self.input_shape,
+                        shape=self.img_size,
                         mode=diagonal_mode,
                         dtype=self.dtype,
                         device=self.device,
@@ -272,7 +273,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
                 )
             else:
                 diagonal = generate_diagonal(
-                    shape=self.input_shape,
+                    shape=self.img_size,
                     mode=diagonal_mode,
                     dtype=self.dtype,
                     device=self.device,
@@ -287,7 +288,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
             raise ValueError(f"Unimplemented transform: {transform}")
 
         B = StructuredRandom(
-            input_shape=self.input_shape,
+            img_size=self.img_size,
             output_shape=self.output_shape,
             mode=self.mode,
             n_layers=self.n_layers,

--- a/deepinv/physics/remote_sensing.py
+++ b/deepinv/physics/remote_sensing.py
@@ -2,7 +2,6 @@ from deepinv.physics.noise import GaussianNoise
 from deepinv.physics.forward import StackedLinearPhysics
 from deepinv.physics.blur import Downsampling
 from deepinv.physics.range import Decolorize
-from deepinv.optim.utils import conjugate_gradient
 from deepinv.utils.tensorlist import TensorList
 
 

--- a/deepinv/physics/singlepixel.py
+++ b/deepinv/physics/singlepixel.py
@@ -3,7 +3,7 @@ import torch
 import numpy as np
 import warnings
 import math
-from deepinv.utils.decorators import deprecated_alias
+from deepinv.utils.decorators import _deprecated_alias
 
 
 def hadamard_1d(u, normalize=True):
@@ -364,7 +364,7 @@ class SinglePixelCamera(DecomposablePhysics):
 
     """
 
-    @deprecated_alias(img_shape="img_size")
+    @_deprecated_alias(img_shape="img_size")
     def __init__(
         self,
         m,

--- a/deepinv/physics/singlepixel.py
+++ b/deepinv/physics/singlepixel.py
@@ -111,10 +111,11 @@ def hadamard_2d_ishift(x):
     return x
 
 
-def sequency_mask(img_shape, m):
+@_deprecated_alias(img_shape="img_size")
+def sequency_mask(img_size, m):
     """
     Generates a sequency-ordered binary mask for single-pixel imaging.
-    :param tuple img_shape: The shape of the input image as a tuple (C, H, W),
+    :param tuple img_size: The shape of the input image as a tuple (C, H, W),
                             where C is the number of channels, H is the height,
                             and W is the width.
     :param int m: The number of pixels to select based on sequency order.
@@ -123,7 +124,7 @@ def sequency_mask(img_shape, m):
     :rtype: torch.Tensor
     """
 
-    _, H, W = img_shape
+    _, H, W = img_size
     n = H * W
 
     indexes = sequency_order(n)[:m]
@@ -131,23 +132,24 @@ def sequency_mask(img_shape, m):
     i = i.flatten(order="F")
     j = j.flatten(order="F")
 
-    mask = torch.zeros((1, *img_shape))
+    mask = torch.zeros((1, *img_size))
     mask[:, :, i[indexes], j[indexes]] = 1.0
 
     return mask
 
 
-def old_sequency_mask(img_shape, m):
+@_deprecated_alias(img_shape="img_size")
+def old_sequency_mask(img_size, m):
     """
     Generates a binary mask for a single-pixel camera based on a sequency ordering.
-    :param tuple img_shape: The shape of the input image as a tuple (C, H, W), where C is the number of channels,
+    :param tuple img_size: The shape of the input image as a tuple (C, H, W), where C is the number of channels,
                             H is the height, and W is the width.
     :param int m: The number of pixels to include in the mask, selected based on the sequency ordering.
     :return: A binary mask of shape (1, C, H, W) with `m` pixels set to 1 and the rest set to 0.
     :rtype: torch.Tensor
     """
 
-    _, H, W = img_shape
+    _, H, W = img_size
     n = H * W
 
     indexes = get_permutation_list(n)[:m]
@@ -155,7 +157,7 @@ def old_sequency_mask(img_shape, m):
     i = i.flatten(order="F")
     j = j.flatten(order="F")
 
-    mask = torch.zeros((1, *img_shape))
+    mask = torch.zeros((1, *img_size))
     mask[:, :, i[indexes], j[indexes]] = 1.0
 
     return mask
@@ -200,10 +202,10 @@ def cake_cutting_order(n):
     return np.argsort(seq)
 
 
-def cake_cutting_mask(img_shape, m):
+def cake_cutting_mask(img_size, m):
     """
     Generates a "cake cutting" mask for single-pixel imaging.
-    :param tuple img_shape: A tuple representing the shape of the input image
+    :param tuple img_size: A tuple representing the shape of the input image
                             in the format (channels, height, width). The height
                             and width must be equal.
     :param int m: The number of pixels to include in the mask.
@@ -213,7 +215,7 @@ def cake_cutting_mask(img_shape, m):
     :raises Warning: If the height and width of the image are not equal.
     """
 
-    _, H, W = img_shape
+    _, H, W = img_size
 
     if H != W:
         warnings.warn("Image height and width must be equal for cake cutting mask.")
@@ -227,7 +229,7 @@ def cake_cutting_mask(img_shape, m):
     i = i.flatten(order="F")
     j = j.flatten(order="F")
 
-    mask = torch.zeros((1, *img_shape))
+    mask = torch.zeros((1, *img_size))
     mask[:, :, i[indexes], j[indexes]] = 1.0
 
     return mask
@@ -259,10 +261,11 @@ def diagonal_index_matrix(H: int, W: int) -> torch.Tensor:
     return flat_A.view(H, W)
 
 
-def zig_zag_mask(img_shape, m):
+@_deprecated_alias(img_shape="img_size")
+def zig_zag_mask(img_size, m):
     """
     Generates a zig-zag mask for an image of a given shape.
-    :param tuple img_shape: A tuple representing the shape of the input image
+    :param tuple img_size: A tuple representing the shape of the input image
                             in the format (C, H, W), where C is the number of
                             channels, H is the height, and W is the width.
     :param int m: The number of elements to include in the zig-zag mask.
@@ -271,20 +274,21 @@ def zig_zag_mask(img_shape, m):
     :rtype: torch.Tensor
     """
 
-    _, H, W = img_shape
+    _, H, W = img_size
     mask = diagonal_index_matrix(H, W)
     mask = mask < m
     mask = mask.float()
-    mask = mask.unsqueeze(0).repeat(1, img_shape[0], 1, 1)
+    mask = mask.unsqueeze(0).repeat(1, img_size[0], 1, 1)
     mask = hadamard_2d_ishift(mask)
 
     return mask
 
 
-def xy_mask(img_shape, m):
+@_deprecated_alias(img_shape="img_size")
+def xy_mask(img_size, m):
     """
     Generates a 2D mask based on the spatial coordinates of an image and a given threshold.
-    :param tuple img_shape: A tuple representing the shape of the input image in the format
+    :param tuple img_size: A tuple representing the shape of the input image in the format
                             (channels, height, width).
     :param int m: The threshold value used to determine the mask size. Pixels with indices
                   less than or equal to `m` will be included in the mask.
@@ -293,7 +297,7 @@ def xy_mask(img_shape, m):
     :rtype: torch.Tensor
     """
 
-    _, H, W = img_shape
+    _, H, W = img_size
 
     X, Y = torch.meshgrid(torch.arange(H), torch.arange(W), indexing="ij")
     index_matrix = X * Y + (X**2 + Y**2) / 4
@@ -306,7 +310,7 @@ def xy_mask(img_shape, m):
     mask = mask.view(H, W) <= m
     mask = mask.float()
 
-    mask = mask.unsqueeze(0).repeat(1, img_shape[0], 1, 1)
+    mask = mask.unsqueeze(0).repeat(1, img_size[0], 1, 1)
     mask = hadamard_2d_ishift(mask)
 
     return mask

--- a/deepinv/physics/structured_random.py
+++ b/deepinv/physics/structured_random.py
@@ -110,7 +110,7 @@ class StructuredRandom(LinearPhysics):
 
     where :math:`F` is a matrix representing a structured transform, :math:`D_i` are diagonal matrices, and :math:`N` refers to the number of layers. It is also possible to replace :math:`x` with :math:`Fx` as an additional 0.5 layer.
 
-    :param tuple img_shape: input shape. If (C, H, W), i.e., the input is a 2D signal with C channels, then zero-padding will be used for oversampling and cropping will be used for undersampling.
+    :param tuple img_size: input shape. If (C, H, W), i.e., the input is a 2D signal with C channels, then zero-padding will be used for oversampling and cropping will be used for undersampling.
     :param tuple output_shape: shape of outputs.
     :param float n_layers: number of layers :math:`N`. If ``layers=N + 0.5``, a first :math`F` transform is included, ie :math:`A(x)=|\prod_{i=1}^N (F D_i) F x|^2`. Default is 1.
     :param Callable transform_func: structured transform function. Default is :func:`deepinv.physics.functional.dst1`.

--- a/deepinv/sampling/diffusion.py
+++ b/deepinv/sampling/diffusion.py
@@ -93,7 +93,7 @@ class DDRM(Reconstructor):
         >>> seed = torch.cuda.manual_seed(0) # Random seed for reproducibility on GPU
         >>> x = 0.5 * torch.ones(1, 3, 32, 32, device=device) # Define plain gray 32x32 image
         >>> physics = dinv.physics.Inpainting(
-        ...   mask=0.5, tensor_size=(3, 32, 32),
+        ...   mask=0.5, img_size=(3, 32, 32),
         ...   noise_model=dinv.physics.GaussianNoise(0.1),
         ...   device=device,
         ... )
@@ -256,7 +256,7 @@ class DiffPIR(Reconstructor):
         >>> device = dinv.utils.get_freer_gpu(verbose=False) if torch.cuda.is_available() else 'cpu'
         >>> x = 0.5 * torch.ones(1, 3, 32, 32, device=device) # Define a plain gray 32x32 image
         >>> physics = dinv.physics.Inpainting(
-        ...   mask=0.5, tensor_size=(3, 32, 32),
+        ...   mask=0.5, img_size=(3, 32, 32),
         ...   noise_model=dinv.physics.GaussianNoise(0.1),
         ...   device=device
         ... )

--- a/deepinv/tests/test_adversarial.py
+++ b/deepinv/tests/test_adversarial.py
@@ -42,7 +42,7 @@ def choose_adversarial_combo(combo_name, imsize, device):
         dis_loss = adversarial.SupAdversarialDiscriminatorLoss(device=device)
     elif combo_name == "UAIR":
         generator = unet
-        discrimin = dinv.models.ESRGANDiscriminator(input_shape=imsize).to(device)
+        discrimin = dinv.models.ESRGANDiscriminator(img_size=imsize).to(device)
         gen_loss = adversarial.UAIRGeneratorLoss(device=device)
         dis_loss = adversarial.UnsupAdversarialDiscriminatorLoss(device=device)
     elif combo_name == "CSGM":

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -324,7 +324,7 @@ def test_FastMRISliceDataset(download_fastmri):
     # Raw data shape
     kspace_shape = (512, 213)
     n_coils = 4
-    img_shape = (213, 213)
+    img_size = (213, 213)
 
     # Clean data shape
     rss_shape = (320, 320)
@@ -350,7 +350,7 @@ def test_FastMRISliceDataset(download_fastmri):
     target1, kspace1 = dataset[0]
     target2, kspace2 = dataset[1]
 
-    assert target1.shape == (1, *img_shape)
+    assert target1.shape == (1, *img_size)
     assert kspace1.shape == (2, n_coils, *kspace_shape)
     assert not torch.all(target1 == target2)
     assert not torch.all(kspace1 == kspace2)
@@ -359,13 +359,13 @@ def test_FastMRISliceDataset(download_fastmri):
     physics = MultiCoilMRI(
         mask=torch.ones(kspace_shape),
         coil_maps=torch.ones(kspace_shape, dtype=torch.complex64),
-        img_size=img_shape,
+        img_size=img_size,
     )
     rss1 = physics.A_adjoint(kspace1.unsqueeze(0), rss=True, crop=True)
     assert torch.allclose(target1.unsqueeze(0), rss1)
 
     # Test singlecoil MRI mag works
-    physics = MRI(mask=torch.ones(kspace_shape), img_size=img_shape)
+    physics = MRI(mask=torch.ones(kspace_shape), img_size=img_size)
     mag1 = physics.A_adjoint(kspace1.unsqueeze(0)[:, :, 0], mag=True, crop=True)
     assert target1.unsqueeze(0).shape == mag1.shape
 
@@ -397,9 +397,9 @@ def download_CMRxRecon():
 def test_CMRxReconSliceDataset(download_CMRxRecon):
     from math import prod
 
-    img_shape = (12, 512, 256)
+    img_size = (12, 512, 256)
 
-    physics_generator = GaussianMaskGenerator(img_shape)
+    physics_generator = GaussianMaskGenerator(img_size)
 
     data_dir = download_CMRxRecon
 
@@ -423,7 +423,7 @@ def test_CMRxReconSliceDataset(download_CMRxRecon):
     target1, kspace1, params1 = dataset[0]
     target2, kspace2, params2 = dataset[1]
 
-    assert target1.shape == kspace1.shape == (2, *img_shape)
+    assert target1.shape == kspace1.shape == (2, *img_size)
     assert not torch.all(target1 == target2)
     assert not torch.all(kspace1 == kspace2)
     assert not torch.all(params1["mask"] == params2["mask"])
@@ -434,7 +434,7 @@ def test_CMRxReconSliceDataset(download_CMRxRecon):
     assert torch.all(params1_again["mask"] == params1["mask"])
 
     # Loaded kspace is directly compatible with deepinv physics
-    physics = DynamicMRI(img_size=img_shape)
+    physics = DynamicMRI(img_size=img_size)
     kspace1_dinv = physics(
         target1.unsqueeze(0), mask=params1["mask"].unsqueeze(0)
     ).squeeze(0)

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -326,6 +326,7 @@ def test_FastMRISliceDataset(download_fastmri):
     kspace_shape = (512, 213)
     n_coils = 4
     n_slices = 16
+    img_size = (213, 213)
 
     # Clean data shape
     rss_shape = (320, 320)

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -325,12 +325,7 @@ def test_FastMRISliceDataset(download_fastmri):
     # Raw data shape
     kspace_shape = (512, 213)
     n_coils = 4
-<<<<<<< HEAD
-    img_size = (213, 213)
-=======
     n_slices = 16
-    img_shape = (213, 213)
->>>>>>> main
 
     # Clean data shape
     rss_shape = (320, 320)

--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -9,17 +9,17 @@ def test_deprecated_physics_image_size():
     rng = torch.Generator("cpu").manual_seed(0)
     device = "cpu"
 
-    # CS: img_shape is changed to img_size
-    with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
-        p = dinv.physics.CompressedSensing(
-            m=m, img_shape=img_size, device="cpu", compute_inverse=True, rng=rng
-        )
-        assert p.img_size == img_size
-
     # Inpainting: tensor_size is changed to img_size
     with pytest.warns(DeprecationWarning, match="tensor_size.*deprecated"):
         p = dinv.physics.Inpainting(
             tensor_size=img_size, mask=0.5, device=device, rng=rng
+        )
+        assert p.img_size == img_size
+
+    # CS: img_shape is changed to img_size
+    with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
+        p = dinv.physics.CompressedSensing(
+            m=m, img_shape=img_size, device="cpu", compute_inverse=True, rng=rng
         )
         assert p.img_size == img_size
 
@@ -35,9 +35,27 @@ def test_deprecated_physics_image_size():
         p = dinv.physics.RandomPhaseRetrieval(m=m, img_shape=img_size, device=device)
         assert p.img_size == img_size
 
-    # RandomPhaseRetrieval: img_shape is changed to img_size
+    # Ptychography: in_shape is changed to img_size
     with pytest.warns(DeprecationWarning, match="in_shape.*deprecated"):
         p = dinv.physics.Ptychography(
             in_shape=img_size, probe=None, shifts=None, device=device
+        )
+        assert p.img_size == img_size
+
+    # Ptychography: input_shape is changed to img_size
+    with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
+        p = dinv.physics.StructuredRandomPhaseRetrieval(
+            input_shape=img_size, output_shape=img_size, n_layers=2, device=device
+        )
+        assert p.img_size == img_size
+
+    # Ptychography: img_shape is changed to img_size
+    with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
+        p = dinv.physics.RandomPhaseRetrieval(m=500, img_shape=img_size, device=device)
+        assert p.img_size == img_size
+
+    with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
+        p = dinv.physics.StructuredRandom(
+            input_shape=img_size, output_shape=img_size, device=device
         )
         assert p.img_size == img_size

--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -83,6 +83,14 @@ def test_deprecated_physics_image_size():
         )
         assert p.img_size == img_size
 
+        p = dinv.physics.generator.inpainting.MultiplicativeSplittingMaskGenerator(
+            tensor_size=img_size,
+            split_generator=dinv.physics.generator.GaussianMaskGenerator(
+                img_size=img_size, acceleration=2
+            ),
+        )
+        assert p.img_size == img_size
+
     # GAN Discriminator
     with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
         model = dinv.models.gan.ESRGANDiscriminator(input_shape=img_size)
@@ -90,9 +98,11 @@ def test_deprecated_physics_image_size():
 
     # Loss
     with pytest.warns(DeprecationWarning, match="tensor_size.*deprecated"):
-        loss = dinv.loss.Phase2PhaseLoss(tensor_size=(2, 4, 4, 4), dynamic_model=False)
+        loss = dinv.loss.mri.Phase2PhaseLoss(
+            tensor_size=(2, 4, 4, 4), dynamic_model=False
+        )
         assert loss.img_size == (2, 4, 4, 4)
-        loss = dinv.loss.Artifact2ArtifactLoss(
+        loss = dinv.loss.mri.Artifact2ArtifactLoss(
             tensor_size=(2, 4, 4, 4), dynamic_model=False
         )
         assert loss.img_size == (2, 4, 4, 4)

--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -87,3 +87,12 @@ def test_deprecated_physics_image_size():
     with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
         model = dinv.models.gan.ESRGANDiscriminator(input_shape=img_size)
         assert model.img_size == img_size
+
+    # Loss
+    with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
+        loss = dinv.loss.Phase2PhaseLoss(tensor_size=(2, 4, 4, 4), dynamic_model=False)
+        assert loss.img_size == (2, 4, 4, 4)
+        loss = dinv.loss.Artifact2ArtifactLoss(
+            tensor_size=(2, 4, 4, 4), dynamic_model=False
+        )
+        assert loss.img_size == (2, 4, 4, 4)

--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -52,10 +52,11 @@ def test_deprecated_physics_image_size():
 
     # StructuredRandomPhaseRetrieval: input_shape is changed to img_size
     with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
-        p = dinv.physics.StructuredRandomPhaseRetrieval(
-            input_shape=img_size, output_shape=img_size, n_layers=2, device=device
-        )
-        assert p.img_size == img_size
+        with pytest.warns(DeprecationWarning, match="output_shape.*deprecated"):
+            p = dinv.physics.StructuredRandomPhaseRetrieval(
+                input_shape=img_size, output_shape=img_size, n_layers=2, device=device
+            )
+            assert p.img_size == img_size
 
     # RandomPhaseRetrieval: img_shape is changed to img_size
     with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
@@ -64,10 +65,11 @@ def test_deprecated_physics_image_size():
 
     # StructuredRandom: input_shape is changed to img_size
     with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
-        p = dinv.physics.StructuredRandom(
-            input_shape=img_size, output_shape=img_size, device=device
-        )
-        assert p.img_size == img_size
+        with pytest.warns(DeprecationWarning, match="output_shape.*deprecated"):
+            p = dinv.physics.StructuredRandom(
+                input_shape=img_size, output_shape=img_size, device=device
+            )
+            assert p.img_size == img_size
 
     # Inpainting mask generators: tensor_size is changed to img_size
     with pytest.warns(DeprecationWarning, match="tensor_size.*deprecated"):
@@ -121,4 +123,38 @@ def test_deprecated_physics_image_size():
         with pytest.warns(DeprecationWarning, match="input_size.*deprecated"):
             model = dinv.models.DeepImagePrior(
                 generator=generator, input_size=(3, 4, 4)
+            )
+
+    # DEPRECATED FUNCTION ARGUMENT TESTS
+    # single_pixel_camera
+    with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
+        mask = dinv.physics.singlepixel.sequency_mask(img_shape=img_size, m=4)
+        assert mask.shape[1:] == img_size
+
+        mask = dinv.physics.singlepixel.old_sequency_mask(img_shape=img_size, m=4)
+        assert mask.shape[1:] == img_size
+
+        mask = dinv.physics.singlepixel.zig_zag_mask(img_shape=img_size, m=4)
+        assert mask.shape[1:] == img_size
+
+        mask = dinv.physics.singlepixel.xy_mask(img_shape=img_size, m=4)
+        assert mask.shape[1:] == img_size
+
+    # structured random
+    with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
+        with pytest.warns(DeprecationWarning, match="output_shape.*deprecated"):
+            dinv.physics.structured_random.compare(
+                input_shape=img_size, output_shape=img_size
+            )
+
+            dinv.physics.structured_random.padding(
+                torch.randn((1,) + img_size),
+                input_shape=img_size,
+                output_shape=img_size,
+            )
+
+            dinv.physics.structured_random.trimming(
+                torch.randn((1,) + img_size),
+                input_shape=img_size,
+                output_shape=img_size,
             )

--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -1,0 +1,43 @@
+import pytest
+import deepinv as dinv
+import torch
+
+
+def test_deprecated_physics_image_size():
+    img_size = (3, 16, 32)
+    m = 30
+    rng = torch.Generator("cpu").manual_seed(0)
+    device = "cpu"
+
+    # CS: img_shape is changed to img_size
+    with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
+        p = dinv.physics.CompressedSensing(
+            m=m, img_shape=img_size, device="cpu", compute_inverse=True, rng=rng
+        )
+        assert p.img_size == img_size
+
+    # Inpainting: tensor_size is changed to img_size
+    with pytest.warns(DeprecationWarning, match="tensor_size.*deprecated"):
+        p = dinv.physics.Inpainting(
+            tensor_size=img_size, mask=0.5, device=device, rng=rng
+        )
+        assert p.img_size == img_size
+
+    # SinglePixelCamera: img_shape is changed to img_size
+    with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
+        p = dinv.physics.SinglePixelCamera(
+            m=m, fast=True, img_shape=img_size, device=device, rng=rng
+        )
+        assert p.img_size == img_size
+
+    # RandomPhaseRetrieval: img_shape is changed to img_size
+    with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
+        p = dinv.physics.RandomPhaseRetrieval(m=m, img_shape=img_size, device=device)
+        assert p.img_size == img_size
+
+    # RandomPhaseRetrieval: img_shape is changed to img_size
+    with pytest.warns(DeprecationWarning, match="in_shape.*deprecated"):
+        p = dinv.physics.Ptychography(
+            in_shape=img_size, probe=None, shifts=None, device=device
+        )
+        assert p.img_size == img_size

--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -42,20 +42,43 @@ def test_deprecated_physics_image_size():
         )
         assert p.img_size == img_size
 
-    # Ptychography: input_shape is changed to img_size
+    # StructuredRandomPhaseRetrieval: input_shape is changed to img_size
     with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
         p = dinv.physics.StructuredRandomPhaseRetrieval(
             input_shape=img_size, output_shape=img_size, n_layers=2, device=device
         )
         assert p.img_size == img_size
 
-    # Ptychography: img_shape is changed to img_size
+    # RandomPhaseRetrieval: img_shape is changed to img_size
     with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
         p = dinv.physics.RandomPhaseRetrieval(m=500, img_shape=img_size, device=device)
         assert p.img_size == img_size
 
+    # StructuredRandom: input_shape is changed to img_size
     with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
         p = dinv.physics.StructuredRandom(
             input_shape=img_size, output_shape=img_size, device=device
+        )
+        assert p.img_size == img_size
+
+    # Inpainting mask generators: tensor_size is changed to img_size
+    with pytest.warns(DeprecationWarning, match="tensor_size.*deprecated"):
+        p = dinv.physics.generator.inpainting.Artifact2ArtifactSplittingMaskGenerator(
+            tensor_size=img_size, device=device
+        )
+        assert p.img_size == img_size
+
+        p = dinv.physics.generator.inpainting.BernoulliSplittingMaskGenerator(
+            tensor_size=img_size, split_ratio=0.5, device=device
+        )
+        assert p.img_size == img_size
+
+        p = dinv.physics.generator.inpainting.GaussianSplittingMaskGenerator(
+            tensor_size=img_size, split_ratio=0.5, device=device
+        )
+        assert p.img_size == img_size
+
+        p = dinv.physics.generator.inpainting.Phase2PhaseSplittingMaskGenerator(
+            tensor_size=img_size, device=device
         )
         assert p.img_size == img_size

--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -89,10 +89,18 @@ def test_deprecated_physics_image_size():
         assert model.img_size == img_size
 
     # Loss
-    with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
+    with pytest.warns(DeprecationWarning, match="tensor_size.*deprecated"):
         loss = dinv.loss.Phase2PhaseLoss(tensor_size=(2, 4, 4, 4), dynamic_model=False)
         assert loss.img_size == (2, 4, 4, 4)
         loss = dinv.loss.Artifact2ArtifactLoss(
             tensor_size=(2, 4, 4, 4), dynamic_model=False
         )
         assert loss.img_size == (2, 4, 4, 4)
+
+    # DIP
+    with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):
+        generator = dinv.models.ConvDecoder(img_shape=(3, 4, 4))
+        with pytest.warns(DeprecationWarning, match="input_size.*deprecated"):
+            model = dinv.models.DeepImagePrior(
+                generator=generator, input_size=(3, 4, 4)
+            )

--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -1,6 +1,7 @@
 import pytest
 import deepinv as dinv
 import torch
+import warnings
 
 
 def test_deprecated_physics_image_size():
@@ -15,6 +16,13 @@ def test_deprecated_physics_image_size():
             tensor_size=img_size, mask=0.5, device=device, rng=rng
         )
         assert p.img_size == img_size
+
+    # test_no_warning_with_correct_parameter
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        p = dinv.physics.Inpainting(img_size=img_size, mask=0.5, device=device, rng=rng)
+        assert p.img_size == img_size
+        assert len(record) == 0
 
     # CS: img_shape is changed to img_size
     with pytest.warns(DeprecationWarning, match="img_shape.*deprecated"):

--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -82,3 +82,8 @@ def test_deprecated_physics_image_size():
             tensor_size=img_size, device=device
         )
         assert p.img_size == img_size
+
+    # GAN Discriminator
+    with pytest.warns(DeprecationWarning, match="input_shape.*deprecated"):
+        model = dinv.models.gan.ESRGANDiscriminator(input_shape=img_size)
+        assert model.img_size == img_size

--- a/deepinv/tests/test_generators.py
+++ b/deepinv/tests/test_generators.py
@@ -440,7 +440,7 @@ def test_mri_generator(generator_name, img_size, batch_size, acc, center_fractio
 def choose_inpainting_generator(name, img_size, split_ratio, pixelwise, device):
     if name == "bernoulli":
         return dinv.physics.generator.BernoulliSplittingMaskGenerator(
-            tensor_size=img_size,
+            img_size=img_size,
             split_ratio=split_ratio,
             device=device,
             pixelwise=pixelwise,
@@ -448,7 +448,7 @@ def choose_inpainting_generator(name, img_size, split_ratio, pixelwise, device):
         )
     elif name == "gaussian":
         return dinv.physics.generator.GaussianSplittingMaskGenerator(
-            tensor_size=img_size,
+            img_size=img_size,
             split_ratio=split_ratio,
             device=device,
             pixelwise=pixelwise,

--- a/deepinv/tests/test_generators.py
+++ b/deepinv/tests/test_generators.py
@@ -372,7 +372,7 @@ def choose_inpainting_generator(name, img_size, split_ratio, pixelwise, device, 
             rng=rng,
         )
         return dinv.physics.generator.MultiplicativeSplittingMaskGenerator(
-            tensor_size=img_size,
+            img_size=img_size,
             split_generator=mri_gen,
         )
     else:

--- a/deepinv/tests/test_loss.py
+++ b/deepinv/tests/test_loss.py
@@ -249,7 +249,7 @@ def imsize():
 @pytest.fixture
 def physics(imsize, device):
     # choose a forward operator
-    return dinv.physics.Inpainting(tensor_size=imsize, mask=0.5, device=device)
+    return dinv.physics.Inpainting(img_size=imsize, mask=0.5, device=device)
 
 
 @pytest.fixture

--- a/deepinv/tests/test_loss_train.py
+++ b/deepinv/tests/test_loss_train.py
@@ -26,7 +26,7 @@ def test_generate_dataset(tmp_path, imsize, device, physics_name):
     test_dataset = DummyCircles(samples=N, imsize=imsize)
 
     if physics_name == "inpainting":
-        physics = Inpainting(mask=0.5, tensor_size=imsize, device=device)
+        physics = Inpainting(mask=0.5, img_size=imsize, device=device)
         y_shape = imsize
     elif physics_name == "pansharpen":  # proxy for StackedPhysics
         physics = Pansharpen(img_size=imsize, factor=2, device=device)
@@ -82,11 +82,11 @@ def test_generate_dataset_physics_generator(
     x_dataset = DummyDataset()
 
     if physics_combo == "single_physics_no_gen":
-        physics = Inpainting(tensor_size=imsize)
+        physics = Inpainting(img_size=imsize)
         physics_generator = None
     elif physics_combo == "single_physics_with_gen":
         if phys_gen == "bernoulli_mask":
-            physics = Inpainting(tensor_size=imsize)
+            physics = Inpainting(img_size=imsize)
             physics_generator = BernoulliSplittingMaskGenerator(imsize, 0.6)
         elif phys_gen == "sigma":
             physics = GaussianNoise()
@@ -267,7 +267,7 @@ def test_optim_algo(name_algo, imsize, device):
     train_dataset = DummyCircles(samples=N, imsize=imsize)
     test_dataset = DummyCircles(samples=N, imsize=imsize)
 
-    physics = dinv.physics.Inpainting(mask=0.5, tensor_size=imsize, device=device)
+    physics = dinv.physics.Inpainting(mask=0.5, img_size=imsize, device=device)
 
     train_dataloader = DataLoader(
         train_dataset, batch_size=2, num_workers=1, shuffle=True

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -281,7 +281,7 @@ def test_data_fidelity_amplitude_loss(device):
             (1, 1, 3, 3), dtype=torch.cfloat, device=device, requires_grad=True
         )
         physics = dinv.physics.RandomPhaseRetrieval(
-            m=10, img_shape=(1, 3, 3), device=device
+            m=10, img_size=(1, 3, 3), device=device
         )
         loss = AmplitudeLoss()
         func = lambda x: loss(x, torch.ones_like(physics(x)), physics)[0]

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -374,7 +374,7 @@ def find_operator(name, device):
     elif name == "structured_random":
         img_size = (1, 8, 8)
         p = dinv.physics.StructuredRandom(
-            input_shape=img_size, output_shape=img_size, device=device
+            img_size=img_size, output_shape=img_size, device=device
         )
     elif name == "ptychography_linear":
         img_size = (1, 32, 32)
@@ -439,7 +439,7 @@ def find_phase_retrieval_operator(name, device):
     elif name == "structured_random_phase_retrieval":
         img_size = (1, 10, 10)
         p = dinv.physics.StructuredRandomPhaseRetrieval(
-            input_shape=img_size, output_shape=img_size, n_layers=2, device=device
+            img_size=img_size, output_shape=img_size, n_layers=2, device=device
         )
     else:
         raise Exception("The inverse problem chosen doesn't exist")

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -374,7 +374,7 @@ def find_operator(name, device):
     elif name == "structured_random":
         img_size = (1, 8, 8)
         p = dinv.physics.StructuredRandom(
-            img_size=img_size, output_shape=img_size, device=device
+            img_size=img_size, output_size=img_size, device=device
         )
     elif name == "ptychography_linear":
         img_size = (1, 32, 32)
@@ -439,7 +439,7 @@ def find_phase_retrieval_operator(name, device):
     elif name == "structured_random_phase_retrieval":
         img_size = (1, 10, 10)
         p = dinv.physics.StructuredRandomPhaseRetrieval(
-            img_size=img_size, output_shape=img_size, n_layers=2, device=device
+            img_size=img_size, output_size=img_size, n_layers=2, device=device
         )
     else:
         raise Exception("The inverse problem chosen doesn't exist")

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -106,7 +106,7 @@ def find_operator(name, device):
     if name == "CS":
         m = 30
         p = dinv.physics.CompressedSensing(
-            m=m, img_shape=img_size, device=device, compute_inverse=True, rng=rng
+            m=m, img_size=img_size, device=device, compute_inverse=True, rng=rng
         )
         norm = (
             1 + np.sqrt(np.prod(img_size) / m)
@@ -116,7 +116,7 @@ def find_operator(name, device):
             m=20,
             fast=True,
             channelwise=True,
-            img_shape=img_size,
+            img_size=img_size,
             device=device,
             rng=rng,
         )
@@ -128,9 +128,7 @@ def find_operator(name, device):
         p = dinv.physics.CompressiveSpectralImaging(img_size, device=device, rng=rng)
         norm = 1 / img_size[0]
     elif name == "inpainting":
-        p = dinv.physics.Inpainting(
-            tensor_size=img_size, mask=0.5, device=device, rng=rng
-        )
+        p = dinv.physics.Inpainting(img_size=img_size, mask=0.5, device=device, rng=rng)
     elif name == "demosaicing":
         p = dinv.physics.Demosaicing(img_size=img_size, device=device)
         norm = 1.0
@@ -209,13 +207,13 @@ def find_operator(name, device):
         norm = 1.4
     elif name == "fast_singlepixel":
         p = dinv.physics.SinglePixelCamera(
-            m=20, fast=True, img_shape=img_size, device=device, rng=rng
+            m=20, fast=True, img_size=img_size, device=device, rng=rng
         )
     elif name == "fast_singlepixel_cake_cutting":
         p = dinv.physics.SinglePixelCamera(
             m=20,
             fast=True,
-            img_shape=img_size,
+            img_size=img_size,
             device=device,
             rng=rng,
             ordering="cake_cutting",
@@ -224,20 +222,20 @@ def find_operator(name, device):
         p = dinv.physics.SinglePixelCamera(
             m=20,
             fast=True,
-            img_shape=img_size,
+            img_size=img_size,
             device=device,
             rng=rng,
             ordering="zig_zag",
         )
     elif name == "fast_singlepixel_xy":
         p = dinv.physics.SinglePixelCamera(
-            m=20, fast=True, img_shape=img_size, device=device, rng=rng, ordering="xy"
+            m=20, fast=True, img_size=img_size, device=device, rng=rng, ordering="xy"
         )
     elif name == "fast_singlepixel_old_sequency":
         p = dinv.physics.SinglePixelCamera(
             m=20,
             fast=True,
-            img_shape=img_size,
+            img_size=img_size,
             device=device,
             rng=rng,
             ordering="old_sequency",
@@ -245,7 +243,7 @@ def find_operator(name, device):
     elif name == "singlepixel":
         m = 20
         p = dinv.physics.SinglePixelCamera(
-            m=m, fast=False, img_shape=img_size, device=device, rng=rng
+            m=m, fast=False, img_size=img_size, device=device, rng=rng
         )
         norm = (
             1 + np.sqrt(np.prod(img_size) / m)
@@ -326,7 +324,7 @@ def find_operator(name, device):
         m = 50
         p = dinv.physics.CompressedSensing(
             m=m,
-            img_shape=img_size,
+            img_size=img_size,
             dtype=torch.cdouble,
             device=device,
             compute_inverse=True,
@@ -429,11 +427,11 @@ def find_phase_retrieval_operator(name, device):
     """
     if name == "random_phase_retrieval":
         img_size = (1, 10, 10)
-        p = dinv.physics.RandomPhaseRetrieval(m=500, img_shape=img_size, device=device)
+        p = dinv.physics.RandomPhaseRetrieval(m=500, img_size=img_size, device=device)
     elif name == "ptychography":
         img_size = (1, 32, 32)
         p = dinv.physics.Ptychography(
-            in_shape=img_size,
+            img_size=img_size,
             probe=None,
             shifts=None,
             device=device,
@@ -456,7 +454,7 @@ def test_stacking(device):
     :return: asserts error is less than 1e-3
     """
     imsize = (2, 5, 5)
-    p1 = dinv.physics.Inpainting(mask=0.5, tensor_size=imsize, device=device)
+    p1 = dinv.physics.Inpainting(mask=0.5, img_size=imsize, device=device)
     p2 = dinv.physics.Physics(A=lambda x: x**2)
     p3 = p1.stack(p2)
 
@@ -773,7 +771,7 @@ def test_concatenation(name, device):
     y = physics(x)
     physics = (
         dinv.physics.Inpainting(
-            tensor_size=y.size()[1:], mask=0.5, pixelwise=False, device=device
+            img_size=y.size()[1:], mask=0.5, pixelwise=False, device=device
         )
         * physics
     )
@@ -813,9 +811,7 @@ def test_phase_retrieval_Avjp(device):
     # essential to enable autograd
     torch.set_grad_enabled(True)
     x = torch.randn((1, 1, 3, 3), dtype=torch.cfloat, device=device, requires_grad=True)
-    physics = dinv.physics.RandomPhaseRetrieval(
-        m=10, img_shape=(1, 3, 3), device=device
-    )
+    physics = dinv.physics.RandomPhaseRetrieval(m=10, img_size=(1, 3, 3), device=device)
     loss = L2()
     func = lambda x: loss(x, torch.ones_like(physics(x)), physics)[0]
     grad_value = torch.func.grad(func)(x)
@@ -839,7 +835,7 @@ def test_linear_physics_Avjp(device, rng):
         generator=rng,
         requires_grad=True,
     )
-    physics = dinv.physics.CompressedSensing(m=10, img_shape=(1, 3, 3), device=device)
+    physics = dinv.physics.CompressedSensing(m=10, img_size=(1, 3, 3), device=device)
     loss = L2()
     func = lambda x: loss(x, torch.ones_like(physics(x)), physics)[0]
     grad_value = torch.func.grad(func)(x)
@@ -929,7 +925,7 @@ def test_noise_domain_inpainting(device):
     mask[1, 1, 1] = 0
     mask[2, 2, 2] = 0
 
-    physics = dinv.physics.Inpainting(tensor_size=x.shape, mask=mask, device=device)
+    physics = dinv.physics.Inpainting(img_size=x.shape, mask=mask, device=device)
     physics.noise_model = choose_noise("Gaussian")
     y1 = physics(
         x

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -154,7 +154,7 @@ def test_algo_inpaint(name_algo, device):
     mask = torch.ones_like(x)
     mask[:, :, 10:20, 10:20] = 0
 
-    physics = dinv.physics.Inpainting(mask=mask, tensor_size=x.shape[1:], device=device)
+    physics = dinv.physics.Inpainting(mask=mask, img_size=x.shape[1:], device=device)
 
     y = physics(x)
 
@@ -271,7 +271,7 @@ def test_sde(device):
                     resize_mode="resize",
                 ).to(device)
                 physics = dinv.physics.Inpainting(
-                    tensor_size=x.shape[1:], mask=0.5, device=device
+                    img_size=x.shape[1:], mask=0.5, device=device
                 )
                 y = physics(x)
 

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -136,7 +136,7 @@ def test_get_samples(
         )
         param_name = "filter"
     elif physics_type == "inpainting":
-        physics = dinv.physics.Inpainting(tensor_size=imsize, device=device, rng=rng)
+        physics = dinv.physics.Inpainting(img_size=imsize, device=device, rng=rng)
         param_name = "mask"
 
     # Define physics generator
@@ -575,7 +575,7 @@ def test_dataloader_formats(
     model = dummy_model
     dataset = DummyDataset()
     dataloader = DataLoader(dataset, batch_size=1)
-    physics = dinv.physics.Inpainting(tensor_size=imsize, mask=1.0, device=device)
+    physics = dinv.physics.Inpainting(img_size=imsize, mask=1.0, device=device)
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-1)
     losses = dinv.loss.MCLoss() if not ground_truth else dinv.loss.SupLoss()
 
@@ -656,7 +656,7 @@ def test_early_stop(
     train_data, eval_data = dummy_dataset, dummy_dataset
     dataloader = DataLoader(train_data, batch_size=2)
     eval_dataloader = DataLoader(eval_data, batch_size=2)
-    physics = dinv.physics.Inpainting(tensor_size=imsize, device=device, mask=0.5)
+    physics = dinv.physics.Inpainting(img_size=imsize, device=device, mask=0.5)
     optimizer = torch.optim.Adam(model.parameters(), lr=1)
     losses = dinv.loss.MCLoss()
     trainer = dinv.Trainer(

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -540,7 +540,7 @@ def test_dataloader_formats(
 
     # Offline generator at low split ratio
     generator = dinv.physics.generator.BernoulliSplittingMaskGenerator(
-        tensor_size=imsize, split_ratio=0.1, rng=rng, device=device
+        img_size=imsize, split_ratio=0.1, rng=rng, device=device
     )
 
     class DummyDataset(Dataset):
@@ -581,7 +581,7 @@ def test_dataloader_formats(
 
     # Online generator at higher split ratio
     generator2 = dinv.physics.generator.BernoulliSplittingMaskGenerator(
-        tensor_size=imsize, split_ratio=0.9, rng=rng, device=device
+        img_size=imsize, split_ratio=0.9, rng=rng, device=device
     )
 
     trainer = dinv.Trainer(

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -1,7 +1,7 @@
 import deepinv
 import torch
 import pytest
-from deepinv.utils.decorators import deprecated_alias
+from deepinv.utils.decorators import _deprecated_alias
 
 
 @pytest.fixture
@@ -128,7 +128,7 @@ def test_plot_ortho3D():
 
 # -------------- Test deprecated_alias --------------
 class DummyModule(torch.nn.Module):
-    @deprecated_alias(old_lr="lr")
+    @_deprecated_alias(old_lr="lr")
     def __init__(self, lr=0.1):
         super().__init__()
         self.lr = lr

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -1,6 +1,7 @@
 import deepinv
 import torch
 import pytest
+from deepinv.utils.decorators import deprecated_alias
 
 
 @pytest.fixture
@@ -123,3 +124,24 @@ def test_plot_ortho3D():
         deepinv.utils.plot_ortho3D(imgs, titles=["a", "b"], show=False)
         deepinv.utils.plot_ortho3D(x, titles="a", show=False)
         deepinv.utils.plot_ortho3D(imgs, show=False)
+
+
+# -------------- Test deprecated_alias --------------
+class DummyModule(torch.nn.Module):
+    @deprecated_alias(old_lr="lr")
+    def __init__(self, lr=0.1):
+        super().__init__()
+        self.lr = lr
+
+
+def test_deprecated_alias():
+    # --- Class (torch.nn.Module) tests ---
+    with pytest.warns(DeprecationWarning, match="old_lr.*deprecated"):
+        m1 = DummyModule(old_lr=0.01)
+        assert m1.lr == 0.01
+
+    m2 = DummyModule(lr=0.02)
+    assert m2.lr == 0.02
+
+    with pytest.raises(TypeError, match="Cannot specify both 'old_lr' and 'lr'"):
+        DummyModule(old_lr=0.01, lr=0.02)

--- a/deepinv/utils/decorators.py
+++ b/deepinv/utils/decorators.py
@@ -4,15 +4,10 @@ import functools
 
 def _deprecated_alias(**aliases):
     """
-    Decorator to support deprecated argument names.
+    Decorator to support deprecated argument names in a class.
 
-    Args:
-        **aliases: mapping of old_name='new_name'
+    :param **aliases: mapping of old_name='new_name'
 
-    Example:
-        @_deprecated_alias(old_arg='new_arg')
-        def __init__(self, new_arg=None):
-            ...
     """
 
     def decorator(func):

--- a/deepinv/utils/decorators.py
+++ b/deepinv/utils/decorators.py
@@ -1,0 +1,36 @@
+import warnings
+import functools
+
+
+def _deprecated_alias(**aliases):
+    """
+    Decorator to support deprecated argument names.
+
+    Args:
+        **aliases: mapping of old_name='new_name'
+
+    Example:
+        @_deprecated_alias(old_arg='new_arg')
+        def __init__(self, new_arg=None):
+            ...
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            for old, new in aliases.items():
+                if old in kwargs:
+                    if new in kwargs:
+                        raise TypeError(f"Cannot specify both '{old}' and '{new}'")
+                    warnings.warn(
+                        f"Argument '{old}' is deprecated and will be removed in a future version. "
+                        f"Use '{new}' instead.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    kwargs[new] = kwargs.pop(old)
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/deepinv/utils/decorators.py
+++ b/deepinv/utils/decorators.py
@@ -4,7 +4,7 @@ import functools
 
 def _deprecated_alias(**aliases):
     """
-    Decorator to support deprecated argument names in a class.
+    Decorator to support deprecated argument names in a class or a function.
 
     :param **aliases: mapping of old_name='new_name'
 
@@ -12,7 +12,7 @@ def _deprecated_alias(**aliases):
 
     def decorator(func):
         @functools.wraps(func)
-        def wrapper(self, *args, **kwargs):
+        def wrapper(*args, **kwargs):
             for old, new in aliases.items():
                 if old in kwargs:
                     if new in kwargs:
@@ -24,7 +24,7 @@ def _deprecated_alias(**aliases):
                         stacklevel=2,
                     )
                     kwargs[new] = kwargs.pop(old)
-            return func(self, *args, **kwargs)
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/docs/source/user_guide/physics/intro.rst
+++ b/docs/source/user_guide/physics/intro.rst
@@ -44,7 +44,7 @@ Composition and linear combinations of linear operators is still a linear operat
     >>> import torch
     >>> import deepinv as dinv
     >>> # load a CS operator with 300 measurements, acting on 28 x 28 grayscale images.
-    >>> physics = dinv.physics.CompressedSensing(m=300, img_shape=(1, 28, 28))
+    >>> physics = dinv.physics.CompressedSensing(m=300, img_size=(1, 28, 28))
     >>> x = torch.rand(1, 1, 28, 28) # create a random image
     >>> y = physics(x) # compute noisy measurements
     >>> y2 = physics.A(x) # compute the linear operator (no noise)

--- a/docs/source/user_guide/physics/intro.rst
+++ b/docs/source/user_guide/physics/intro.rst
@@ -24,7 +24,7 @@ They are :class:`torch.nn.Module` which can be called with the ``forward`` metho
     >>> import torch
     >>> import deepinv as dinv
     >>> # load an inpainting operator that masks 50% of the pixels and adds Gaussian noise
-    >>> physics = dinv.physics.Inpainting(mask=.5, tensor_size=(1, 28, 28),
+    >>> physics = dinv.physics.Inpainting(mask=.5, img_size=(1, 28, 28),
     ...                    noise_model=dinv.physics.GaussianNoise(sigma=.05))
     >>> x = torch.rand(1, 1, 28, 28) # create a random image
     >>> y = physics(x) # compute noisy measurements

--- a/docs/source/user_guide/reconstruction/optimization.rst
+++ b/docs/source/user_guide/reconstruction/optimization.rst
@@ -52,7 +52,7 @@ least squares problem.
     >>> # Forward operator, here inpainting
     >>> mask = torch.ones((1, 2, 2))
     >>> mask[0, 0, 0] = 0
-    >>> physics = dinv.physics.Inpainting(tensor_size=mask.shape, mask=mask)
+    >>> physics = dinv.physics.Inpainting(img_size=mask.shape, mask=mask)
     >>> # Generate data
     >>> x = torch.ones((1, 1, 2, 2))
     >>> y = physics(x)

--- a/docs/source/user_guide/training/datasets.rst
+++ b/docs/source/user_guide/training/datasets.rst
@@ -37,7 +37,7 @@ For example, here we generate a compressed sensing MNIST dataset:
     data_test = datasets.MNIST(root=save_dir, train=False, transform=transform_data)
 
     # define forward operator
-    physics = dinv.physics.CompressedSensing(m=300, img_shape=(1, 28, 28))
+    physics = dinv.physics.CompressedSensing(m=300, img_size=(1, 28, 28))
     physics.noise_model = dinv.physics.GaussianNoise(sigma=.05)
 
     # generate paired dataset

--- a/examples/basics/demo_dip.py
+++ b/examples/basics/demo_dip.py
@@ -48,7 +48,7 @@ torch.manual_seed(0)
 # We use image inpainting as the forward operator and Gaussian noise as the noise model.
 
 sigma = 0.1  # noise level
-physics = dinv.physics.Inpainting(mask=0.5, tensor_size=x.shape[1:], device=device)
+physics = dinv.physics.Inpainting(mask=0.5, img_size=x.shape[1:], device=device)
 physics.noise_model = dinv.physics.GaussianNoise(sigma=sigma)
 
 # %%

--- a/examples/basics/demo_dip.py
+++ b/examples/basics/demo_dip.py
@@ -80,7 +80,7 @@ lr = 1e-2  # learning rate for the optimizer.
 channels = 64  # number of channels per layer in the decoder.
 in_size = [2, 2]  # size of the input to the decoder.
 backbone = dinv.models.ConvDecoder(
-    img_shape=x.shape[1:], in_size=in_size, channels=channels
+    img_size=x.shape[1:], in_size=in_size, channels=channels
 ).to(device)
 
 f = dinv.models.DeepImagePrior(

--- a/examples/basics/demo_phase_retrieval.py
+++ b/examples/basics/demo_phase_retrieval.py
@@ -78,14 +78,14 @@ assert torch.allclose(x_phase.real**2 + x_phase.imag**2, torch.tensor(1.0))
 
 # Define physics information
 oversampling_ratio = 5.0
-img_shape = x.shape[1:]
-m = int(oversampling_ratio * torch.prod(torch.tensor(img_shape)))
+img_size = x.shape[1:]
+m = int(oversampling_ratio * torch.prod(torch.tensor(img_size)))
 n_channels = 1  # 3 for color images, 1 for gray-scale images
 
 # Create the physics
 physics = dinv.physics.RandomPhaseRetrieval(
     m=m,
-    img_shape=img_shape,
+    img_size=img_size,
     device=device,
 )
 

--- a/examples/basics/demo_physics_tour.py
+++ b/examples/basics/demo_physics_tour.py
@@ -93,7 +93,7 @@ physics = dinv.physics.CompressedSensing(
     m=2048,
     fast=False,
     channelwise=True,
-    img_shape=img_size,
+    img_size=img_size,
     compute_inverse=True,
     device=device,
 )
@@ -217,7 +217,7 @@ plot([x, y[0], y[1]], titles=["signal", "low res rgb", "high res gray"])
 # When ``fast=True``, the patterns are generated using a fast Hadamard transform.
 
 physics = dinv.physics.SinglePixelCamera(
-    m=256, fast=True, img_shape=img_size, device=device
+    m=256, fast=True, img_size=img_size, device=device
 )
 
 y = physics(x)

--- a/examples/basics/demo_physics_tour.py
+++ b/examples/basics/demo_physics_tour.py
@@ -216,11 +216,7 @@ plot([x, y[0], y[1]], titles=["signal", "low res rgb", "high res gray"])
 # When ``fast=True``, the patterns are generated using a fast Hadamard transform.
 
 physics = dinv.physics.SinglePixelCamera(
-<<<<<<< HEAD
-    m=256, fast=True, img_size=img_size, device=device
-=======
-    m=1024, fast=True, ordering="cake_cutting", img_shape=img_size, device=device
->>>>>>> main
+    m=1024, fast=True, ordering="cake_cutting", img_size=img_size, device=device
 )
 
 y = physics(x)

--- a/examples/basics/demo_physics_tour.py
+++ b/examples/basics/demo_physics_tour.py
@@ -57,7 +57,7 @@ plot([x, y], titles=["signal", "measurement"])
 sigma = 0.1  # noise level
 physics = dinv.physics.Inpainting(
     mask=0.5,
-    tensor_size=x.shape[1:],
+    img_size=x.shape[1:],
     noise_model=dinv.physics.GaussianNoise(sigma=sigma),
     device=device,
 )

--- a/examples/basics/demo_ptychography.py
+++ b/examples/basics/demo_ptychography.py
@@ -60,7 +60,7 @@ probe = dinv.physics.phase_retrieval.build_probe(
 shifts = dinv.physics.phase_retrieval.generate_shifts(img_size, n_img=n_img, fov=170)
 
 physics = Ptychography(
-    in_shape=img_size,
+    img_size=img_size,
     probe=probe,
     shifts=shifts,
     device=device,

--- a/examples/basics/demo_spc.py
+++ b/examples/basics/demo_spc.py
@@ -84,7 +84,7 @@ x = load_url_image(
 physics_list = [
     dinv.physics.SinglePixelCamera(
         m=m,
-        img_shape=(1, img_size_H, img_size_W),
+        img_size=(1, img_size_H, img_size_W),
         noise_model=dinv.physics.GaussianNoise(sigma=noise_level_img),
         device=device,
         ordering=ordering,
@@ -205,7 +205,7 @@ shifted_masks = [hadamard_2d_shift(mask) for mask in masks]
 # Calculate the Hadamard spectrum for visualization
 physics_full = dinv.physics.SinglePixelCamera(
     m=n,
-    img_shape=(1, img_size_H, img_size_W),
+    img_size=(1, img_size_H, img_size_W),
     noise_model=dinv.physics.GaussianNoise(sigma=noise_level_img),
     device=device,
 )

--- a/examples/basics/demo_tour_mri.py
+++ b/examples/basics/demo_tour_mri.py
@@ -271,7 +271,7 @@ x, y = next(iter(DataLoader(dataset)))
 
 print("Shapes:", x.shape, y.shape)  # x (B, 1, W, W); y (B, C, N, H, W)
 
-img_shape, kspace_shape = x.shape[-2:], y.shape[-2:]
+img_size, kspace_shape = x.shape[-2:], y.shape[-2:]
 n_coils = y.shape[2]
 
 # %%
@@ -282,7 +282,7 @@ n_coils = y.shape[2]
 #
 
 physics = dinv.physics.MultiCoilMRI(
-    img_size=img_shape,
+    img_size=img_size,
     mask=torch.ones(kspace_shape),
     coil_maps=torch.ones((n_coils,) + kspace_shape, dtype=torch.complex64),
     device=device,

--- a/examples/basics/demo_train_inpainting.py
+++ b/examples/basics/demo_train_inpainting.py
@@ -65,7 +65,7 @@ probability_mask = 0.5  # probability to mask pixel
 
 # Generate inpainting operator
 physics = dinv.physics.Inpainting(
-    tensor_size=(n_channels, img_size, img_size), mask=probability_mask, device=device
+    img_size=(n_channels, img_size, img_size), mask=probability_mask, device=device
 )
 
 

--- a/examples/optimization/demo_wavelet_prior.py
+++ b/examples/optimization/demo_wavelet_prior.py
@@ -71,7 +71,7 @@ mask[
 ] = 0
 
 physics = dinv.physics.Inpainting(
-    tensor_size=(n_channels, img_size, img_size),
+    img_size=(n_channels, img_size, img_size),
     mask=mask,
     device=device,
     noise_model=dinv.physics.GaussianNoise(sigma=noise_level_img),

--- a/examples/patch-priors/demo_epll.py
+++ b/examples/patch-priors/demo_epll.py
@@ -71,7 +71,7 @@ plot(
 
 sigma = 0.01
 physics = Inpainting(
-    tensor_size=test_img[0].shape,
+    img_size=test_img[0].shape,
     mask=0.7,
     device=device,
     noise_model=GaussianNoise(sigma),

--- a/examples/plug-and-play/demo_PnP_custom_optim.py
+++ b/examples/plug-and-play/demo_PnP_custom_optim.py
@@ -185,14 +185,9 @@ operation = "single_pixel"
 noise_level_img = 0.03  # Gaussian Noise standard deviation for the degradation
 n_channels = 1  # 3 for color images, 1 for gray-scale images
 physics = dinv.physics.SinglePixelCamera(
-<<<<<<< HEAD
-    m=100,
-    img_size=(1, 64, 64),
-=======
     m=600,
-    img_shape=(1, 64, 64),
+    img_size=(1, 64, 64),
     ordering="cake_cutting",
->>>>>>> main
     noise_model=dinv.physics.GaussianNoise(sigma=noise_level_img),
     device=device,
 )

--- a/examples/plug-and-play/demo_PnP_custom_optim.py
+++ b/examples/plug-and-play/demo_PnP_custom_optim.py
@@ -183,7 +183,7 @@ noise_level_img = 0.03  # Gaussian Noise standard deviation for the degradation
 n_channels = 1  # 3 for color images, 1 for gray-scale images
 physics = dinv.physics.SinglePixelCamera(
     m=100,
-    img_shape=(1, 64, 64),
+    img_size=(1, 64, 64),
     noise_model=dinv.physics.GaussianNoise(sigma=noise_level_img),
     device=device,
 )

--- a/examples/sampling/demo_ddrm.py
+++ b/examples/sampling/demo_ddrm.py
@@ -44,7 +44,7 @@ x = load_url_image(url=url, img_size=32).to(device)
 sigma = 0.1  # noise level
 physics = dinv.physics.Inpainting(
     mask=0.5,
-    tensor_size=x.shape[1:],
+    img_size=x.shape[1:],
     device=device,
     noise_model=dinv.physics.GaussianNoise(sigma=sigma),
 )

--- a/examples/sampling/demo_diffpir.py
+++ b/examples/sampling/demo_diffpir.py
@@ -49,7 +49,7 @@ mask[:, :, 80:130, 50:100] = 0
 sigma_noise = 12.75 / 255.0  # noise level
 physics = dinv.physics.Inpainting(
     mask=mask,
-    tensor_size=x.shape[1:],
+    img_size=x.shape[1:],
     noise_model=dinv.physics.GaussianNoise(sigma=sigma_noise),
     device=device,
 )

--- a/examples/sampling/demo_diffusion_sde.py
+++ b/examples/sampling/demo_diffusion_sde.py
@@ -174,7 +174,7 @@ except FileNotFoundError:
 del trajectory  # clean memory
 mask = torch.ones_like(x)
 mask[..., 24:40, 24:40] = 0.0
-physics = dinv.physics.Inpainting(tensor_size=x.shape[1:], mask=mask, device=device)
+physics = dinv.physics.Inpainting(img_size=x.shape[1:], mask=mask, device=device)
 y = physics(x)
 
 weight = 1.0  # guidance strength
@@ -385,7 +385,7 @@ mask = torch.ones_like(x)
 mask[..., 70:150, 120:180] = 0
 physics = dinv.physics.Inpainting(
     mask=mask,
-    tensor_size=x.shape[1:],
+    img_size=x.shape[1:],
     device=device,
 )
 

--- a/examples/sampling/demo_dps.py
+++ b/examples/sampling/demo_dps.py
@@ -42,7 +42,7 @@ x = x_true.clone()
 sigma = 12.75 / 255.0  # noise level
 
 physics = dinv.physics.Inpainting(
-    tensor_size=(3, x.shape[-2], x.shape[-1]),
+    img_size=(3, x.shape[-2], x.shape[-1]),
     mask=0.1,
     pixelwise=True,
     device=device,

--- a/examples/sampling/demo_sampling.py
+++ b/examples/sampling/demo_sampling.py
@@ -45,7 +45,7 @@ x = load_url_image(url=url, img_size=32).to(device)
 # This example uses inpainting as the forward operator and Gaussian noise as the noise model.
 
 sigma = 0.1  # noise level
-physics = dinv.physics.Inpainting(mask=0.5, tensor_size=x.shape[1:], device=device)
+physics = dinv.physics.Inpainting(mask=0.5, img_size=x.shape[1:], device=device)
 physics.noise_model = dinv.physics.GaussianNoise(sigma=sigma)
 
 # Set the global random seed from pytorch to ensure reproducibility of the example.

--- a/examples/self-supervised-learning/demo_multioperator_imaging.py
+++ b/examples/self-supervised-learning/demo_multioperator_imaging.py
@@ -77,7 +77,7 @@ number_of_operators = 10
 
 # defined physics
 physics = [
-    dinv.physics.Inpainting(mask=0.5, tensor_size=(1, 28, 28), device=device)
+    dinv.physics.Inpainting(mask=0.5, img_size=(1, 28, 28), device=device)
     for _ in range(number_of_operators)
 ]
 

--- a/examples/unfolded/demo_LISTA.py
+++ b/examples/unfolded/demo_LISTA.py
@@ -71,7 +71,7 @@ num_workers = 4 if torch.cuda.is_available() else 0
 
 # Generate the compressed sensing measurement operator with 10x under-sampling factor.
 physics = dinv.physics.CompressedSensing(
-    m=78, img_shape=(n_channels, img_size, img_size), fast=True, device=device
+    m=78, img_size=(n_channels, img_size, img_size), fast=True, device=device
 )
 my_dataset_name = "demo_LISTA"
 n_images_max = (

--- a/examples/unfolded/demo_custom_prior_unfolded.py
+++ b/examples/unfolded/demo_custom_prior_unfolded.py
@@ -70,7 +70,7 @@ num_workers = 4 if torch.cuda.is_available() else 0
 
 # Generate the compressed sensing measurement operator with 10x under-sampling factor.
 physics = dinv.physics.CompressedSensing(
-    m=78, img_shape=(n_channels, img_size, img_size), fast=True, device=device
+    m=78, img_size=(n_channels, img_size, img_size), fast=True, device=device
 )
 my_dataset_name = "demo_LICP"
 n_images_max = (

--- a/examples/unfolded/demo_unfolded_constrained_LISTA.py
+++ b/examples/unfolded/demo_unfolded_constrained_LISTA.py
@@ -84,7 +84,7 @@ probability_mask = 0.5  # probability to mask pixel
 
 # Generate inpainting operator
 physics = dinv.physics.Inpainting(
-    tensor_size=(n_channels, img_size, img_size), mask=probability_mask, device=device
+    img_size=(n_channels, img_size, img_size), mask=probability_mask, device=device
 )
 
 


### PR DESCRIPTION
Close #481 by creating aliases. Fully backward compatible.
- `dinv.physics.Inpainting` has `tensor_size` ---> now `img_size`
- `dinv.physics.CompressedSensing` has `img_shape` ---> now `img_size`
- `dinv.physics.SinglePixelCamera` has `img_shape` ---> now `img_size`
- `dinv.physics.RandomPhaseRetrieval` has `img_shape` ---> now `img_size`
- `dinv.physics.Ptychography` has `in_shape` ---> now `img_size`

- `dinv.physics.StructuredRandom` has `input_shape` and `output_shape` ---> now `img_size` and `output_shape`
- `dinv.physics.StructuredRandomPhaseRetrieval` has `input_shape` and `output_shape` ---> now `img_size` and `output_shape`

The codebase is changed accordingly. 
Deprecated warning is added if one uses the old argument name. 
Test functions of the expected behavior is also added. 

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
