### PR TITLE
add auto_release

### DIFF
--- a/.github/scripts/bump_patch_version.py
+++ b/.github/scripts/bump_patch_version.py
@@ -1,0 +1,16 @@
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+    
+with open("pyproject.toml", "rb") as f:
+    data = tomllib.load(f)
+    
+version = data["project"]["version"]
+major, minor, patch = map(int, version.split("."))
+patch += 1
+new_version = f"{major}.{minor}.{patch}"
+data["project"]["version"] = new_version
+with open(file_path, "w") as f:
+    toml.dump(data, f)
+print(f"Bumped version to {new_version}")

--- a/.github/scripts/get_version.py
+++ b/.github/scripts/get_version.py
@@ -1,0 +1,7 @@
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+    
+data = tomllib.load("pyproject.toml")
+print(data["project"]["version"])

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Auto Publish to PyPI
+
+on:
+  schedule:
+    - cron: '0 0 */21 * *'  # every 21 days at 00:00 UTC
+  workflow_dispatch:        # manual trigger
+
+jobs:
+  build-test-publish:
+    name: Auto version, test & publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install tools
+        run: |
+          pip install --upgrade build twine toml
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          python .github/scripts/bump_patch_version.py
+          echo "version=$(python .github/scripts/get_version.py)" >> "$GITHUB_OUTPUT"
+
+      - name: Build the package
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: |
+          python -m twine upload --repository testpypi dist/*
+
+      - name: Install from TestPyPI and test
+        run: |
+          pip install --index-url https://test.pypi.org/simple/ deepinv --extra-index-url https://pypi.org/simple
+          python -c "import deepinv"
+
+      - name: Publish to PyPI
+        if: ${{ success() }}
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          python -m twine upload dist/*
+          
+      - name: Commit version bump and tag
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git commit -am "Release version ${{ steps.bump.outputs.version }}"
+          git tag v${{ steps.bump.outputs.version }}
+          git push origin HEAD --tags
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.bump.outputs.version }}
+          name: Release v${{ steps.bump.outputs.version }}
+          files: dist/*

--- a/deepinv/__about__.py
+++ b/deepinv/__about__.py
@@ -1,3 +1,11 @@
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+    
+with open("pyproject.toml", "rb") as f:
+    metadata = tomllib.load(f)["project"]
+
 __all__ = [
     "__title__",
     "__summary__",
@@ -7,11 +15,14 @@ __all__ = [
     "__license__",
 ]
 
-__title__ = "deepinv"
-__summary__ = "Deep Learning for Inverse Problems Library for PyTorch"
-__version__ = "0.3"
-__author__ = (
-    "Julian Tachella, Samuel Hurault, Matthieu Terris, Dongdong Chen, Andrew Wang"
-)
-__license__ = "BSD 3-Clause Clear"
-__url__ = "https://deepinv.github.io/"
+__title__ = metadata["name"]
+__summary__ = metadata["description"]
+__version__ = metadata["version"]
+authors = ""
+for author in metadata["authors"]:
+    if authors:
+        authors += ", "
+    authors += author["name"]
+__author__ = authors
+__license__ = metadata["license"]["text"]
+__url__ = metadata["urls"]["Homepage"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,15 +19,27 @@ import doctest
 basedir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, basedir)
 
+    
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "deepinverse"
-copyright = "2024, deepinverse contributors"
-author = (
-    "Julian Tachella, Matthieu Terris, Samuel Hurault, Dongdong Chen and Andrew Wang"
-)
-release = "0.3"
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+with open(os.path.join(basedir, "pyproject.toml"), "rb") as f:
+    metadata = tomllib.load(f)["project"]
+    
+project = metadata["name"]
+copyright = "deepinverse contributors"
+
+author = ""
+for auth in metadata["authors"]:
+    if auth:
+        author += ", "
+    author += auth["name"]
+release = metadata["version"]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
add automatic releases every 21 days, which add a patch to the current version ie going from `a.b.c` to `a.b.c'` where `c'=c+1`. The github action should check first with TestPyPI that everything is working fine before doing the final release.

### Checks to be done before submitting your PR
- [ ] `python3 -m pytest tests/` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
