### PR TITLE
Fix for Issue #647 – UNet uses zero-padding even when it shouldn't

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Changed
 Fixed
 ^^^^^
 - Fix memory leak in `deepinv.physics.tomography` when using autograd (:gh:`651` by `Minh Hai Nguyen`_)
-
+- Fix the circular padded UNet (:gh:`653` by `Victor Sechaud`_)
 
 v0.3.2
 ------

--- a/deepinv/models/unet.py
+++ b/deepinv/models/unet.py
@@ -116,7 +116,13 @@ class UNet(Denoiser):
                     ),
                     nn.ReLU(inplace=True),
                     nn.Conv2d(
-                        ch_out, ch_out, kernel_size=3, stride=1, padding=1, bias=bias, padding_mode="circular" if circular_padding else "zeros"
+                        ch_out,
+                        ch_out,
+                        kernel_size=3,
+                        stride=1,
+                        padding=1,
+                        bias=bias,
+                        padding_mode="circular" if circular_padding else "zeros",
                     ),
                     (
                         BFBatchNorm2d(ch_out, use_bias=bias)
@@ -138,7 +144,13 @@ class UNet(Denoiser):
                     ),
                     nn.ReLU(inplace=True),
                     nn.Conv2d(
-                        ch_out, ch_out, kernel_size=3, stride=1, padding=1, bias=bias, padding_mode="circular" if circular_padding else "zeros"
+                        ch_out,
+                        ch_out,
+                        kernel_size=3,
+                        stride=1,
+                        padding=1,
+                        bias=bias,
+                        padding_mode="circular" if circular_padding else "zeros",
                     ),
                     nn.ReLU(inplace=True),
                 )
@@ -148,7 +160,13 @@ class UNet(Denoiser):
                 return nn.Sequential(
                     nn.Upsample(scale_factor=2),
                     nn.Conv2d(
-                        ch_in, ch_out, kernel_size=3, stride=1, padding=1, bias=bias, padding_mode="circular" if circular_padding else "zeros"
+                        ch_in,
+                        ch_out,
+                        kernel_size=3,
+                        stride=1,
+                        padding=1,
+                        bias=bias,
+                        padding_mode="circular" if circular_padding else "zeros",
                     ),
                     (
                         BFBatchNorm2d(ch_out, use_bias=bias)
@@ -161,7 +179,13 @@ class UNet(Denoiser):
                 return nn.Sequential(
                     nn.Upsample(scale_factor=2),
                     nn.Conv2d(
-                        ch_in, ch_out, kernel_size=3, stride=1, padding=1, bias=bias, padding_mode="circular" if circular_padding else "zeros"
+                        ch_in,
+                        ch_out,
+                        kernel_size=3,
+                        stride=1,
+                        padding=1,
+                        bias=bias,
+                        padding_mode="circular" if circular_padding else "zeros",
                     ),
                     nn.ReLU(inplace=True),
                 )

--- a/deepinv/models/unet.py
+++ b/deepinv/models/unet.py
@@ -116,7 +116,7 @@ class UNet(Denoiser):
                     ),
                     nn.ReLU(inplace=True),
                     nn.Conv2d(
-                        ch_out, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
+                        ch_out, ch_out, kernel_size=3, stride=1, padding=1, bias=bias, padding_mode="circular" if circular_padding else "zeros"
                     ),
                     (
                         BFBatchNorm2d(ch_out, use_bias=bias)
@@ -138,7 +138,7 @@ class UNet(Denoiser):
                     ),
                     nn.ReLU(inplace=True),
                     nn.Conv2d(
-                        ch_out, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
+                        ch_out, ch_out, kernel_size=3, stride=1, padding=1, bias=bias, padding_mode="circular" if circular_padding else "zeros"
                     ),
                     nn.ReLU(inplace=True),
                 )
@@ -148,7 +148,7 @@ class UNet(Denoiser):
                 return nn.Sequential(
                     nn.Upsample(scale_factor=2),
                     nn.Conv2d(
-                        ch_in, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
+                        ch_in, ch_out, kernel_size=3, stride=1, padding=1, bias=bias, padding_mode="circular" if circular_padding else "zeros"
                     ),
                     (
                         BFBatchNorm2d(ch_out, use_bias=bias)
@@ -161,7 +161,7 @@ class UNet(Denoiser):
                 return nn.Sequential(
                     nn.Upsample(scale_factor=2),
                     nn.Conv2d(
-                        ch_in, ch_out, kernel_size=3, stride=1, padding=1, bias=bias
+                        ch_in, ch_out, kernel_size=3, stride=1, padding=1, bias=bias, padding_mode="circular" if circular_padding else "zeros"
                     ),
                     nn.ReLU(inplace=True),
                 )


### PR DESCRIPTION
This PR proposes a fix for [issue #647](https://github.com/deepinv/deepinv/issues/647).

I've added support for circular padding to all Conv2d layers in the UNet by specifying `padding_mode="circular"` where it was previously missing.

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
