### PR TITLE
spectral method for phase retrieval throwing errors for physics.dtype = torch.float 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Changed
 
 Fixed
 ^^^^^
-
+- Fixed spectral method for phase retrieval throwing errors for physics.dtype = torch.float 
 
 v0.3.1
 ----------------

--- a/deepinv/optim/phase_retrieval.py
+++ b/deepinv/optim/phase_retrieval.py
@@ -169,7 +169,7 @@ def spectral_methods(
     y = y / torch.mean(y)
     diag_T = preprocessing(y, physics)
     if physics.dtype == torch.cfloat:
-        # x = x.to(torch.cfloat)
+        x = x.to(torch.cfloat)
         diag_T = diag_T.to(torch.cfloat)
         
     for i in range(n_iter):

--- a/deepinv/optim/phase_retrieval.py
+++ b/deepinv/optim/phase_retrieval.py
@@ -165,11 +165,13 @@ def spectral_methods(
     #! for the structured case, when the mean of the squared diagonal elements is 1, we have norm(x) = sqrt(sum(y)), otherwise y gets scaled by the mean to the power of number of layers
     norm_x = torch.sqrt(y.sum())
 
-    x = x.to(torch.cfloat)
     # y should have mean 1
     y = y / torch.mean(y)
     diag_T = preprocessing(y, physics)
-    diag_T = diag_T.to(torch.cfloat)
+    if physics.dtype == torch.cfloat:
+        # x = x.to(torch.cfloat)
+        diag_T = diag_T.to(torch.cfloat)
+        
     for i in range(n_iter):
         x_new = physics.B(x)
         x_new = diag_T * x_new

--- a/examples/test/real_and_complex_pr.py
+++ b/examples/test/real_and_complex_pr.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Jun  6 15:18:28 2025
+
+@author: olehl
+"""
+
+import deepinv as dinv
+from pathlib import Path
+import torch
+import matplotlib.pyplot as plt
+from deepinv.models import DRUNet
+from deepinv.optim.data_fidelity import L2
+from deepinv.optim.prior import PnP, Zero
+from deepinv.optim.optimizers import optim_builder
+from deepinv.utils.demo import load_example
+from deepinv.utils.plotting import plot
+from deepinv.optim.phase_retrieval import (
+    correct_global_phase,
+    cosine_similarity,
+    spectral_methods,
+)
+from deepinv.models.complex import to_complex_denoiser
+
+BASE_DIR = Path(".")
+RESULTS_DIR = BASE_DIR / "results"
+# Set global random seed to ensure reproducibility.
+torch.manual_seed(0)
+
+device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
+
+# Image size
+img_size = 32
+# The pixel values of the image are in the range [0, 1].
+x = load_example(
+    "SheppLogan.png",
+    img_size=img_size,
+    grayscale=True,
+    resize_mode="resize",
+    device=device,
+)
+print(x.min(), x.max())
+
+plot(x, titles="Original image")
+
+x_phase = torch.exp(1j * x * torch.pi - 0.5j * torch.pi)
+x_real = x
+
+# Every element of the signal should have unit norm.
+assert torch.allclose(x_phase.real**2 + x_phase.imag**2, torch.tensor(1.0))
+
+# Define physics information
+oversampling_ratio = 5.0
+img_shape = x.shape[1:]
+m = int(oversampling_ratio * torch.prod(torch.tensor(img_shape)))
+n_channels = 1  # 3 for color images, 1 for gray-scale images
+
+# Create the physics
+# dtype=torch.float to make the problem real
+physics = dinv.physics.RandomPhaseRetrieval(
+    m=m,
+    img_shape=img_shape,
+    dtype=torch.float,
+    device=device,
+)
+
+# Generate measurements
+y = physics(x_real)
+
+# Spectral methods return a tensor with unit norm.
+x_phase_spec = physics.A_dagger(y, n_iter=300)
+
+# correct possible global phase shifts
+# x_spec = correct_global_phase(x_phase_spec, x_real)
+# extract phase information and normalize to the range [0, 1]
+# x_spec = torch.angle(x_spec) / torch.pi + 0.5
+plot([x, x_phase_spec], titles=["Signal", "Reconstruction"], rescale_mode="clip")
+
+
+physics_c = dinv.physics.RandomPhaseRetrieval(
+    m=m,
+    img_shape=img_shape,
+    # dtype=torch.float,
+    device=device,
+)
+
+# Generate measurements
+y_c = physics_c(x_phase)
+
+# Spectral methods return a tensor with unit norm.
+x_phase_spec = physics_c.A_dagger(y_c, n_iter=300)
+
+# correct possible global phase shifts
+x_spec = correct_global_phase(x_phase_spec, x_phase)
+# extract phase information and normalize to the range [0, 1]
+x_spec = torch.angle(x_spec) / torch.pi + 0.5
+plot([x, x_spec], titles=["Signal", "Reconstruction"], rescale_mode="clip")


### PR DESCRIPTION
Fixed spectral method for phase retrieval, throwing errors for physics.dtype = torch.float 

examples/test/real_and_complex_pr.py provides a test that shows that both real- and complex-valued models work.

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
