### PR TITLE
Fix the sitemap urls

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,6 +66,10 @@ nitpicky = True
 autodoc_inherit_docstrings = False
 # for sitemap
 html_baseurl = "https://deepinv.github.io/deepinv/"
+# the default scheme makes for wrong urls so we specify it properly here
+# For more details, see:
+# https://sphinx-sitemap.readthedocs.io/en/v2.5.0/advanced-configuration.html
+sitemap_url_scheme = "{link}"
 
 ####  userguide directive ###
 from docutils import nodes


### PR DESCRIPTION
Towards fixing #505

The urls listed in the sitemap are currently incorrect due to a /en bit appended by default.

The fix consists in changing the value of `sitemap_url_scheme` from its default value `{lang}{version}{link}` to `{link}` instead. Note that unlike `{lang}` which defaults to `/en`, `version` appears to default to the empty string instead of the actual library version.

It is explained here: https://sphinx-sitemap.readthedocs.io/en/v2.5.0/advanced-configuration.html

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
