### PR TITLE
Ruff zip strict

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Install and run ruff
         run: |
           pip install ruff
-          ruff check --target-version "py310" --select "UP006" --select "F401"
+          ruff check --target-version "py310" --select "UP006" --select "F401" --select "B905"

--- a/deepinv/datasets/satellite.py
+++ b/deepinv/datasets/satellite.py
@@ -120,8 +120,7 @@ class NBUDataset(Dataset):
 
         self.ms_paths = natsorted(self.data_dir.glob("MS_256/*.mat"))
         self.pan_paths = natsorted(self.data_dir.glob("PAN_1024/*.mat"))
-        assert len(self.ms_paths) == len(self.pan_paths), "Image dataset incomplete."
-        self.image_paths = list(zip(self.ms_paths, self.pan_paths))
+        self.image_paths = list(zip(self.ms_paths, self.pan_paths, strict=True))
         for _ms, _pan in self.image_paths:
             assert _ms.name == _pan.name, "MS and PAN filenames do not match."
 

--- a/deepinv/models/diffunet.py
+++ b/deepinv/models/diffunet.py
@@ -936,7 +936,7 @@ def update_ema(target_params, source_params, rate=0.99):
     :param source_params: the source parameter sequence.
     :param rate: the EMA rate (closer to 1 means slower).
     """
-    for targ, src in zip(target_params, source_params):
+    for targ, src in zip(target_params, source_params, strict=True):
         targ.detach().mul_(rate).add_(src, alpha=1 - rate)
 
 

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -197,7 +197,8 @@ class BaseOptim(Reconstructor):
         # By default, each parameter in ``params_algo` is a list.
         # If given as a single number, we convert it to a list of 1 element.
         # If given as a list of more than 1 element, it should have lenght ``max_iter``.
-        for key, value in zip(params_algo.keys(), params_algo.values()):
+        # NOTE: The zip iterator appears to be an unidiomatic version of `metrics.items()`.
+        for key, value in zip(params_algo.keys(), params_algo.values(), strict=True):
             if not isinstance(value, Iterable):
                 params_algo[key] = [value]
             else:
@@ -269,7 +270,10 @@ class BaseOptim(Reconstructor):
         """
         cur_params_dict = {
             key: value[it] if len(value) > 1 else value[0]
-            for key, value in zip(self.params_algo.keys(), self.params_algo.values())
+            # NOTE: The zip iterator appears to be an unidiomatic version of `metrics.items()`.
+            for key, value in zip(
+                self.params_algo.keys(), self.params_algo.values(), strict=True
+            )
         }
         return cur_params_dict
 
@@ -397,8 +401,11 @@ class BaseOptim(Reconstructor):
                     F = X["cost"][i]
                     metrics["cost"][i].append(F.detach().cpu().item())
                 if self.custom_metrics is not None:
+                    # NOTE: The zip iterator appears to be an unidiomatic version of `metrics.items()`.
                     for custom_metric_name, custom_metric_fn in zip(
-                        self.custom_metrics.keys(), self.custom_metrics.values()
+                        self.custom_metrics.keys(),
+                        self.custom_metrics.values(),
+                        strict=True,
                     ):
                         metrics[custom_metric_name][i].append(
                             custom_metric_fn(

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -172,7 +172,7 @@ def least_squares(
 def dot(a, b, dim):
     if isinstance(a, TensorList):
         aux = 0
-        for ai, bi in zip(a.x, b.x):
+        for ai, bi in zip(a.x, b.x, strict=True):
             aux += (ai.conj() * bi).sum(
                 dim=dim, keepdim=True
             )  # performs batched dot product
@@ -445,7 +445,10 @@ def lsqr(
         if b_domain:
             if isinstance(v, TensorList):
                 return TensorList(
-                    [vi * alpha.view(bi_shape) for vi, bi_shape in zip(v, b_shape)]
+                    [
+                        vi * alpha.view(bi_shape)
+                        for vi, bi_shape in zip(v, b_shape, strict=True)
+                    ]
                 )
             else:
                 return v * alpha.view(b_shape)

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -551,7 +551,7 @@ class LinearPhysics(Physics):
             V = [randn_like(au) for au in Au]
             Atv = self.A_adjoint(V, **kwargs)
             s1 = 0
-            for au, v in zip(Au, V):
+            for au, v in zip(Au, V, strict=True):
                 s1 += (v.conj() * au).flatten().sum()
 
         else:

--- a/deepinv/sampling/diffusion.py
+++ b/deepinv/sampling/diffusion.py
@@ -281,8 +281,8 @@ class DiffPIR(Reconstructor):
         >>> (dinv.metric.PSNR()(xhat, x) > dinv.metric.PSNR()(y, x)).cpu() # Should be closer to the original
         tensor([True])
 
-    
-        
+
+
     """
 
     def __init__(
@@ -617,7 +617,7 @@ class DPS(Reconstructor):
 
         seq = range(0, self.num_train_timesteps, skip)
         seq_next = [-1] + list(seq[:-1])
-        time_pairs = list(zip(reversed(seq), reversed(seq_next)))
+        time_pairs = list(zip(reversed(seq), reversed(seq_next), strict=True))
 
         # Initial sample from x_T
         x = torch.randn_like(y) if x_init is None else (2 * x_init - 1)

--- a/deepinv/sampling/sampling.py
+++ b/deepinv/sampling/sampling.py
@@ -255,7 +255,9 @@ class BaseSampling(Reconstructor):
                     if self.history_size:
                         self.history.append(X)
 
-                    for _, (g, stat) in enumerate(zip(g_statistics, statistics)):
+                    for _, (g, stat) in enumerate(
+                        zip(g_statistics, statistics, strict=True)
+                    ):
                         stat.update(g(X))
 
             # Check convergence for all statistics

--- a/deepinv/sampling/sde_solver.py
+++ b/deepinv/sampling/sde_solver.py
@@ -127,7 +127,7 @@ class BaseSDESolver(nn.Module):
             timesteps = timesteps.to(sde.device, sde.dtype)
 
         for t_cur, t_next in tqdm(
-            zip(timesteps[:-1], timesteps[1:]),
+            zip(timesteps[:-1], timesteps[1:], strict=True),
             total=len(timesteps) - 1,
             disable=not verbose,
         ):

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1199,10 +1199,7 @@ def test_mri_fft():
         return torch.cat((right, left), dim=dim)
 
     def roll(x: torch.Tensor, shift: list[int], dim: list[int]) -> torch.Tensor:
-        if len(shift) != len(dim):
-            raise ValueError("len(shift) must match len(dim)")
-
-        for s, d in zip(shift, dim):
+        for s, d in zip(shift, dim, strict=True):
             x = roll_one_dim(x, s, d)
 
         return x
@@ -1358,7 +1355,7 @@ def test_operators_differentiability(name, device):
         with torch.enable_grad():
             y_hat = physics.A(x_hat)
             if isinstance(y_hat, TensorList):
-                for y_hat_item, y_item in zip(y_hat.x, y.x):
+                for y_hat_item, y_item in zip(y_hat.x, y.x, strict=True):
                     loss = torch.nn.functional.mse_loss(y_hat_item, y_item)
                     loss.backward()
                     assert x_hat.requires_grad == True
@@ -1386,7 +1383,7 @@ def test_operators_differentiability(name, device):
             with torch.enable_grad():
                 y_hat = physics.A(x, **parameters)
                 if isinstance(y_hat, TensorList):
-                    for y_hat_item, y_item in zip(y_hat.x, y.x):
+                    for y_hat_item, y_item in zip(y_hat.x, y.x, strict=True):
                         loss = torch.nn.functional.mse_loss(y_hat_item, y_item)
                         loss.backward()
 
@@ -1473,7 +1470,7 @@ def test_device_consistency(name):
             # skip denoising that adds random noise in each forward call
             if not isinstance(physics, dinv.physics.Denoising):
                 if isinstance(y2, TensorList):
-                    for y11, y22 in zip(y1, y2):
+                    for y11, y22 in zip(y1, y2, strict=True):
                         assert torch.linalg.norm((y11.to(cuda) - y22).ravel()) < 1e-5
                 else:
                     assert torch.linalg.norm((y1.to(cuda) - y2).ravel()) < 1e-5

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -307,7 +307,7 @@ def test_sde(device):
         HeunSolver(timesteps=timesteps, rng=rng),
     ]
     sde_classes = [VarianceExplodingDiffusion, VariancePreservingDiffusion]
-    for denoiser, kwargs in zip(denoisers, list_kwargs):
+    for denoiser, kwargs in zip(denoisers, list_kwargs, strict=True):
         for solver in solvers:
             for sde_class in sde_classes:
                 sde = sde_class(

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -317,14 +317,22 @@ def test_trainer_physics_generator_params(
     if loop_random_online_physics:
         # Test measurements random but repeat every epoch
         assert len(set(trainer.ys)) == len(set(trainer.fs)) == N
-        assert all([a == b for (a, b) in zip(trainer.ys[:N], trainer.ys[N:])])
-        assert all([a == b for (a, b) in zip(trainer.fs[:N], trainer.fs[N:])])
+        assert all(
+            [a == b for (a, b) in zip(trainer.ys[:N], trainer.ys[N:], strict=True)]
+        )
+        assert all(
+            [a == b for (a, b) in zip(trainer.fs[:N], trainer.fs[N:], strict=True)]
+        )
     else:
         # Test measurements random but don't repeat
         # This is ok for supervised training but not self-supervised!
         assert len(set(trainer.ys)) == len(set(trainer.fs)) == N * 2
-        assert all([a != b for (a, b) in zip(trainer.ys[:N], trainer.ys[N:])])
-        assert all([a != b for (a, b) in zip(trainer.fs[:N], trainer.fs[N:])])
+        assert all(
+            [a != b for (a, b) in zip(trainer.ys[:N], trainer.ys[N:], strict=True)]
+        )
+        assert all(
+            [a != b for (a, b) in zip(trainer.fs[:N], trainer.fs[N:], strict=True)]
+        )
 
 
 def test_trainer_identity(imsize, rng, device):

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -163,11 +163,11 @@ def test_dirac_like(shape, length):
     y = deepinv.utils.TensorList(
         [
             deepinv.physics.functional.conv2d(xi, hi, padding="circular")
-            for hi, xi in zip(h, x)
+            for hi, xi in zip(h, x, strict=True)
         ]
     )
 
-    for xi, hi, yi in zip(x, h, y):
+    for xi, hi, yi in zip(x, h, y, strict=True):
         assert (
             hi.shape == xi.shape
         ), "Dirac delta should have the same shape as the input tensor."
@@ -199,7 +199,7 @@ def test_plot(
     img_list = torch.ones(shape)
     img_list = [img_list] * n_images if isinstance(img_list, torch.Tensor) else img_list
     titles = "0" if n_images == 1 else [str(i) for i in range(n_images)]
-    img_list = {k: v for k, v in zip(titles, img_list)}
+    img_list = {k: v for k, v in zip(titles, img_list, strict=True)}
     if not with_titles:
         titles = None
     if not dict_img_list:

--- a/deepinv/transform/augmentation.py
+++ b/deepinv/transform/augmentation.py
@@ -106,7 +106,7 @@ class RandomPhaseError(Transform):
         **kwargs,
     ) -> Tensor:
         out = []
-        for _se, _so in zip(se, so):
+        for _se, _so in zip(se, so, strict=True):
             shift = MRIMixin.to_torch_complex(torch.zeros_like(y))
             shift[..., 0::2] = torch.exp(-1j * _se)  # assume readouts in w
             shift[..., 1::2] = torch.exp(-1j * _so)

--- a/deepinv/transform/projective.py
+++ b/deepinv/transform/projective.py
@@ -285,6 +285,7 @@ class Homography(Transform):
                     skew,
                     stretch_x,
                     stretch_y,
+                    strict=True,
                 )
             ],
             dim=0,

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -505,7 +505,8 @@ def wandb_imgs(imgs, captions, n_plot):
 
 
 def wandb_plot_curves(metrics, batch_idx=0, step=0):
-    for metric_name, metric_val in zip(metrics.keys(), metrics.values()):
+    # NOTE: The zip iterator appears to be an unidiomatic version of `metrics.items()`.
+    for metric_name, metric_val in zip(metrics.keys(), metrics.values(), strict=True):
         if len(metric_val) > 0:
             batch_size, n_iter = len(metric_val), len(metric_val[0])
             wandb.log(
@@ -543,7 +544,8 @@ def plot_parameters(model, init_params=None, save_dir=None, show=True):
     fig, ax = plt.subplots(figsize=(7, 7))
 
     if init_params is not None:
-        for key, value in zip(init_params.keys(), init_params.values()):
+        # NOTE: The zip iterator appears to be an unidiomatic version of `metrics.items()`.
+        for key, value in zip(init_params.keys(), init_params.values(), strict=True):
             if not isinstance(value, Iterable):
                 init_params[key] = [value]
 

--- a/deepinv/utils/tensorlist.py
+++ b/deepinv/utils/tensorlist.py
@@ -119,7 +119,7 @@ class TensorList:
         if not isinstance(other, list) and not isinstance(other, TensorList):
             return TensorList([xi + other for xi in self.x])
         else:
-            return TensorList([xi + otheri for xi, otheri in zip(self.x, other)])
+            return TensorList([xi + otheri for xi, otheri in zip(self.x, other, strict=True)])
 
     def __mul__(self, other):
         r"""
@@ -130,7 +130,7 @@ class TensorList:
         if not isinstance(other, list) and not isinstance(other, TensorList):
             return TensorList([xi * other for xi in self.x])
         else:
-            return TensorList([xi * otheri for xi, otheri in zip(self.x, other)])
+            return TensorList([xi * otheri for xi, otheri in zip(self.x, other, strict=True)])
 
     def __rmul__(self, other):
         r"""
@@ -141,7 +141,7 @@ class TensorList:
         if not isinstance(other, list) and not isinstance(other, TensorList):
             return TensorList([xi * other for xi in self.x])
         else:
-            return TensorList([xi * otheri for xi, otheri in zip(self.x, other)])
+            return TensorList([xi * otheri for xi, otheri in zip(self.x, other, strict=True)])
 
     def __truediv__(self, other):
         r"""
@@ -152,7 +152,7 @@ class TensorList:
         if not isinstance(other, list) and not isinstance(other, TensorList):
             return TensorList([xi / other for xi in self.x])
         else:
-            return TensorList([xi / otheri for xi, otheri in zip(self.x, other)])
+            return TensorList([xi / otheri for xi, otheri in zip(self.x, other, strict=True)])
 
     def __neg__(self):
         r"""
@@ -170,7 +170,7 @@ class TensorList:
         if not isinstance(other, list) and not isinstance(other, TensorList):
             return TensorList([xi - other for xi in self.x])
         else:
-            return TensorList([xi - otheri for xi, otheri in zip(self.x, other)])
+            return TensorList([xi - otheri for xi, otheri in zip(self.x, other, strict=True)])
 
     def conj(self):
         r"""

--- a/examples/basics/demo_denoiser_tour.py
+++ b/examples/basics/demo_denoiser_tour.py
@@ -63,7 +63,7 @@ def show_image_comparison(images, suptitle=None, ref=None):
         psnr = [dinv.metric.cal_psnr(image, im).item() for im in images.values()]
         titles = [
             f"{name} \n (PSNR: {psnr:.2f})" if name != "Original" else name
-            for name, psnr in zip(images.keys(), psnr)
+            for name, psnr in zip(images.keys(), psnr, strict=True)
         ]
     # Plot the images with zoom-in
     fig = plot_inset(
@@ -168,7 +168,7 @@ psnr = dinv.loss.metric.PSNR()
 psnr_x = psnr(noisy_images, image)
 res = [
     {"sigma": sig.item(), "denoiser": "Noisy", "psnr": v.item(), "time": 0.0}
-    for sig, v in zip(noise_levels, psnr_x)
+    for sig, v in zip(noise_levels, psnr_x, strict=True)
 ]
 
 # %%
@@ -199,7 +199,7 @@ for name, d in denoisers.items():
     res.extend(
         [
             {"sigma": sig.item(), "denoiser": name, "psnr": v.item(), "time": runtime}
-            for sig, v in zip(noise_levels, psnr_x)
+            for sig, v in zip(noise_levels, psnr_x, strict=True)
         ]
     )
     print(f" done ({runtime:.2f}s)")
@@ -254,7 +254,7 @@ for th in thresholds:
             "th": th.item(),
             "time": runtime,
         }
-        for sig, clean_img in zip(noise_levels, clean_images)
+        for sig, clean_img in zip(noise_levels, clean_images, strict=True)
     )
 df_wavelet = pd.DataFrame(res)
 
@@ -387,7 +387,7 @@ for name, d in adapted_denoisers.items():
     res.extend(
         [
             {"sigma": sig.item(), "denoiser": name, "psnr": v.item(), "time": runtime}
-            for sig, v in zip(noise_levels, psnr_x)
+            for sig, v in zip(noise_levels, psnr_x, strict=True)
         ]
     )
     print(f" done ({runtime:.2f}s)")

--- a/examples/basics/demo_spc.py
+++ b/examples/basics/demo_spc.py
@@ -96,7 +96,9 @@ physics_list = [
 # -----------------------------------------
 # Generate measurements using the physics models and reconstruct images using the adjoint operator.
 y_list = [physics(x) for physics in physics_list]
-x_list = [physics.A_adjoint(y) for physics, y in zip(physics_list, y_list)]
+x_list = [
+    physics.A_adjoint(y) for physics, y in zip(physics_list, y_list, strict=True)
+]
 
 # %%
 # Calculate PSNR
@@ -110,7 +112,7 @@ title_orderings = [o.replace("_", " ").title() for o in orderings]
 title_orderings[-1] = "XY"  # Special case for 'xy'
 titles = ["Ground Truth"] + [
     f"{ordering}\nPSNR: {psnr:.2f}"
-    for ordering, psnr in zip(title_orderings, psnr_values)
+    for ordering, psnr in zip(title_orderings, psnr_values, strict=True)
 ]
 
 # Print information about the SPC setup
@@ -173,14 +175,14 @@ model.eval()
 x_recon = []
 psnr_values = []
 
-for y, physics in zip(y_list, physics_list):
+for y, physics in zip(y_list, physics_list, strict=True):
     x_recon.append(model(y, physics))
     psnr_values.append(psnr_metric(x_recon[-1], x).item())
 
 # Update titles with PSNR values for the reconstructed images
 titles = ["Ground Truth"] + [
     f"{ordering}\nPSNR: {psnr:.2f}"
-    for ordering, psnr in zip(title_orderings, psnr_values)
+    for ordering, psnr in zip(title_orderings, psnr_values, strict=True)
 ]
 
 # %%


### PR DESCRIPTION
Now that we dropped support for Python 3.9 we can start using strict zip calls:
https://docs.python.org/3.10/library/functions.html#zip

I suggest we make it mandatory to specify if a zip is strict or not by toggling ruff rule B905:
https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/

The goal is to catch bugs early on and to make the code clearer. (It's not always obvious if a zip call is meant to be strict.)

I checked the current zip calls individually and it seems to me that they are all meant to be strict so I made them strict.