### PR TITLE
Fix some issues related to denoiser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Fixed
 ^^^^^
 - Fix the total loss reported by the trainer (:gh:`515` by `Jérémy Scanvic`_)
 - Fix the gradient norm reported by the trainer (:gh:`520` by `Jérémy Scanvic`_)
-
+- Fix some issues related to denoisers: ICNN grad not working inside torch.no_grad(), batch of image and batch of sigma for some denoisers (DiffUNet, BM3D, TV, Wavemet), EPLL error when batch size > 1 (:gh:`TODO` by `Minh Hai Nguyen`_)  
 
 v0.3.1
 ----------------

--- a/deepinv/models/bm3d.py
+++ b/deepinv/models/bm3d.py
@@ -46,14 +46,28 @@ class BM3D(Denoiser):
 
         out = torch.zeros_like(x)
 
-        if not torch.is_tensor(sigma):
-            sigma = torch.tensor(sigma).repeat(x.shape[0])
+        sigma = self._handle_sigma(sigma, x.size(0))
 
         for i in range(x.shape[0]):
             out[i, :, :, :] = array2tensor(
-                bm3d.bm3d(tensor2array(x[i, :, :, :]), sigma[i].item())
+                bm3d.bm3d(tensor2array(x[i, :, :, :]), sigma[i])
             )
         return out
+
+    @staticmethod
+    def _handle_sigma(sigma, batch_size):
+        r"""
+        Handle various sigma input: float, int, tensor
+        """
+        if isinstance(sigma, (float, int)):
+            return [sigma] * batch_size
+        elif isinstance(sigma, torch.Tensor):
+            sigma = sigma.squeeze()
+            if sigma.ndim == 0:
+                return [sigma.item()] * batch_size
+            else:
+                assert sigma.ndim == 1 and sigma.size(0) == batch_size
+                return sigma.tolist()
 
 
 def tensor2array(img):

--- a/deepinv/models/diffunet.py
+++ b/deepinv/models/diffunet.py
@@ -393,7 +393,6 @@ class DiffUNet(Denoiser):
 
         hs = []
         emb = self.time_embed(timestep_embedding(timesteps, self.model_channels))
-
         if self.num_classes is not None:
             assert y.shape == (x.shape[0],)
             emb = emb + self.label_emb(y)
@@ -415,12 +414,12 @@ class DiffUNet(Denoiser):
         """
         Get the alpha sequences; this is necessary for mapping noise levels to timesteps when performing pure denoising.
         """
-        betas = np.linspace(beta_start, beta_end, num_train_timesteps, dtype=np.float32)
-        betas = torch.from_numpy(
-            betas
-        )  # .to(self.device) Removing this for now, can be done outside
+        betas = torch.linspace(
+            beta_start, beta_end, num_train_timesteps, dtype=torch.float32
+        )
+        # .to(self.device) Removing this for now, can be done outside
         alphas = 1.0 - betas
-        alphas_cumprod = np.cumprod(alphas.cpu(), axis=0)  # This is \overline{\alpha}_t
+        alphas_cumprod = torch.cumprod(alphas, dim=0)  # This is \overline{\alpha}_t
 
         # Useful sequences deriving from alphas_cumprod
         sqrt_alphas_cumprod = torch.sqrt(alphas_cumprod)
@@ -438,12 +437,9 @@ class DiffUNet(Denoiser):
 
     def find_nearest(self, array, value):
         """
-        Find the argmin of the nearest value in an array.
+        Find the argmin of the nearest value in a tensor.
         """
-        array = np.asarray(array)
-        if isinstance(value, torch.Tensor):
-            value = np.asarray(value.cpu())
-        idx = (np.abs(array - value)).argmin()
+        idx = (torch.abs(array[:, None] - value[None, :])).argmin(dim=0)
         return idx
 
     def forward_denoise(self, x, sigma, y=None):
