### PR TITLE
Fix test_inpainting_generator_random_ratio

### DIFF
--- a/deepinv/tests/test_generators.py
+++ b/deepinv/tests/test_generators.py
@@ -458,9 +458,8 @@ def test_inpainting_generators(
 @pytest.mark.parametrize("num_channels", NUM_CHANNELS)
 @pytest.mark.parametrize("device", DEVICES)
 @pytest.mark.parametrize("dtype", DTYPES)
-def test_inpainting_generator_random_ratio(num_channels, device, dtype):
-    rng = torch.Generator().manual_seed(0)
-
+@pytest.mark.parametrize("rng", [torch.Generator().manual_seed(0)])
+def test_inpainting_generator_random_ratio(num_channels, device, dtype, rng):
     # NOTE elements of this test are now redundant given above tests
     size = (100, 100)  # we take it large to have significant statistical numbers after
     physics = dinv.physics.Inpainting((num_channels, size[0], size[1]), 0.9)


### PR DESCRIPTION
Fixes #537 

* Make `test_inpainting_generator_random_ratio` deterministic by seeding the `torch.randn` calls
* Increase error tolerance to make the test less dependent on the rng state
 
**Checks**

I found a rng state that makes the test fail then verified that 1) seeding the randn calls make the test pass and that independently from that 2) increasing the tolerance also makes the test pass.

### Checks to be done before submitting your PR
- [x] `python3 -m pytest tests/` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
