### PR TITLE
fix release one last time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,39 +45,18 @@ jobs:
             echo "❌ One or both workflows failed — aborting."
             exit 1
           fi
+          
+      - name: Install tools
+        run: |
+          pip install --upgrade tomlkit
 
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Check for recent release commit
-        id: check_release
-        run: |
-          LAST_COMMIT_MSG=$(git log -1 --pretty=%s)
-          echo "Last commit: $LAST_COMMIT_MSG"
-          if [[ "$LAST_COMMIT_MSG" =~ ^Release\ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "Latest commit is a release. Skipping release process."
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Exit if no new changes
-        if: steps.check_release.outputs.skip == 'true'
-        run: |
-          echo "No new changes since last release. Skipping workflow."
-          exit 1
           
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
-
-      - name: Install tools
-        run: |
-          pip install --upgrade build twine tomlkit
-
-      - name: Build the package
-        run: python -m build
 
       - name: Update changelog
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,17 +46,17 @@ jobs:
             exit 1
           fi
           
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
       - name: Install tools
         run: |
           pip install --upgrade tomlkit
 
       - name: Checkout code
         uses: actions/checkout@v4
-          
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
 
       - name: Update changelog
         id: changelog
@@ -78,6 +78,9 @@ jobs:
             This automatic PR updates the version to v${{ steps.bump.outputs.version }} and updates the changelog.
             Please merge this PR to finalize the release.
           commit-message: "Release v${{ steps.bump.outputs.version }}"
+          add-paths: |
+            pyproject.toml
+            CHANGELOG.rst
           base: main
           labels: release
           delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Auto Publish to PyPI
 
 on:
-  schedule:
-    - cron: '0 0 */21 * *'  # every 21 days at 00:00 UTC
   workflow_dispatch:        # manual trigger
     inputs:
       bump_type:
@@ -99,13 +97,18 @@ jobs:
             exit 1
           fi
 
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add pyproject.toml CHANGELOG.rst 
-          git commit -m "Release version ${{ steps.bump.outputs.version }}"
-          git push origin HEAD
+      - name: create PR with changes
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: release-${{ steps.bump.outputs.version }}
+          title: "Release v${{ steps.bump.outputs.version }}"
+          body: |
+            This automatic PR updates the version to v${{ steps.bump.outputs.version }} and updates the changelog.
+            Please merge this PR to finalize the release.
+          commit-message: "Release v${{ steps.bump.outputs.version }}"
+          base: main
+          labels: release
+          delete-branch: true
           
       - name: Publish to TestPyPI
         env:
@@ -121,14 +124,15 @@ jobs:
           python -c "import deepinv"
           
       - name: Publish to PyPI
-        if: ${{ success() }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        if: ${{ github.event.inputs.bump_type != 'dev' }} and ${{ success() }}
         run: |
           python -m twine --verbose upload dist/*
 
       - name: Create Github release
+        if: ${{ github.event.inputs.bump_type != 'dev' }} and ${{ success() }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.bump.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,17 +90,10 @@ jobs:
           python .github/scripts/bump_version.py pyproject.toml ${{github.event.inputs.bump_type}}
           echo "version=$(python .github/scripts/get_version.py pyproject.toml)" >> "$GITHUB_OUTPUT"
 
-      - name: Stop if not on main
-        run: |
-          if [ "${{ github.ref_name }}" != "main" ]; then
-            echo "❌ Not on main branch — skipping release."
-            exit 1
-          fi
-
       - name: create PR with changes
         uses: peter-evans/create-pull-request@v7
         with:
-          branch: release-${{ steps.bump.outputs.version }}
+          branch: release-branch
           title: "Release v${{ steps.bump.outputs.version }}"
           body: |
             This automatic PR updates the version to v${{ steps.bump.outputs.version }} and updates the changelog.
@@ -109,28 +102,7 @@ jobs:
           base: main
           labels: release
           delete-branch: true
-          
-      - name: Publish to TestPyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-        run: |
-          python -m twine check dist/*
-          python -m twine upload --verbose --repository testpypi dist/*
-
-      - name: Install from TestPyPI and test
-        run: |
-          pip install --index-url https://test.pypi.org/simple/ deepinv --extra-index-url https://pypi.org/simple
-          python -c "import deepinv"
-          
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        if: ${{ github.event.inputs.bump_type != 'dev' }} and ${{ success() }}
-        run: |
-          python -m twine --verbose upload dist/*
-
+    
       - name: Create Github release
         if: ${{ github.event.inputs.bump_type != 'dev' }} and ${{ success() }}
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -12,6 +12,21 @@ jobs:
       github.event.pull_request.head.ref == 'release-branch'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install tools
+        run: |
+          pip install --upgrade build twine
+
+      - name: Build the package
+        run: python -m build
+
       - name: Publish to TestPyPI
         env:
           TWINE_USERNAME: __token__
@@ -31,3 +46,5 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           python -m twine --verbose upload dist/*
+        
+      

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -1,0 +1,33 @@
+name: Deploy on release branch merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  deploy:
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.ref == 'release-branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: |
+          python -m twine check dist/*
+          python -m twine upload --verbose --repository testpypi dist/*
+
+      - name: Install from TestPyPI and test
+        run: |
+          pip install --index-url https://test.pypi.org/simple/ deepinv --extra-index-url https://pypi.org/simple
+          python -c "import deepinv"
+          
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          python -m twine --verbose upload dist/*


### PR DESCRIPTION
I've separated the release into two different actions: first, we manually run the release.yml which creates a PR, and once the PR is merged, this triggers the second action which uploads the new release to pipy

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