@@ -467,7 +463,8 @@ class DiffUNet(Denoiser):
         """
         if not isinstance(sigma, torch.Tensor):
             sigma = torch.tensor(sigma).to(x.device)
-
+        else:
+            sigma = sigma.squeeze().view((sigma.shape + (1,) * (4 - sigma.ndim)))
         alpha = 1 / (1 + 4 * sigma**2)
         x = alpha.sqrt() * (2 * x - 1)
         sigma = sigma * alpha.sqrt()
@@ -480,16 +477,16 @@ class DiffUNet(Denoiser):
         ) = self.get_alpha_prod()
 
         timesteps = self.find_nearest(
-            sqrt_1m_alphas_cumprod, sigma * 2
+            sqrt_1m_alphas_cumprod.to(x.device), sigma.squeeze() * 2
         )  # Factor 2 because image rescaled in [-1, 1]
 
-        noise_est_sample_var = self.forward_diffusion(
-            x, torch.tensor([timesteps]).to(x.device), y=y
-        )
+        timesteps = timesteps.to(x.device)
+        noise_est_sample_var = self.forward_diffusion(x, timesteps, y=y)
         noise_est = noise_est_sample_var[:, :3, ...]
-        denoised = (x - noise_est * sigma * 2) / sqrt_alphas_cumprod[timesteps]
+        denoised = (x - noise_est * sigma * 2) / sqrt_alphas_cumprod.to(x.device)[
+            timesteps
+        ].view(-1, 1, 1, 1)
         denoised = denoised.clamp(-1, 1)
-
         return (denoised + 1) / 2
 
 

--- a/deepinv/models/diffunet.py
+++ b/deepinv/models/diffunet.py
@@ -462,7 +462,7 @@ class DiffUNet(Denoiser):
         :return: an `(N, C, ...)` Tensor of outputs.
         """
         if not isinstance(sigma, torch.Tensor):
-            sigma = torch.tensor(sigma).to(x.device)
+            sigma = torch.tensor([sigma]).to(x.device).view(1, 1, 1, 1)
         else:
             sigma = sigma.squeeze().view((sigma.shape + (1,) * (4 - sigma.ndim)))
         alpha = 1 / (1 + 4 * sigma**2)
@@ -477,7 +477,7 @@ class DiffUNet(Denoiser):
         ) = self.get_alpha_prod()
 
         timesteps = self.find_nearest(
-            sqrt_1m_alphas_cumprod.to(x.device), sigma.squeeze() * 2
+            sqrt_1m_alphas_cumprod.to(x.device), sigma.squeeze(dim=(1, 2, 3)) * 2
         )  # Factor 2 because image rescaled in [-1, 1]
 
         timesteps = timesteps.to(x.device)

--- a/deepinv/models/epll.py
+++ b/deepinv/models/epll.py
@@ -2,6 +2,8 @@ import torch
 from deepinv.optim.epll import EPLL
 from deepinv.physics import Denoising, GaussianNoise
 from .base import Denoiser
+from typing import Union
+from deepinv.optim.utils import GaussianMixtureModel
 
 
 class EPLLDenoiser(Denoiser):
@@ -30,12 +32,12 @@ class EPLLDenoiser(Denoiser):
 
     def __init__(
         self,
-        GMM=None,
-        n_components=200,
-        pretrained="download",
-        patch_size=6,
-        channels=1,
-        device="cpu",
+        GMM: GaussianMixtureModel = None,
+        n_components: int = 200,
+        pretrained: str = "download",
+        patch_size: int = 6,
+        channels: int = 1,
+        device: torch.device = torch.device("cpu"),
     ):
         super(EPLLDenoiser, self).__init__()
         self.PatchGMM = EPLL(
@@ -43,7 +45,13 @@ class EPLLDenoiser(Denoiser):
         )
         self.denoising_operator = Denoising(GaussianNoise(0))
 
-    def forward(self, x, sigma, betas=None, batch_size=-1):
+    def forward(
+        self,
+        x: torch.Tensor,
+        sigma: Union[float, torch.Tensor, list[float]],
+        betas: list[float] = None,
+        batch_size: int = -1,
+    ) -> torch.Tensor:
         r"""
         Denoising method based on the minimization problem.
 
@@ -55,6 +63,7 @@ class EPLLDenoiser(Denoiser):
             but a small value reduces the memory consumption
             and might increase the computation time. ``-1`` for considering all patches at once.
         """
+        sigma = self._handle_sigma(sigma, x.size(0)).to(x.device)
         return self.PatchGMM(
             x,
             x_init=x.clone(),
@@ -63,3 +72,34 @@ class EPLLDenoiser(Denoiser):
             batch_size=batch_size,
             betas=betas,
         )
