### PR TITLE
Add support for new parameters in ``plot_inset``

### DIFF
--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -665,6 +665,8 @@ def plot_inset(
         interpolation=interpolation,
         cbar=cbar,
         dpi=dpi,
+        fig=fig,
+        axs=axs,
         return_fig=True,
         return_axs=True,
     )

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -582,18 +582,29 @@ def plot_parameters(model, init_params=None, save_dir=None, show=True):
 def plot_inset(
     img_list: list[torch.Tensor],
     titles: list[str] = None,
+    save_fn: str = None,
+    save_dir=None,
+    tight=True,
+    max_imgs=4,
+    rescale_mode="min_max",
+    show: bool = True,
+    figsize: tuple[int] = None,
+    suptitle=None,
+    cmap: str = "gray",
+    fontsize=17,
+    interpolation="none",
+    cbar=False,
+    dpi: int = 1200,
+    fig=None,
+    axs=None,
     labels: list[str] = [],
     label_loc: Union[tuple, list] = (0.03, 0.03),
     extract_loc: Union[tuple, list] = (0.0, 0.0),
     extract_size: float = 0.2,
     inset_loc: Union[tuple, list] = (0.0, 0.5),
     inset_size: float = 0.4,
-    figsize: tuple[int] = None,
-    save_fn: str = None,
-    dpi: int = 1200,
-    show: bool = True,
     return_fig: bool = False,
-    cmap: str = "gray",
+    return_axs=False,
 ):
     r"""Plots a list of images with zoomed-in insets extracted from the images.
 
@@ -603,31 +614,60 @@ def plot_inset(
 
     Coordinates are fractions from 0-1, (0, 0) is the top left corner and (1, 1) is the bottom right corner.
 
-    :param list[torch.Tensor], torch.Tensor img_list: list of images to plot or single image.
-    :param list[str] titles: list of titles for each image, has to be same length as img_list.
+    :param list[torch.Tensor], dict[str,torch.Tensor], torch.Tensor img_list: list of images, single image,
+        or dict of titles: images to plot.
+    :param list[str], str, None titles: list of titles for each image, has to be same length as img_list.
+    :param None, str, pathlib.Path save_fn: path to save the plot as a single image (i.e. side-by-side).
+    :param None, str, pathlib.Path save_dir: path to save the plots as individual images.
+    :param bool tight: use tight layout.
+    :param int max_imgs: maximum number of images to plot.
+    :param str rescale_mode: rescale mode, either ``'min_max'`` (images are linearly rescaled between 0 and 1 using
+        their min and max values) or ``'clip'`` (images are clipped between 0 and 1).
+    :param bool show: show the image plot. Under the hood, this calls the ``plt.show()`` function.
+    :param tuple[int] figsize: size of the figure. If ``None``, calculated from the size of ``img_list``.
+    :param str suptitle: title of the figure.
+    :param str cmap: colormap to use for the images. Default: gray
+    :param int fontsize: fontsize for the plot. Default: 17
+    :param str interpolation: interpolation to use for the images.
+        See https://matplotlib.org/stable/gallery/images_contours_and_fields/interpolation_methods.html for more details.
+        Default: none
+    :param bool cbar: whether to add colorbar to the images.
+    :param int dpi: DPI to save images.
+    :param None, Figure fig: matplotlib Figure object to plot on. If None, create new Figure. Defaults to None.
+    :param None, Axes axs: matplotlib Axes object to plot on. If None, create new Axes. Defaults to None.
     :param list[str] labels: list of overlaid labels for each image, has to be same length as img_list.
     :param list, tuple label_loc: location or locations for label to be plotted on image, defaults to (.03, .03)
     :param list, tuple extract_loc: image location or locations for extract to be taken from, defaults to (0., 0.)
     :param float extract_size: size of extract to be taken from image, defaults to 0.2
     :param list, tuple inset_loc: location or locations for inset to be plotted on image, defaults to (0., 0.5)
     :param float inset_size: size of inset to be plotted on image, defaults to 0.4
-    :param tuple[int] figsize: size of the figure.
-    :param str save_fn: filename for plot to be saved, if None, don't save, defaults to None
-    :param int dpi: DPI to save images.
-    :param bool show: show the image plot.
     :param bool return_fig: return the figure object.
+    :param bool return_axs: return the axs object.
     """
 
