### PR TITLE
Add an error on trainer directory collisions instead of overwriting files silently

### DIFF
--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -831,8 +831,8 @@ def test_out_dir_collision_detection(dummy_dataset, imsize, device, dummy_model)
 
     timestamp = get_timestamp()
 
-    # NOTE: Due to the way it's imported in the trainer module we need to patch
-    # the importing module instead of the imported module.
+    # NOTE: Due to the way it's imported in the trainer module we need to patch
+    # the importing module instead of the imported module.
     with patch.object(dinv.training.trainer, "get_timestamp", return_value=timestamp):
         with pytest.raises(FileExistsError, match=re.escape(timestamp)):
             # Train twice

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -749,7 +749,7 @@ def test_total_loss(dummy_dataset, imsize, device, dummy_model):
 # epoch 2, and so on. Then, we run the trainer while capturing the standard
 # output to get # the reported values for the gradient norms and compare them
 # to the expected values.
-def test_out_dir_collision_detection(dummy_dataset, imsize, device, dummy_model):
+def test_gradient_norm(dummy_dataset, imsize, device, dummy_model):
     train_data, eval_data = dummy_dataset, dummy_dataset
     dataloader = DataLoader(train_data, batch_size=2)
     physics = dinv.physics.Inpainting(tensor_size=imsize, device=device, mask=0.5)

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -831,7 +831,9 @@ def test_out_dir_collision_detection(dummy_dataset, imsize, device, dummy_model)
 
     timestamp = get_timestamp()
 
-    with patch.object(dinv.utils, "get_timestamp", return_value=timestamp):
+    # NOTE: Due to the way it's imported in the trainer module we need to patch
+    # the importing module instead of the imported module.
+    with patch.object(dinv.training.trainer, "get_timestamp", return_value=timestamp):
         with pytest.raises(FileExistsError, match=re.escape(timestamp)):
             # Train twice
             for _ in range(2):

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -816,7 +816,7 @@ def test_out_dir_collision_detection(dummy_dataset, imsize, device, dummy_model)
     assert torch.allclose(gradient_norms, expected_gradient_norms, atol=1e-2)
 
 
-# Test output directory collision detection
+# Test output directory collision detection
 # It is difficult to deterministically trigger actual collisions so we mock the
 # get_timestamp function used in the implementation to make it return the same
 # value every time it is called. This forces a collision to occur and we make
@@ -833,7 +833,7 @@ def test_out_dir_collision_detection(dummy_dataset, imsize, device, dummy_model)
 
     with patch.object(dinv.utils, "get_timestamp", return_value=timestamp):
         with pytest.raises(FileExistsError, match=re.escape(timestamp)):
-            # Train twice
+            # Train twice
             for _ in range(2):
                 trainer = dinv.Trainer(
                     model,

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -24,6 +24,7 @@ from conftest import no_plot
 
 NO_LEARNING = ["A_dagger", "A_adjoint", "prox_l2", "y"]
 
+
 @pytest.fixture
 def imsize():
     return (3, 37, 31)
@@ -43,7 +44,7 @@ def physics(imsize, device):
 
 @pytest.fixture
 def save_path():
-    # NOTE: The save path should be unique to avoid collision errors.
+    # NOTE: The save path should be unique to avoid collision errors.
     with tempfile.TemporaryDirectory() as dirname:
         yield dirname
 
@@ -836,7 +837,9 @@ def test_gradient_norm(dummy_dataset, imsize, device, dummy_model, save_path):
 # get_timestamp function used in the implementation to make it return the same
 # value every time it is called. This forces a collision to occur and we make
 # sure that it is detected as it should.
-def test_out_dir_collision_detection(dummy_dataset, imsize, device, dummy_model, save_path):
+def test_out_dir_collision_detection(
+    dummy_dataset, imsize, device, dummy_model, save_path
+):
     train_data, eval_data = dummy_dataset, dummy_dataset
     dataloader = DataLoader(train_data, batch_size=2)
     physics = dinv.physics.Inpainting(tensor_size=imsize, device=device, mask=0.5)

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -340,7 +340,7 @@ class Trainer:
             # directory. For this reason, we make sure the directory does not
             # already exist.
             dir_path = f"{self.save_path}/{get_timestamp()}"
-            # Acquire the output directory (might fail with an exception)
+            # Acquire the output directory (might fail with an exception)
             os.makedirs(dir_path, exist_ok=False)
             self.save_path = dir_path
         else:

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -335,9 +335,16 @@ class Trainer:
         if train and self.check_grad:
             self.check_grad_val = AverageMeter("Gradient norm", ":.2e")
 
-        self.save_path = (
-            f"{self.save_path}/{get_timestamp()}" if self.save_path else None
-        )
+        if self.save_path:
+            # NOTE: Two separate training should not write to the same
+            # directory. For this reason, we make sure the directory does not
+            # already exist.
+            dir_path = f"{self.save_path}/{get_timestamp()}"
+            # Acquire the output directory (might fail with an exception)
+            os.makedirs(dir_path, exist_ok=False)
+            self.save_path = dir_path
+        else:
+            self.save_path = None
 
         # count the overall training parameters
         if self.verbose and train:


### PR DESCRIPTION
Fixes #525

This PR is a quick fix to prevent data losses due to overwriting until we decide how best to deal with collisions (let acquisition fail or add a retry strategy).

We let the training fail when the output directory already exists before training starts thereby preventing concurrent training writing (and overwriting) files in the same directory.

The other tests are currently prone to collisions and fail with this fix so I change them so they use unique directories.

**Reproducing**

```python
import deepinv as dinv
from torch.utils.data import DataLoader
import torch
from pathlib import Path
from torchvision import transforms
from deepinv.utils.demo import load_dataset

from unittest.mock import patch
import math
import threading
import copy
import os

physics = dinv.physics.Inpainting(tensor_size=(3, 16, 16), mask=0.5, device="cpu")

train_dataset = dinv.datasets.CBSD68(
    "data/Set14",
    transform=transforms.Compose(
        [
            transforms.ToTensor(),
            transforms.Resize((16, 16)),
        ]
    ),
    download=True,
)
train_dataloader = DataLoader(train_dataset, batch_size=1, shuffle=False)

backbone = dinv.models.UNet(in_channels=3, out_channels=3, scales=2)
model = dinv.models.ArtifactRemoval(backbone)

losses = [
    dinv.loss.SupLoss(),
]

optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)

# Increase the probability of collision by running the same code many times
for _ in range(100):
    paths = []

    def train_worker(run_idx: int):
        trainer = dinv.Trainer(
            model=copy.deepcopy(model),    # avoid parameter clashes
            device="cpu",
            save_path="ckps",
            verbose=True,
            show_progress_bar=False,
            physics=physics,
            epochs=2,
            losses=copy.deepcopy(losses),  # avoid shared state
            optimizer=copy.deepcopy(optimizer),
            train_dataloader=train_dataloader,
            online_measurements=True,
            check_grad=True,
        )

        trainer.train()
        paths.append(trainer.save_path)

    threads = []
    for i in range(2):                      # spin up exactly two threads
        t = threading.Thread(target=train_worker, args=(i,))
        t.start()
        threads.append(t)

    for t in threads:                       # wait for both to finish
        t.join()

    if len(paths) != len(set(paths)):
        raise RuntimeError(
            f"Collision detected: {len(paths)} paths, {len(set(paths))} unique paths"
        )

```


### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