+
+    @staticmethod
+    def _handle_sigma(sigma, batch_size):
+        r"""
+        Handle the sigma parameter for the denoising method.
+
+        :param float, torch.Tensor sigma: noise level, can be a scalar or a list of scalars.
+        :param batch_size: size of the batch.
+        :return: sigma as a tensor of shape (batch_size, 1).
+        """
+        if isinstance(sigma, (int, float)):
+            sigma = torch.tensor([float(sigma)] * batch_size)
+        elif isinstance(sigma, list):
+            assert (
+                len(sigma) == batch_size
+            ), "Length of sigma list must match batch size."
+            sigma = (
+                torch.tensor(sigma, dtype=torch.float32)
+                .squeeze()
+                .view(-1)
+                .expand(batch_size)
+            )
+        elif isinstance(sigma, torch.Tensor):
+            sigma = sigma.squeeze().view(-1).expand(batch_size)
+        else:
+            raise TypeError(
+                "sigma must be a scalar, list, or torch.Tensor, "
+                f"but got {type(sigma)}."
+            )
+
+        return sigma

--- a/deepinv/models/guided_diffusion.py
+++ b/deepinv/models/guided_diffusion.py
@@ -64,7 +64,7 @@ class ADMUNet(Denoiser):
         attn_resolutions=[32, 16, 8],  # List of resolutions with self-attention.
         dropout=0.10,  # List of resolutions with self-attention.
         label_dropout=0,  # Dropout probability of class labels for classifier-free guidance.
-        pretrained: str = None,
+        pretrained: str = "download",
         pixel_std: float = 0.75,
         device=None,
         *args,

--- a/deepinv/models/guided_diffusion.py
+++ b/deepinv/models/guided_diffusion.py
@@ -223,7 +223,7 @@ class ADMUNet(Denoiser):
             class_labels=class_labels,
             augment_labels=augment_labels,
         )
-        D_x = c_skip.view(-1, 1, 1, 1) * x + c_out * F_x
+        D_x = c_skip.view(-1, 1, 1, 1) * x + c_out.view(-1, 1, 1, 1) * F_x
 
         # Rescale [-1,1] output to [0,-1]
         if self._train_on_minus_one_one:
@@ -275,17 +275,17 @@ class ADMUNet(Denoiser):
     def _handle_sigma(sigma, dtype, device, batch_size):
         if isinstance(sigma, torch.Tensor):
             if sigma.ndim == 0:
-                return sigma[None].to(device, dtype).expand(batch_size)
+                return sigma[None].to(device, dtype)
             elif sigma.ndim == 1:
                 assert (
                     sigma.size(0) == batch_size or sigma.size(0) == 1
                 ), "sigma must be a Tensor with batch_size equal to 1 or the batch_size of input images"
-                return sigma.to(device, dtype).expand(batch_size // sigma.size(0))
+                return sigma.to(device, dtype)
 
             else:
                 raise ValueError(f"Unsupported sigma shape {sigma.shape}.")
 
         elif isinstance(sigma, (float, int)):
-            return torch.tensor([sigma]).to(device, dtype).expand(batch_size)
+            return torch.tensor([sigma]).to(device, dtype)
         else:
             raise ValueError("Unsupported sigma type.")

--- a/deepinv/models/icnn.py
+++ b/deepinv/models/icnn.py
@@ -134,6 +134,7 @@ class ICNN(nn.Module):
             dim=[1, 2, 3]
         ).reshape(-1, 1)
 
