### PR TITLE
Make adjoint_function use A in autograd

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ New Features
 
 Changed
 ^^^^^^^
+- Make autograd use the base linear operator for `deepinv.physics.adjoint_function` (:gh:`519` by `Jérémy Scanvic`_)
 
 Fixed
 ^^^^^

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -893,17 +893,34 @@ def adjoint_function(A, input_size, device="cpu", dtype=torch.float):
     (_, vjpfunc) = torch.func.vjp(A, x)
     batches = x.size()[0]
 
-    def adjoint(y):
-        if y.size()[0] < batches:
-            y2 = torch.zeros((batches,) + y.shape[1:], device=y.device, dtype=y.dtype)
-            y2[: y.size()[0], ...] = y
-            return vjpfunc(y2)[0][: y.size()[0], ...]
-        elif y.size()[0] > batches:
-            raise ValueError("Batch size of A_adjoint input is larger than expected")
-        else:
-            return vjpfunc(y)[0]
+    # NOTE: In certain cases A(x) can't be differentiated infinitely many times
+    # wrt x. In that case, the adjoint of A computed using automatic
+    # differentiation might not be automatically differentiable either. We
+    # avoid this problem by using the involutive property of the adjoint
+    # operator, i.e.,  (A^\top)^\top = A, and we specifically define the
+    # adjoint of the adjoint as the original linear operator A.
+    # For more details, see https://github.com/deepinv/deepinv/issues/511
+    class Adjoint(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, y):
+            if y.size()[0] < batches:
+                y2 = torch.zeros(
+                    (batches,) + y.shape[1:], device=y.device, dtype=y.dtype
+                )
+                y2[: y.size()[0], ...] = y
+                return vjpfunc(y2)[0][: y.size()[0], ...]
+            elif y.size()[0] > batches:
+                raise ValueError(
+                    "Batch size of A_adjoint input is larger than expected"
+                )
+            else:
+                return vjpfunc(y)[0]
 
-    return adjoint
+        @staticmethod
+        def backward(ctx, grad_output):
+            return A(grad_output)
+
+    return Adjoint.apply
 
 
 def stack(*physics: Union[Physics, LinearPhysics]):

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1281,3 +1281,36 @@ def test_unmixing(device):
 
     assert torch.all(x_hat[:, 0].squeeze() == torch.tensor([1.0, 0.0]))
     assert torch.all(x_hat[:, 1].squeeze() == torch.tensor([0.0, 1.0]))
+
+
+@pytest.mark.parametrize("name", OPERATORS)
+def test_adjoint_autograd(name, device):
+    # NOTE: The current implementation of adjoint_function does not support
+    # physics that return tensor lists or complex tensors.
+    if name in {
+        "aliased_pansharpen",
+        "pansharpen_valid",
+        "pansharpen_circular",
+        "pansharpen_reflect",
+        "pansharpen_replicate",
+        "complex_compressed_sensing",
+        "ptychography_linear",
+    }:
+        pytest.skip(f"Operator {name} is not supported by adjoint_function.")
+
+    physics, imsize, _, dtype = find_operator(name, device)
+
+    x = torch.randn(imsize, device=device, dtype=dtype).unsqueeze(0)
+    y = physics.A(x)
+
+    A_adjoint = adjoint_function(physics.A, x.shape, x.device, x.dtype)
+
+    # Compute Df^\top(z) using autograd where f(z) = A^\top z.
+    y.requires_grad_()
+    z = torch.randn_like(x, device=device, dtype=dtype)
+    l = (z * A_adjoint(y)).sum()
+    l.backward()
+    # \delta y := \delta_y <z, A^\top y> = Az
+    delta_y = y.grad
+    Az = physics.A(z)
+    assert torch.allclose(delta_y, Az, rtol=1e-5)


### PR DESCRIPTION
Implements the (excellent!) suggestion @johertrich and @tachella made in #511

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
