### PR TITLE
Add unused import linting rule (F401) for ruff 

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 import tomlkit
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Install and run ruff
         run: |
           pip install ruff
-          ruff check --target-version "py39" --select "UP006"
+          ruff check 

--- a/deepinv/datasets/fastmri.py
+++ b/deepinv/datasets/fastmri.py
@@ -22,12 +22,10 @@ from contextlib import contextmanager
 from typing import Any, Callable, NamedTuple, Optional, Union, Any
 from collections import defaultdict
 import pickle
-import math
 import warnings
 import os
 import h5py
 from tqdm import tqdm
-import numpy as np
 import torch
 from torchvision.transforms import Compose, CenterCrop
 

--- a/deepinv/datasets/lidc_idri.py
+++ b/deepinv/datasets/lidc_idri.py
@@ -6,7 +6,6 @@ from typing import (
 )
 import os
 
-import numpy
 import torch
 import numpy as np
 

--- a/deepinv/loss/adversarial/uair.py
+++ b/deepinv/loss/adversarial/uair.py
@@ -1,6 +1,6 @@
 import torch.nn as nn
 from torch import Tensor
-from .base import GeneratorLoss, DiscriminatorLoss
+from .base import GeneratorLoss
 from deepinv.physics import Physics
 
 

--- a/deepinv/loss/augmentation.py
+++ b/deepinv/loss/augmentation.py
@@ -12,7 +12,6 @@ from deepinv.physics.mri import MRI
 from deepinv.transform.base import Transform, Identity
 from deepinv.transform.rotate import Rotate
 from deepinv.transform.shift import Shift
-from deepinv.physics.forward import LinearPhysics
 
 
 class AugmentConsistencyLoss(Loss):

--- a/deepinv/loss/mc.py
+++ b/deepinv/loss/mc.py
@@ -3,7 +3,6 @@ from typing import Union
 import torch
 from deepinv.loss.loss import Loss
 from deepinv.loss.metric.metric import Metric
-from deepinv.transform.base import Transform
 
 
 class MCLoss(Loss):

--- a/deepinv/loss/metric/distortion.py
+++ b/deepinv/loss/metric/distortion.py
@@ -4,7 +4,6 @@ from functools import partial
 
 import torch
 from torch import Tensor
