### PR TITLE
fix metric tests

### DIFF
--- a/deepinv/tests/test_metric.py
+++ b/deepinv/tests/test_metric.py
@@ -69,11 +69,23 @@ def choose_metric(metric_name, device, **kwargs) -> metric.Metric:
         raise ValueError("Incorrect metric name.")
 
 
+@pytest.fixture
+def test_image(device):
+    return load_example(
+        "celeba_example.jpg",
+        img_size=128,
+        resize_mode="resize",
+        device=device,
+    )
+
+
 @pytest.mark.parametrize("metric_name", METRICS)
 @pytest.mark.parametrize("train_loss", [True, False])
 @pytest.mark.parametrize("norm_inputs", [None])
 @pytest.mark.parametrize("channels", [1, 2, 3])
-def test_metrics(metric_name, train_loss, norm_inputs, rng, device, channels):
+def test_metrics(
+    metric_name, train_loss, norm_inputs, rng, device, channels, test_image
+):
     m = choose_metric(
         metric_name,
         device,
@@ -82,12 +94,8 @@ def test_metrics(metric_name, train_loss, norm_inputs, rng, device, channels):
         norm_inputs=norm_inputs,
         reduction="mean",
     )
-    x = load_example(
-        "celeba_example.jpg",
-        img_size=128,
-        resize_mode="resize",
-        device=device,
-    )
+
+    x = test_image.clone()
 
     if metric_name == "QNR":
         x_hat = x


### PR DESCRIPTION
Testing is [sometimes failing](https://github.com/deepinv/deepinv/actions/runs/16461350562) due to an error downloading a test image in `test_metrics` via `load_example`. I believe that this error is coming from the multiple consecutive downloads of the test, which could be avoided by using a `pytest.fixture` that downloads the demo image a single time.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
