### PR TITLE
Add a least-squares option to the conjugate_gradient algorithm

### DIFF
--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -85,7 +85,6 @@ def least_squares(
         parallel_dim = [parallel_dim]
 
     if solver == "lsqr":  # rectangular solver
-
         if gamma is not None:
             eta = 1 / gamma
         else:
@@ -134,7 +133,7 @@ def least_squares(
                 eta = 1 / gamma
             else:
                 eta = 0
-            
+
             x = conjugate_gradient(
                 A=H,
                 b=b,


### PR DESCRIPTION
Following the same signature than the `lsqr` function, the PR adds a least-squares option to the `conjugate_gradient` function. It allows to solve the regularized least-squares problem with an efficient implementation of `ATA` (not permitted by the `lsqr` algorithm which calls `A` and `AT` separately).

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
