### PR TITLE
Speed up the test suite by parallelizing the slowest outlier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,12 +48,10 @@ jobs:
 
       - name: Test with pytest and generate coverage report
         run: |
-          python3 -m pytest --cov=deepinv --junitxml=junit.xml -o junit_family=legacy -v
+          python3 -m pytest -n 2 --dist=loadgroup --cov=deepinv --junitxml=junit.xml -o junit_family=legacy -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
-
-

--- a/deepinv/tests/conftest.py
+++ b/deepinv/tests/conftest.py
@@ -73,3 +73,25 @@ def no_plot():
         plt.close("all")
         matplotlib.use(original_backend, force=True)
         importlib.reload(plt)
+
+
+# Certain tests are particularly slow and make for a large part of
+# the time it takes for the entire test suite to run. For this reason, we make
+# them run in parallel of the rest of the tests thereby reducing the overall
+# test time drastically.
+def pytest_collection_modifyitems(config, items):
+    """Set the xdist group of the test items based on their markers."""
+    next_slow_idx = 1
+    for item in items:
+        slow_marker = item.get_closest_marker("slow")
+        if slow_marker is not None:
+            # Slow tests can't share the same group to make sure they run in
+            # parallel. This is why we use a counter to create unique group
+            # names.
+            group_name = f"slow_{next_slow_idx}"
+            item.add_marker(pytest.mark.xdist_group(group_name))
+            next_slow_idx += 1
+        else:
+            # All other tests are grouped under "main" and run one at a time
+            # but in parallel of the slow tests.
+            item.add_marker(pytest.mark.xdist_group("main"))

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -189,6 +189,7 @@ def test_algo_inpaint(name_algo, device):
     assert (mean_target_masked - mean_outside_crop).abs() < 0.01
 
 
+@pytest.mark.slow
 @torch.no_grad()
 def test_sde(device):
     from deepinv.sampling import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ Tracker = "https://github.com/deepinv/deepinv/issues"
 test = [
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
     "coverage",
 ]
 


### PR DESCRIPTION
The test suite takes about 30 minutes to run and about 20 of them are spent on the single test `test_sde` in `deepinv.tests.test_sampling`.

I'm not sure why so much time is spent on this single test but we should be able to get a 10 minutes (30%) speed up by letting it run in parallel of the other tests.

As a matter of comparison, the 2nd slowest test is `test_priors_algo` in `deepinv.tests.test_optim` and it only takes 3 minutes to finish off.

**How**

The test suite currently runs sequentially, one test at a time, but it is possible to parallelize it using `pytest-xdist`. Here, we run the tests on two separate workers, one for `test_sde` and one for the other tests which remain sequentially executed.

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
