### PR TITLE
Fix DRUNet doc and signature

### DIFF
--- a/deepinv/models/GSPnP.py
+++ b/deepinv/models/GSPnP.py
@@ -97,7 +97,7 @@ def GSDRUNet(
     :param int in_channels: Number of input channels
     :param int out_channels: Number of output channels
     :param int nb: Number of blocks in the DRUNet
-    :param list nc: Number of channels in the DRUNet
+    :param list[int,int,int,int] nc: number of channels per convolutional layer in the DRUNet. The network has a fixed number of 4 scales with ``nb`` blocks per scale (default: ``[64,128,256,512]``).
     :param str act_mode: activation mode, "R" for ReLU, "L" for LeakyReLU "E" for ELU and "S" for Softplus.
     :param str downsample_mode: Downsampling mode, "avgpool" for average pooling, "maxpool" for max pooling, and
         "strideconv" for convolution with stride 2.

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -23,9 +23,8 @@ class DRUNet(Denoiser):
 
     :param int in_channels: number of channels of the input.
     :param int out_channels: number of channels of the output.
-    :param list nc: number of convolutional layers.
+    :param list[int,int,int,int] nc: number of channels per convolutional layer, the network has a fixed number of 4 scales with ``nb`` blocks per scale (default: ``[64,128,256,512]``).
     :param int nb: number of convolutional blocks per layer.
-    :param int nf: number of channels per convolutional layer.
     :param str act_mode: activation mode, "R" for ReLU, "L" for LeakyReLU "E" for ELU and "s" for Softplus.
     :param str downsample_mode: Downsampling mode, "avgpool" for average pooling, "maxpool" for max pooling, and
         "strideconv" for convolution with stride 2.


### PR DESCRIPTION
The DRUNet class has an unused argument in its documentation ``nf: number of channels per convolutional layer.`` which actually corresponds to the ``nc`` parameter. I've removed ``nf`` from the documentation.

I've also completed the documentation, which was slightly misleading. I was expecting to control the number of scales instanciated in the DRUNet with the ``nc`` argument, while in practice the number of scales is hard-coded and fixed to 4.


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
