### PR TITLE
Exclude type checking conditionals from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,9 @@ omit = ['examples/*', 'deepinv/tests']  # define paths to omit
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+exclude_also = [
+    "if TYPE_CHECKING:",
+]
 
 [tool.ruff.lint.per-file-ignores]
 # NOTE: Rule F401 is ruff's unused imports rule.


### PR DESCRIPTION
Fix #624

I got the fix from https://coverage.readthedocs.io/en/7.10.1/excluding.html