-    fig = plot(
-        img_list,
-        titles,
+    if save_dir:
+        save_dir = Path(save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+    fig, axs = plot(
+        img_list=img_list,
+        titles=titles,
+        save_dir=save_dir,
+        tight=tight,
+        max_imgs=max_imgs,
+        rescale_mode=rescale_mode,
         show=False,
         close=False,
-        return_fig=True,
-        cmap=cmap,
         figsize=figsize,
+        suptitle=suptitle,
+        cmap=cmap,
+        fontsize=fontsize,
+        interpolation=interpolation,
+        cbar=cbar,
+        dpi=dpi,
+        return_fig=True,
+        return_axs=True,
     )
-    axs = fig.axes
     batch_size = img_list[0].shape[0]
 
     # Expand the locs over img_list and batch dimensions
@@ -642,75 +682,87 @@ def plot_inset(
     inset_locs = expand_locs(inset_loc, len(img_list) * batch_size)
     label_locs = expand_locs(label_loc, len(img_list) * batch_size)
 
-    for img, ax, label, extract_loc, inset_loc, label_loc in zip_longest(
-        [vol[[i]] for i in range(batch_size) for vol in img_list],
-        axs,
-        labels,
-        extract_locs,
-        inset_locs,
-        label_locs,
-    ):
-        _, _, h, w = img.shape
+    # Loop through all axes and apply the inset to each image
+    for r, row_axs in enumerate(axs):
+        for i, ax in enumerate(row_axs):
+            idx = i * batch_size + r
 
-        # Plot inset
-        axins = ax.inset_axes(
-            (inset_loc[0], 1 - inset_loc[1] - inset_size, inset_size, inset_size)
-        )
-        axins.imshow(
-            rescale_img(img)
-            .type(torch.float32)
-            .squeeze(0)
-            .permute(1, 2, 0)
-            .detach()
-            .cpu()
-            .numpy(),
-            cmap=cmap,
-        )
+            # Get the preprocessed image that's already been displayed in this axis
+            img = img_list[i][[r]]
+            img = preprocess_img(img, rescale_mode=rescale_mode)
 
-        # Set inset image according to extract
-        axins.set_xlim(extract_loc[0] * w, (extract_loc[0] + extract_size) * w)
-        axins.set_ylim((extract_loc[1] + extract_size) * h, extract_loc[1] * h)
-
-        # Inset borders
-        for spine in ["bottom", "top", "left", "right"]:
-            axins.spines[spine].set_color("lime")
-
-        axins.grid(False)
-        axins.set_xticks([])
-        axins.set_yticks([])
-
-        # Extract borders
-        ax.indicate_inset(
-            [
-                extract_loc[0] * w,
-                extract_loc[1] * h,
-                extract_size * w,
-                extract_size * h,
-            ],
-            edgecolor="red",
-        )
-
-        if label is not None:
-            ax.text(
-                label_loc[0],
-                1 - label_loc[1],
-                str(label),
-                fontsize="medium",
-                color="red",
-                ha="left",
-                va="top",
-                transform=ax.transAxes,
-                bbox=dict(boxstyle="square,pad=0", fc="white", ec="none"),
+            loc_in = inset_locs[idx]
+            axins = ax.inset_axes(
+                (
+                    loc_in[0],
+                    1 - loc_in[1] - inset_size,
+                    inset_size,
+                    inset_size,
+                )
             )
+            axins.imshow(
+                img.squeeze(0).permute(1, 2, 0).cpu().numpy(),
+                cmap=cmap,
+                interpolation=interpolation,
+            )
+
+            h, w = img.shape[2], img.shape[3]
+            ex = extract_locs[idx]
+            axins.set_xlim(ex[0] * w, (ex[0] + extract_size) * w)
+            axins.set_ylim((ex[1] + extract_size) * h, ex[1] * h)
+
+            for spine in axins.spines.values():
+                spine.set_color("lime")
+            axins.set_xticks([])
+            axins.set_yticks([])
+            axins.grid(False)
+
+            ax.indicate_inset(
+                [
+                    ex[0] * w,
+                    ex[1] * h,
+                    extract_size * w,
+                    extract_size * h,
+                ],
+                edgecolor="red",
+            )
+
+            if labels is not None and i < len(labels):
+                lab = labels[i]
+                loc_lab = label_locs[idx]
+                ax.text(
+                    loc_lab[0],
+                    1 - loc_lab[1],
+                    str(lab),
+                    fontsize="medium",
+                    color="red",
+                    ha="left",
+                    va="top",
+                    transform=ax.transAxes,
+                    bbox=dict(boxstyle="square,pad=0", fc="white", ec="none"),
+                )
 
     if save_fn:
         plt.savefig(save_fn, dpi=dpi)
 
+    if save_dir:
+        save_dir = Path(save_dir)
+        save_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save the whole figure
+        plt.savefig(save_dir / "inset_images.svg", dpi=dpi)
+
     if show:
         plt.show()
 
+    if return_axs and return_fig:
+        return fig, axs
+
     if return_fig:
         return fig
+
+    if return_axs:
+        return axs
 
 
 def plot_videos(

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -249,8 +249,8 @@ def plot(
         See https://matplotlib.org/stable/gallery/images_contours_and_fields/interpolation_methods.html for more details.
         Default: none
     :param int dpi: DPI to save images.
-    :param None, Figure: matplotlib Figure object to plot on. If None, create new Figure. Defaults to None.
-    :param None, Axes: matplotlib Axes object to plot on. If None, create new Axes. Defaults to None.
+    :param None, matplotlib.figure.Figure fig: matplotlib Figure object to plot on. If None, create new Figure. Defaults to None.
+    :param None, matplotlib.axes.Axes axs: matplotlib Axes object to plot on. If None, create new Axes. Defaults to None.
     :param bool return_fig: return the figure object.
     :param bool return_axs: return the axs object.
     """
@@ -633,8 +633,8 @@ def plot_inset(
         Default: none
     :param bool cbar: whether to add colorbar to the images.
     :param int dpi: DPI to save images.
-    :param None, Figure fig: matplotlib Figure object to plot on. If None, create new Figure. Defaults to None.
-    :param None, Axes axs: matplotlib Axes object to plot on. If None, create new Axes. Defaults to None.
+    :param None, matplotlib.figure.Figure fig: matplotlib Figure object to plot on. If None, create new Figure. Defaults to None.
+    :param None, matplotlib.axes.Axes axs: matplotlib Axes object to plot on. If None, create new Axes. Defaults to None.
     :param list[str] labels: list of overlaid labels for each image, has to be same length as img_list.
     :param list, tuple label_loc: location or locations for label to be plotted on image, defaults to (.03, .03)
     :param list, tuple extract_loc: image location or locations for extract to be taken from, defaults to (0., 0.)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ intersphinx_mapping = {
     "torchvision": ("https://pytorch.org/vision/stable/", None),
     "python": ("https://docs.python.org/3.9/", None),
     "deepinv": ("https://deepinv.github.io/deepinv/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
 # for python3 type hints


### PR DESCRIPTION
This pull request harmonizes the parameters between the ``plot`` and ``plot_inset`` functions, addressing issue #598.

- All parameters in ``plot`` are also supported by ``plot_inset`` (for instance ``rescale_mode``, ``suptitle``, `save_dir``, etc.)
- The docstring is adapted to match the new parameters, reusing the one from ``plot``.
- I also refactored the inner loop of ``plot_inset`` to match the style and structure of ``plot``

Given the redundancy between the two functions, I'm wondering if it wouldn't be better to merge the two functions in the future ? Maybe just add optional parameters related to the insets in ``plot``.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
