### PR TITLE
Increase test coverage of `deepinv.utils`

### DIFF
--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -3,6 +3,8 @@ import torch
 import pytest
 from deepinv.utils.decorators import _deprecated_alias
 import warnings
+import numpy as np
+from contextlib import nullcontext
 
 
 @pytest.fixture
@@ -172,3 +174,50 @@ def test_deprecated_alias():
         warnings.simplefilter("always")
         dummy_function(new_arg=0.3)
         assert len(record) == 0
+
+
+@pytest.mark.parametrize("size", [64, 128])
+@pytest.mark.parametrize("n_data", [1, 2, 3])
+@pytest.mark.parametrize("transform", [None, lambda x: x])
+@pytest.mark.parametrize("length", [1, 2, 10, np.inf])
+def test_random_phantom_dataset(size, n_data, transform, length):
+    # Although it is the default value for the parameter length, the current
+    # implementation fails when it is used. We simply verify this behavior
+    # but it will probably need to be changed in the future.
+    dataset = None
+    with pytest.raises(ValueError) if length == np.inf else nullcontext():
+        dataset = deepinv.utils.RandomPhantomDataset(
+            size=size, n_data=n_data, transform=transform, length=length
+        )
+        assert dataset is not None, "Dataset should not be None when length is finite."
+
+    if dataset is not None:
+        x, y = dataset[0]
+
+        assert (
+            len(dataset) == length
+        ), "Length of dataset should match the specified length."
+
+        assert x.shape == (
+            n_data,
+            size,
+            size,
+        ), "Shape of phantom should match (n_data, size, size)."
+
+
+@pytest.mark.parametrize("size", [64, 128])
+@pytest.mark.parametrize("n_data", [1, 2, 3])
+@pytest.mark.parametrize("transform", [None, lambda x: x])
+def test_shepp_logan_dataset(size, n_data, transform):
+    dataset = deepinv.utils.SheppLoganDataset(
+        size=size, n_data=n_data, transform=transform
+    )
+    x, y = dataset[0]
+
+    assert len(dataset) == 1, "Length of dataset should be 1 for Shepp-Logan phantom."
+
+    assert x.shape == (
+        n_data,
+        size,
+        size,
+    ), "Shape of phantom should match (n_data, size, size)."

--- a/deepinv/utils/phantoms.py
+++ b/deepinv/utils/phantoms.py
@@ -53,6 +53,10 @@ class RandomPhantomDataset(Dataset):
         self.size = size
         self.n_data = n_data
         self.transform = transform
+        if length == np.inf:
+            raise ValueError(
+                "Length cannot be infinite. Please specify a finite length."
+            )
         self.length = int(length)
 
     def __len__(self):


### PR DESCRIPTION
Towards #487

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
