### PR TITLE
FIX add `__all__` variable in `__about__.py` to fix undefined __version__ attribute

### DIFF
--- a/deepinv/__about__.py
+++ b/deepinv/__about__.py
@@ -7,3 +7,12 @@ __version__ = metadata["Version"]
 __author__ = metadata["Author"]
 __license__ = metadata["License"]
 __url__ = metadata["Project-URL"]
+
+__all__ = [
+    "__title__",
+    "__summary__",
+    "__version__",
+    "__author__",
+    "__license__",
+    "__url__",
+]


### PR DESCRIPTION
Currently 
```
import deepinv
deepinv.__version__
```
fails with an AttributeError

This is because in the `__init__.py` we do `from .__about__ import *` and this command does not import variables in `__about__.py` whose name starts with a dunder, unless  `__all__` is defined

hence the fix
