### PR TITLE
add ``Trainer`` compatibility with ``Denoiser``

### DIFF
--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -864,3 +864,34 @@ def test_out_dir_collision_detection(
                 )
 
                 trainer.train()
+
+
+# Test that when training a denoiser, the model is unwrapped correctly at
+# the end of training.
+def test_denoiser_unwrap(dummy_dataset, imsize, device, dummy_model, tmpdir):
+    train_data, eval_data = dummy_dataset, dummy_dataset
+    dataloader = DataLoader(train_data, batch_size=2)
+    physics = dinv.physics.Denoising(
+        noise_model=dinv.physics.GaussianNoise(), device=device
+    )
+
+    model = dinv.models.DRUNet().to(device)
+
+    trainer = dinv.Trainer(
+        model,
+        device=device,
+        save_path=tmpdir,
+        verbose=True,
+        show_progress_bar=False,
+        physics=physics,
+        epochs=2,
+        losses=dinv.loss.SupLoss(),
+        optimizer=torch.optim.AdamW(model.parameters(), lr=1e-3),
+        train_dataloader=dataloader,
+        online_measurements=True,
+        check_grad=True,
+    )
+    model = trainer.train()
+
+    # Check that the model is unwrapped correctly
+    assert not hasattr(trainer.model, "backbone_net")


### PR DESCRIPTION
This PR follows the suggestion from @tachella in issue #593. 
When the model passed to the ``Trainer`` is a ``Denoiser``, it is wrapped in an ``ArtifactRemoval`` class. It is unwrapped at the end of the training, and during intermediate checkpoints to preserve the ``state_dict``.

:warning:  Note that this fixes the issue for the specific case of ``Denoiser``, but if we later want to support more general models (e.g., those conditioned on additional inputs such as segmentations or other images), the Trainer may require further generalization.
Let me know if I should add a gallery example or notebook on how to train a denoiser, I think that is a fairly common use case of the library. :smile: 

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