-from torch.nn import MSELoss, L1Loss
 from torchmetrics.functional.image import (
     structural_similarity_index_measure,
     multiscale_structural_similarity_index_measure,

--- a/deepinv/loss/moi.py
+++ b/deepinv/loss/moi.py
@@ -1,6 +1,5 @@
 from typing import Union, Optional
 
-import numpy as np
 import torch
 
 from deepinv.loss.loss import Loss

--- a/deepinv/loss/score.py
+++ b/deepinv/loss/score.py
@@ -1,5 +1,4 @@
 import torch
-import deepinv.physics
 from deepinv.loss.loss import Loss
 from deepinv.models.base import Reconstructor
 

--- a/deepinv/loss/sure.py
+++ b/deepinv/loss/sure.py
@@ -1,7 +1,5 @@
 import torch
-import torch.nn as nn
 import numpy as np
-import deepinv.physics
 from deepinv.loss.loss import Loss
 
 

--- a/deepinv/models/equivariant.py
+++ b/deepinv/models/equivariant.py
@@ -1,5 +1,4 @@
 from typing import Optional
-import torch
 from deepinv.transform import Transform, Rotate, Reflect
 from .base import Denoiser
 

--- a/deepinv/models/icnn.py
+++ b/deepinv/models/icnn.py
@@ -1,5 +1,4 @@
 # Code borrowed from https://github.com/ZhenghanFang/learned-proximal-networks
-import numpy as np
 import torch
 from torch import nn
 

--- a/deepinv/models/varnet.py
+++ b/deepinv/models/varnet.py
@@ -12,7 +12,7 @@ from deepinv.models import DnCNN
 from deepinv.physics.mri import MRIMixin, MRI, MultiCoilMRI
 
 if TYPE_CHECKING:
-    from deepinv.physics.forward import Physics
+    pass
 
 
 class VarNet(ArtifactRemoval, MRIMixin):

--- a/deepinv/optim/bregman.py
+++ b/deepinv/optim/bregman.py
@@ -1,5 +1,4 @@
 import torch
-import torch.nn as nn
 from deepinv.optim.potential import Potential
 
 

--- a/deepinv/optim/distance.py
+++ b/deepinv/optim/distance.py
@@ -1,6 +1,5 @@
 import torch
 from deepinv.optim.potential import Potential
-from deepinv.utils.tensorlist import TensorList
 
 
 class Distance(Potential):

--- a/deepinv/optim/optim_iterators/optim_iterator.py
+++ b/deepinv/optim/optim_iterators/optim_iterator.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 

--- a/deepinv/optim/optim_iterators/primal_dual_CP.py
+++ b/deepinv/optim/optim_iterators/primal_dual_CP.py
@@ -1,4 +1,3 @@
-
 from .optim_iterator import OptimIterator, fStep, gStep
 
 

--- a/deepinv/optim/optim_iterators/primal_dual_CP.py
+++ b/deepinv/optim/optim_iterators/primal_dual_CP.py
@@ -1,4 +1,3 @@
-import torch
 
 from .optim_iterator import OptimIterator, fStep, gStep
 

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -13,7 +13,6 @@ from deepinv.optim.potential import Potential
 from deepinv.models.tv import TVDenoiser
 from deepinv.models.wavdict import WaveletDenoiser, WaveletDictDenoiser
 from deepinv.utils import patch_extractor
-from typing import Callable
 
 
 class Prior(Potential):

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -1,7 +1,6 @@
 from torchvision.transforms.functional import rotate
 import torchvision
 import torch
-import numpy as np
 import torch.fft as fft
 from torch import Tensor
 from deepinv.physics.forward import LinearPhysics, DecomposablePhysics

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from typing import Union
 import copy
 import inspect
-import itertools
 import collections.abc
 
 import torch

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -5,7 +5,6 @@ import numpy as np
 
 try:
     import astra
-    from astra import experimental
 except:
     astra = ImportError("The astra-toolbox package is not installed.")
 

--- a/deepinv/physics/generator/base.py
+++ b/deepinv/physics/generator/base.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
 from typing import Union
-import warnings
 from hashlib import sha256
 
 

--- a/deepinv/sampling/diffusion.py
+++ b/deepinv/sampling/diffusion.py
@@ -3,10 +3,8 @@ import numpy as np
 from tqdm import tqdm
 from deepinv.models import Reconstructor
 
-from typing import Dict, Any
 
 import deepinv.physics
-from deepinv.utils.plotting import plot
 from deepinv.sampling import BaseSampling
 from deepinv.sampling.sampling_iterators import DiffusionIterator
 

--- a/deepinv/sampling/sampling_iterators/SKRock.py
+++ b/deepinv/sampling/sampling_iterators/SKRock.py
@@ -1,4 +1,3 @@
-import torch.nn as nn
 from deepinv.sampling.utils import projbox
 import torch
 import numpy as np

--- a/deepinv/tests/test_adversarial.py
+++ b/deepinv/tests/test_adversarial.py
@@ -5,7 +5,6 @@ from torch.utils.data import DataLoader
 
 import deepinv as dinv
 from deepinv.loss import adversarial
-from test_loss import dataset, physics
 
 ADVERSARIAL_COMBOS = ["DeblurGAN", "CSGM", "AmbientGAN", "UAIR"]
 

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -30,7 +30,6 @@ from deepinv.physics.mri import MultiCoilMRI, MRI, DynamicMRI
 from deepinv.physics.generator import GaussianMaskGenerator
 
 from unittest.mock import patch
-import unittest.mock as mock
 import io
 
 
@@ -591,7 +590,6 @@ def download_CMRxRecon():
 
 
 def test_CMRxReconSliceDataset(download_CMRxRecon):
-    from math import prod
 
     img_size = (12, 512, 256)
 

--- a/deepinv/tests/test_loss_train.py
+++ b/deepinv/tests/test_loss_train.py
@@ -8,7 +8,7 @@ from torch.utils.data import DataLoader, Dataset
 import deepinv as dinv
 from deepinv.optim.data_fidelity import L2
 from deepinv.optim.prior import PnP
-from dummy import DummyCircles, DummyModel
+from dummy import DummyCircles
 from deepinv.unfolded import unfolded_builder
 from deepinv.physics import Inpainting, GaussianNoise, Blur, Pansharpen
 from deepinv.physics.generator import (

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -9,7 +9,7 @@ import numpy as np
 from deepinv.physics.forward import adjoint_function
 import deepinv as dinv
 from deepinv.optim.data_fidelity import L2
-from deepinv.physics.mri import MRI, MRIMixin, DynamicMRI, MultiCoilMRI, SequentialMRI
+from deepinv.physics.mri import MRI, MRIMixin, DynamicMRI, MultiCoilMRI
 from deepinv.utils import TensorList
 
 

--- a/deepinv/tests/test_physics_functional.py
+++ b/deepinv/tests/test_physics_functional.py
@@ -8,7 +8,6 @@ Created on Thu Jul 11 14:48:05 2024
 
 import deepinv as dinv
 import torch
-import pytest
 
 
 def test_conv2d_adjointness(device):

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -13,12 +13,9 @@ from deepinv.physics.noise import GaussianNoise, PoissonNoise
 
 from unittest.mock import patch
 import math
-import builtins
 import io
 import contextlib
 import re
-import tempfile
-import os
 
 from conftest import no_plot
 

--- a/deepinv/training/testing.py
+++ b/deepinv/training/testing.py
@@ -1,4 +1,3 @@
-import torch
 from deepinv.loss.metric import PSNR
 from deepinv.training import Trainer
 

--- a/deepinv/transform/reflect.py
+++ b/deepinv/transform/reflect.py
@@ -1,8 +1,5 @@
 from typing import Union, Iterable
 import torch
-from torchvision.transforms.functional import rotate
-from torchvision.transforms import InterpolationMode
-import numpy as np
 from deepinv.transform.base import Transform, TransformParam
 import itertools
 

--- a/deepinv/utils/demo.py
+++ b/deepinv/utils/demo.py
@@ -13,7 +13,6 @@ import torchvision
 from torchvision import transforms
 
 
-
 def get_git_root():
     import git
 

--- a/deepinv/utils/demo.py
+++ b/deepinv/utils/demo.py
@@ -9,11 +9,9 @@ from PIL import Image
 import numpy as np
 import torch
 from torch.utils.data import Dataset
-from torch.nn import Module
 import torchvision
 from torchvision import transforms
 
-from deepinv.models.base import Reconstructor, Denoiser
 
 
 def get_git_root():

--- a/deepinv/utils/metric.py
+++ b/deepinv/utils/metric.py
@@ -1,5 +1,3 @@
-import torch
-import numpy as np
 import warnings
 
 

--- a/deepinv/utils/parameters.py
+++ b/deepinv/utils/parameters.py
@@ -1,4 +1,3 @@
-import numpy as np
 
 
 def get_GSPnP_params(problem, noise_level_img):

--- a/deepinv/utils/parameters.py
+++ b/deepinv/utils/parameters.py
@@ -1,5 +1,3 @@
-
-
 def get_GSPnP_params(problem, noise_level_img):
     r"""
     Default parameters for the GSPnP Plug-and-Play algorithm.

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -21,7 +21,6 @@ from matplotlib.animation import FuncAnimation
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from PIL import Image
-import io
 
 
 def config_matplotlib(fontsize=17):

--- a/examples/adversarial-learning/demo_gan_imaging.py
+++ b/examples/adversarial-learning/demo_gan_imaging.py
@@ -39,9 +39,7 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader, random_split
-from torchvision.datasets import ImageFolder
 from torchvision.transforms import Compose, ToTensor, CenterCrop, Resize
-from torchvision.datasets.utils import download_and_extract_archive
 
 import deepinv as dinv
 from deepinv.loss import adversarial

--- a/examples/basics/demo_phase_retrieval.py
+++ b/examples/basics/demo_phase_retrieval.py
@@ -27,7 +27,6 @@ from deepinv.utils.plotting import plot
 from deepinv.optim.phase_retrieval import (
     correct_global_phase,
     cosine_similarity,
-    spectral_methods,
 )
 from deepinv.models.complex import to_complex_denoiser
 

--- a/examples/basics/demo_spc.py
+++ b/examples/basics/demo_spc.py
@@ -31,7 +31,6 @@ and Hadamard spectrum.
 
 import torch
 from pathlib import Path
-import matplotlib.pyplot as plt
 import deepinv as dinv
 from deepinv.utils.demo import get_image_url, load_url_image
 from deepinv.utils.plotting import plot

--- a/examples/external-libraries/_demo_astra_tomography.py
+++ b/examples/external-libraries/_demo_astra_tomography.py
@@ -24,7 +24,6 @@ from deepinv.physics import LogPoissonNoise
 from deepinv.optim import LogPoissonLikelihood
 
 try:
-    import astra
     from deepinv.physics import TomographyWithAstra
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(

--- a/examples/optimization/demo_3D_wavelets.py
+++ b/examples/optimization/demo_3D_wavelets.py
@@ -10,7 +10,6 @@ bases, which does not admit a closed-form solution. We solve the denoising probl
 import deepinv as dinv
 from pathlib import Path
 import numpy as np
-import matplotlib.pyplot as plt
 
 import torch
 import torch.nn as nn

--- a/examples/optimization/demo_wavelet_prior.py
+++ b/examples/optimization/demo_wavelet_prior.py
@@ -15,7 +15,7 @@ from torchvision import transforms
 
 from deepinv.optim.data_fidelity import L2
 from deepinv.optim.optimizers import optim_builder
-from deepinv.utils.demo import load_dataset, load_degradation
+from deepinv.utils.demo import load_dataset
 from deepinv.utils.plotting import plot, plot_curves
 
 # %%

--- a/examples/plug-and-play/demo_PnP_mirror_descent.py
+++ b/examples/plug-and-play/demo_PnP_mirror_descent.py
@@ -19,7 +19,6 @@ In https://publications.ut-capitole.fr/id/eprint/25852/1/25852.pdf, it is shown 
 import deepinv as dinv
 from pathlib import Path
 import torch
-from torch.utils.data import DataLoader
 from deepinv.optim.data_fidelity import PoissonLikelihood
 from deepinv.optim.prior import RED
 from deepinv.optim import optim_builder

--- a/examples/self-supervised-learning/demo_artifact2artifact.py
+++ b/examples/self-supervised-learning/demo_artifact2artifact.py
@@ -24,9 +24,8 @@ Phase2Phase.
 
 """
 
-from pathlib import Path
 import torch
-from torch.utils.data import DataLoader, Subset
+from torch.utils.data import DataLoader
 from torchvision import transforms
 
 import deepinv as dinv

--- a/examples/unfolded/demo_DEQ.py
+++ b/examples/unfolded/demo_DEQ.py
@@ -14,11 +14,9 @@ import deepinv as dinv
 from pathlib import Path
 import torch
 from torch.utils.data import DataLoader
-from deepinv.models import DnCNN
 from deepinv.optim.data_fidelity import L2
 from deepinv.optim.prior import PnP
 from deepinv.unfolded import DEQ_builder
-from deepinv.training import train, test
 from torchvision import transforms
 from deepinv.utils.demo import load_dataset, load_degradation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,27 @@ omit = ['examples/*', 'deepinv/tests']  # define paths to omit
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+
+#####################################################################
+# Linting configuration with Ruff
+
+[tool.ruff]
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.9
+target-version = "py39"
+
+[tool.ruff.lint]
+
+select = [
+ # non-pep585-annotation
+ "UP006",
+ # unused imports
+ "F401"
+]
+
+exclude = [
+
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,5 +134,5 @@ select = [
 ]
 
 exclude = [
-
+    "__init__.py",
 ]


### PR DESCRIPTION
This is a small-scale PR that adds a new rule to the ``ruff`` linting, preventing us from keeping unused imports.
The main contribution is to add ``ruff``'s settings in the ``pyproject.toml`` file instead of specifying them in the command line run by the CI ``lint.yaml``. The PR also enforces this new rule onto the whole repo.

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