+    @torch.enable_grad()
     def grad(self, x):
         r"""
         Calculate the gradient of the potential function.

--- a/deepinv/models/ncsnpp.py
+++ b/deepinv/models/ncsnpp.py
@@ -349,16 +349,16 @@ class NCSNpp(Denoiser):
         if isinstance(sigma, torch.Tensor):
             sigma = sigma.squeeze()
             if sigma.ndim == 0:
-                return sigma[None].to(device, dtype).expand(batch_size)
+                return sigma[None].to(device, dtype)
             elif sigma.ndim == 1:
                 assert (
                     sigma.size(0) == batch_size or sigma.size(0) == 1
                 ), "sigma must be a Tensor with batch_size equal to 1 or the batch_size of input images"
-                return sigma.to(device, dtype).expand(batch_size // sigma.size(0))
+                return sigma.to(device, dtype)
             else:
                 raise ValueError(f"Unsupported sigma shape {sigma.shape}.")
 
         elif isinstance(sigma, (float, int)):
-            return torch.tensor([sigma]).to(device, dtype).expand(batch_size)
+            return torch.tensor([sigma]).to(device, dtype)
         else:
             raise ValueError("Unsupported sigma type.")

--- a/deepinv/models/ncsnpp.py
+++ b/deepinv/models/ncsnpp.py
@@ -81,7 +81,7 @@ class NCSNpp(Denoiser):
             3,
             1,
         ],  # Resampling filter: [1,1] for DDPM++, [1,3,3,1] for NCSN++.
-        pretrained: str = None,
+        pretrained: str = "download",
         pixel_std: float = 0.75,
         device=None,
     ):

--- a/deepinv/models/tgv.py
+++ b/deepinv/models/tgv.py
@@ -106,8 +106,8 @@ class TGVDenoiser(Denoiser):
             self.restart = False
 
         if ths is not None:
-            lambda1 = ths * 0.1
-            lambda2 = ths * 0.15
+            lambda1 = self._handle_sigma(ths, y.size(0)) * 0.1
+            lambda2 = self._handle_sigma(ths, y.size(0)) * 0.15
 
         cy = (y**2).sum() / 2
         primalcostlowerbound = 0
@@ -153,7 +153,7 @@ class TGVDenoiser(Denoiser):
                     torch.sqrt(torch.sum(self.epsilon_adjoint(u) ** 2, axis=-1))
                 )  # to check feasibility: the value will be  <= lambda1 only at convergence. Since u is not feasible, the dual cost is not reliable: the gap=primalcost-dualcost can be <0 and cannot be used as stopping criterion.
                 u3 = u / torch.maximum(
-                    tmp / lambda1, torch.tensor([1], device=tmp.device).type(tmp.dtype)
+                    tmp / lambda1, torch.ones_like(tmp)
                 )  # u3 is a scaled version of u, which is feasible. so, its dual cost is a valid, but very rough lower bound of the primal cost.
                 dualcost2 = (
                     cy
@@ -201,7 +201,7 @@ class TGVDenoiser(Denoiser):
         Applies the jacobian of a vector field.
         """
         b, c, h, w, _ = I.shape
-        G = torch.zeros((b, c, h, w, 4), device=I.device).type(I.dtype)
+        G = torch.zeros((b, c, h, w, 4), device=I.device, dtype=I.dtype)
         G[:, :, 1:, :, 0] = G[:, :, 1:, :, 0] - I[:, :, :-1, :, 0]  # xdy
         G[..., 0] = G[..., 0] + I[..., 0]
         G[..., 1:, 1] = G[..., 1:, 1] - I[..., :-1, 0]  # xdx
