### PR TITLE
Fix syntaxerror in docs build

### DIFF
--- a/deepinv/physics/singlepixel.py
+++ b/deepinv/physics/singlepixel.py
@@ -7,7 +7,7 @@ from deepinv.utils.decorators import _deprecated_alias
 
 
 def hadamard_1d(u, normalize=True):
-    """
+    r"""
     Multiply H_n @ u where H_n is the Hadamard matrix of dimension n x n.
 
     :param torch.Tensor u: Input tensor of shape ``(..., n)``.

--- a/deepinv/transform/augmentation.py
+++ b/deepinv/transform/augmentation.py
@@ -63,7 +63,7 @@ class RandomNoise(Transform):
 
 
 class RandomPhaseError(Transform):
-    """Random phase error transform.
+    r"""Random phase error transform.
 
     This transform is specific to MRI problems, and adds a phase error to k-space using:
 


### PR DESCRIPTION
Very minor fix

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
