### PR TITLE
fix FMD dataset

### DIFF
--- a/deepinv/datasets/fmd.py
+++ b/deepinv/datasets/fmd.py
@@ -239,4 +239,4 @@ class FMD(torch.utils.data.Dataset):
             noisy_img = self.transform(noisy_img)
         if self.target_transform is not None:
             clean_img = self.target_transform(clean_img)
-        return noisy_img, clean_img
+        return clean_img, noisy_img


### PR DESCRIPTION
fix output order in FMD, the clean image should go first following deepinv convention `(x,y)`

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