@@ -218,7 +218,7 @@ class TGVDenoiser(Denoiser):
         Applies the adjoint of the jacobian of a vector field.
         """
         b, c, h, w, _ = G.shape
-        I = torch.zeros((b, c, h, w, 2), device=G.device).type(G.dtype)
+        I = torch.zeros((b, c, h, w, 2), device=G.device, dtype=G.dtype)
         I[:, :, :-1, :, 0] = I[:, :, :-1, :, 0] - G[:, :, 1:, :, 0]
         I[..., 0] = I[..., 0] + G[..., 0]
         I[..., :-1, 0] = I[..., :-1, 0] - G[..., 1:, 1]
@@ -228,3 +228,16 @@ class TGVDenoiser(Denoiser):
         I[:, :, :-1, :, 1] = I[:, :, :-1, :, 1] - G[:, :, :-1, :, 3]
         I[:, :, 1:, :, 1] = I[:, :, 1:, :, 1] + G[:, :, :-1, :, 3]
         return I
+
+    @staticmethod
+    def _handle_sigma(sigma, batch_size):
+        r"""
+        Handle various sigma input: float, int, tensor
+        """
+        if isinstance(sigma, (float, int)):
+            return torch.tensor(sigma).view(1, 1, 1, 1)
+        elif isinstance(sigma, torch.Tensor):
+            sigma = sigma.squeeze()
+            assert sigma.ndim == 0 or (sigma.ndim == 1 and sigma.size(0) == batch_size)
+
+            return sigma.view(sigma.shape + (1,) * (4 - sigma.ndim))

--- a/deepinv/models/tgv.py
+++ b/deepinv/models/tgv.py
@@ -97,17 +97,17 @@ class TGVDenoiser(Denoiser):
 
         if restart:
             self.x2 = y.clone()
-            self.r2 = torch.zeros((*self.x2.shape, 2), device=self.x2.device).type(
-                self.x2.dtype
+            self.r2 = torch.zeros(
+                (*self.x2.shape, 2), device=self.x2.device, dtype=self.x2.dtype
             )
-            self.u2 = torch.zeros((*self.x2.shape, 4), device=self.x2.device).type(
-                self.x2.dtype
+            self.u2 = torch.zeros(
+                (*self.x2.shape, 4), device=self.x2.device, dtype=self.x2.dtype
             )
             self.restart = False
 
         if ths is not None:
-            lambda1 = self._handle_sigma(ths, y.size(0)) * 0.1
-            lambda2 = self._handle_sigma(ths, y.size(0)) * 0.15
+            lambda1 = self._handle_sigma(ths, y.size(0)).to(y.device, y.dtype) * 0.1
+            lambda2 = self._handle_sigma(ths, y.size(0)).to(y.device, y.dtype) * 0.15
 
         cy = (y**2).sum() / 2
         primalcostlowerbound = 0
@@ -127,9 +127,9 @@ class TGVDenoiser(Denoiser):
             self.r2 = self.r2 + self.rho * (r - self.r2)
             self.u2 = self.u2 + self.rho * (u - self.u2)
 
-            rel_err = torch.linalg.norm(
-                x_prev.flatten() - self.x2.flatten()
-            ) / torch.linalg.norm(self.x2.flatten() + 1e-12)
+            rel_err = torch.linalg.norm(x_prev.flatten() - self.x2.flatten()) / (
+                torch.linalg.norm(self.x2.flatten()) + 1e-12
+            )
 
             if _ > 1 and rel_err < self.crit:
                 self.has_converged = True

--- a/deepinv/models/tv.py
+++ b/deepinv/models/tv.py
@@ -78,7 +78,7 @@ class TVDenoiser(Denoiser):
         return u / (
             torch.maximum(
                 torch.sqrt(torch.sum(u**2, axis=-1)) / lambda2,
-                torch.tensor([1], device=u.device).type(u.dtype),
+                torch.tensor([1], device=u.device, dtype=u.dtype),
             ).unsqueeze(-1)
         )
 
@@ -111,7 +111,7 @@ class TVDenoiser(Denoiser):
             u2 = self.u2.clone()
 
         if ths is not None:
-            lambd = self._handle_sigma(ths, y.size(0))
+            lambd = self._handle_sigma(ths, y.size(0)).to(y.device, y.dtype)
 
         for _ in range(self.n_it_max):
             x_prev = x2

--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -218,7 +218,7 @@ class WaveletDenoiser(Denoiser):
         for level in range(1, self.level + 1):
             ths_cur = self.reshape_ths(ths, level)
             for c, key in enumerate(["aad", "ada", "daa", "add", "dad", "dda", "ddd"]):
-                coeffs[level][key] = self.prox_l1(coeffs[level][key], ths_cur[c])
+                coeffs[level][key] = self.thresold_func(coeffs[level][key], ths_cur[c])
         return coeffs
 
     def threshold_ND(self, coeffs, ths):
@@ -243,7 +243,9 @@ class WaveletDenoiser(Denoiser):
             padding_bottom = h % 2
             padding_right = w % 2
             p = (padding_bottom, padding_right)
-            x = torch.nn.functional.pad(x, (0, p[0], 0, p[1]), mode="replicate")
+            x = torch.nn.functional.pad(
+                x, (0, padding_right, 0, padding_bottom), mode="replicate"
+            )
         elif self.dimension == 3:
             d, h, w = x.size()[-3:]
             padding_depth = d % 2
@@ -251,7 +253,9 @@ class WaveletDenoiser(Denoiser):
             padding_right = w % 2
             p = (padding_depth, padding_bottom, padding_right)
             x = torch.nn.functional.pad(
-                x, (0, p[0], 0, p[1], 0, p[2]), mode="replicate"
+                x,
+                (0, padding_right, 0, padding_bottom, 0, padding_depth),
+                mode="replicate",
             )
         return x, p
 
@@ -275,9 +279,11 @@ class WaveletDenoiser(Denoiser):
         Since the approximation coefficients are not thresholded, we do not need to provide a thresholding parameter,
         ths has shape (n_levels-1, 3).
         """
+
+        # Return tensor of shape (B, n_level - 1, numel)
         numel = 3 if self.dimension == 2 else 7
         if not torch.is_tensor(ths):
