### PR TITLE
typo in vp sde

### DIFF
--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -333,7 +333,7 @@ class VariancePreservingDiffusion(DiffusionSDE):
 
     This class is the reverse-time SDE of the VP-SDE, serving as the generation process.
 
-    :param deepinv.models.Denoiser denoiser: a denoiser used to provide an approximation of the score at time :math:`t` : :math:`\nabla \log p_t`.
+    :param deepinv.models.Denoiser denoiser: a denoiser used to provide an approximation of the score at time :math:`t`: :math:`\nabla \log p_t`.
     :param float beta_min: the minimum noise level.
     :param float beta_max: the maximum noise level.
     :param float alpha: the weighting factor of the diffusion term.

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -331,9 +331,9 @@ class VariancePreservingDiffusion(DiffusionSDE):
 
     where :math:`\alpha \in [0,1]` is a constant weighting the diffusion term.
 
-    This class is the reverse-time SDE of the VE-SDE, serving as the generation process.
+    This class is the reverse-time SDE of the VP-SDE, serving as the generation process.
 
-    :param deepinv.models.Denoiser denoiser: a denoiser used to provide an approximation of the score at time :math:`t` :math:`\nabla \log p_t`.
+    :param deepinv.models.Denoiser denoiser: a denoiser used to provide an approximation of the score at time :math:`t` : :math:`\nabla \log p_t`.
     :param float beta_min: the minimum noise level.
     :param float beta_max: the maximum noise level.
     :param float alpha: the weighting factor of the diffusion term.


### PR DESCRIPTION
Correct a small typo in the docstring

### Checks to be done before submitting your PR
- [ x ] `python3 -m pytest tests/` runs successfully.
- [ x ] `black .` runs successfully.
- [ x ] `make html` runs successfully (in the `docs/` directory).
- [ x ] Updated docstrings related to the changes (as applicable).
- [  ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
