### PR TITLE
set correct env for order in nvida-smi

### DIFF
--- a/deepinv/utils/nn.py
+++ b/deepinv/utils/nn.py
@@ -17,12 +17,14 @@ def get_freer_gpu(verbose=True):
     """
     try:
         pipeline = "nvidia-smi -q -d Memory | grep -A5 GPU | grep Free"
+        env = os.environ.copyy()
+        env["CUDA_DEVICE_ORDER"]="PCI_BUS_ID" # by default 'nvidia-smi' uses 'FASTEST_FIRST' / torch.devices 'PCI_BUS_ID'
         if os.name == "posix":
             shell = True
         else:
             pipeline = ["bash", "-c", pipeline]
             shell = False
-        proc = subprocess.run(pipeline, shell=shell, capture_output=True, text=True)
+        proc = subprocess.run(pipeline, shell=shell, env=env, capture_output=True, text=True)
         stdout = proc.stdout
         lines = stdout.splitlines()
         memory_available = [int(line.split()[2]) for line in lines]


### PR DESCRIPTION
I noticed that utility function `deepinv.utils.nn.get_freeier_gpu()` in practice does not return GPU with 
most of free VRAM memory. The issue is known and described here 
https://discuss.pytorch.org/t/gpu-devices-nvidia-smi-and-cuda-get-device-name-output-appear-inconsistent/13150

Solution is to add an environmental variable in bash/sh shell that runs 'nvidia-smi' command to align with torch library.

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