-            if isinstance(ths, int) or isinstance(ths, float):
+            if isinstance(ths, (int, float)):
                 ths_cur = [ths] * numel
             elif len(ths) == 1:
                 ths_cur = [ths[0]] * numel
@@ -286,12 +292,47 @@ class WaveletDenoiser(Denoiser):
                 if len(ths_cur) == 1:
                     ths_cur = [ths_cur[0]] * numel
         else:
-            if len(ths.shape) == 1:  # Needs to reshape to shape (n_levels-1, 3)
-                ths_cur = ths.squeeze().repeat(numel)
+            if ths.ndim == 0 or ths.ndim == 1:  # a tensor of shape 0 or (B,)
+                return self._reshape_ths_one_dim(ths, level)
+            elif ths.ndim == 2:  # (B, n_levels-1)
+                return self._reshape_ths_two_dim(ths, level)
+            elif ths.ndim == 3:
+                # (B, n_levels-1, numel) or (B, n_levels-1, 1)
+                ths_cur = self._reshape_ths_three_dim(ths, level)
             else:
-                ths_cur = ths[level - 2]
+                raise ValueError(
+                    f"Expected tensor of 0, 1, 2 or 3 dimensions. Got tensor of {ths.ndim} dimensions"
+                )
 
         return ths_cur
+
+    def _reshape_ths_one_dim(self, ths, level):
+        numel = 3 if self.dimension == 2 else 7
+        return [ths] * numel
+
+    def _reshape_ths_two_dim(self, ths, level):
+        numel = 3 if self.dimension == 2 else 7
+        if ths.size(1) == 1:
+            return [ths[:, 0]] * numel
+        else:
+            assert ths.size(1) == self.level
+            return [ths[:, level - 2]] * numel
+
+    def _reshape_ths_three_dim(self, ths, level):
+        numel = 3 if self.dimension == 2 else 7
+        if ths.size(1) == 1:
+            ths = ths.expand(-1, self.level, -1)
+        assert (
+            ths.size(1) == self.level
+        ), f"Expected tensor of shape (B, {self.level}, {numel}), got {ths.shape}"
+        if ths.size(-1) == numel:
+            return ths.permute(2, 0, 1)[..., level - 2]
+        elif ths.size(-1) == 1:
+            return self._reshape_ths_two_dim(ths[..., 0], level)
+        else:
+            raise ValueError(
+                f"Expected tensor of shape (B, {self.level}, {numel}), got {ths.shape}"
+            )
 
     def forward(self, x, ths=0.1, **kwargs):
         r"""
@@ -300,8 +341,8 @@ class WaveletDenoiser(Denoiser):
         :param torch.Tensor x: noisy image.
         :param int, float, torch.Tensor ths: thresholding parameter :math:`\gamma`.
             If `ths` is a tensor, it should be of shape
-            ``(1, )`` (same coefficent for all levels), ``(n_levels-1, )`` (one coefficient per level),
-            or ``(n_levels-1, 3)`` (one coefficient per subband and per level).
+            ``(B,)`` (same coefficent for all levels), ``(B, n_levels-1)`` (one coefficient per level),
+            or ``(B, n_levels-1, 3)`` (one coefficient per subband and per level). `B` should be the same as the batch size of the input or `1`.
             If ``non_linearity`` equals ``"soft"`` or ``"hard"``, ``ths`` serves as a (soft or hard)
             thresholding parameter for the wavelet coefficients. If ``non_linearity`` equals ``"topk"``,
             ``ths`` can indicate the number of wavelet coefficients

--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -138,7 +138,7 @@ class WaveletDenoiser(Denoiser):
             return float(ths)
         elif isinstance(ths, torch.Tensor):
             ths = ths.squeeze()
-            return ths.view(-1, *([1] * (x.ndim - 1)))
+            return ths.view(-1, *([1] * (x.ndim - 1))).to(x.device)
         else:
             raise ValueError(f"Invalid threshold type: {type(ths)}")
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -375,7 +375,12 @@ def test_denoiser_sigma_gray(batch_size, denoiser, device):
     sigma = torch.tensor(0.1)
     y = noiser(x, sigma=sigma)
     with torch.no_grad():
-        x_hat = model(x, sigma)
+        x_hat = model(y, sigma)
+    assert x_hat.shape == x.shape
+
+    # Same sigma but a float
+    with torch.no_grad():
+        x_hat = model(y, sigma)
     assert x_hat.shape == x.shape
 
     # Each sigma for each image in the batch
@@ -383,7 +388,35 @@ def test_denoiser_sigma_gray(batch_size, denoiser, device):
         sigma = torch.linspace(0.1, 0.3, batch_size, device=device)
         with torch.no_grad():
             y = noiser(x, sigma=sigma)
-        x_hat = model(x, sigma)
+            x_hat = model(y, sigma)
+        assert x_hat.shape == x.shape
+
+
+@pytest.mark.parametrize("denoiser", MODEL_LIST)
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+def test_denoiser_sigma_color(batch_size, denoiser, device):
+    img_size = (3, 64, 64)
+    model = choose_denoiser(denoiser, img_size).to(device)
+    noiser = dinv.physics.GaussianNoise()
+    x = torch.ones((batch_size,) + img_size, device=device, dtype=torch.float32)
+    # Same sigma for all image in the batch
+    sigma = torch.tensor(0.1)
+    y = noiser(x, sigma=sigma)
+    with torch.no_grad():
+        x_hat = model(y, sigma)
+    assert x_hat.shape == x.shape
+
+    # Same sigma but a float
+    with torch.no_grad():
+        x_hat = model(y, sigma)
+    assert x_hat.shape == x.shape
+
+    # Each sigma for each image in the batch
+    if batch_size > 1:
+        sigma = torch.linspace(0.1, 0.3, batch_size, device=device)
+        with torch.no_grad():
+            y = noiser(x, sigma=sigma)
+            x_hat = model(y, sigma)
         assert x_hat.shape == x.shape
 
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -364,19 +364,7 @@ def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
     assert x_hat.shape == x.shape
 
 
-@pytest.mark.parametrize(
-    "denoiser",
-    list(
-        set(MODEL_LIST_1_CHANNEL)
-        - set(
-            [
-                "epll",
-                "waveletdenoiser",
-                "waveletdict",
-            ]
-        )
-    ),
-)
+@pytest.mark.parametrize("denoiser", MODEL_LIST_1_CHANNEL)
 @pytest.mark.parametrize("batch_size", [1, 2, 3])
 def test_denoiser_sigma_gray(batch_size, denoiser, device):
     img_size = (1, 64, 64)

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -2,6 +2,7 @@ import sys
 import pytest
 import torch
 from torch.utils.data import DataLoader, Dataset
+from torchvision.transforms.functional import rgb_to_grayscale
 
 import deepinv as dinv
 from dummy import DummyCircles, DummyModel
@@ -89,11 +90,17 @@ def choose_denoiser(name, imsize):
         out = dinv.models.Restormer(in_channels=imsize[0], out_channels=imsize[0])
     elif name == "ncsnpp":
         out = dinv.models.NCSNpp(
-            in_channels=imsize[0], out_channels=imsize[0], img_resolution=imsize[1]
+            in_channels=imsize[0],
+            out_channels=imsize[0],
+            img_resolution=imsize[1],
+            pretrained=None,
         )
     elif name == "admunet":
         out = dinv.models.ADMUNet(
-            in_channels=imsize[0], out_channels=imsize[0], img_resolution=imsize[1]
+            in_channels=imsize[0],
+            out_channels=imsize[0],
+            img_resolution=imsize[1],
+            pretrained=None,
         )
     else:
         raise Exception("Unknown denoiser")
@@ -786,7 +793,10 @@ def test_pannet():
 def test_ncsnpp_net(device, image_size, n_channels, batch_size, precond, use_fp16):
     # Load the pretrained model
     model = dinv.models.NCSNpp(
-        img_resolution=image_size, in_channels=n_channels, out_channels=n_channels
+        img_resolution=image_size,
+        in_channels=n_channels,
+        out_channels=n_channels,
+        pretrained=None,
     )
     if precond:
         model = dinv.models.EDMPrecond(model, use_fp16=use_fp16).to(device)


### PR DESCRIPTION
Fix the following issue related to deepinv denoisers:
- ICNN.grad not working inside torch.no_grad()
-  Some denoisers dont work for different combination of image and noise level sigma:
    - Batch of image, single value of sigma (a float or a tensor)   (BM3D when a single sigma is given as a tensor), ADMUnet, NCSNpp
    - Batch of  image and batch of sigma (TVDenoiser, TGVDenoiser, WaveletDenoiser)
 - EPLL in #503 
 - Add some more tests for the denoisers
 -  -  -  - 



### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
