### PR TITLE
Make ruff more convenient to deal with

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Install and run ruff
         run: |
           pip install ruff
-          ruff check --target-version "py310" --select "UP006" --select "F401" --select "B905"
+          ruff check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,12 @@ omit = ['examples/*', 'deepinv/tests']  # define paths to omit
 show_missing = true
 skip_covered = true
 
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["UP006", "F401", "B905"]
+
 [tool.ruff.lint.per-file-ignores]
 # NOTE: Rule F401 is ruff's unused imports rule.
 "__init__.py" = ["F401"]


### PR DESCRIPTION
Currently ruff does not automatically use the settings it uses in the CI pipeline when executed locally. This is because the configuration is hard-coded as flags in the ruff command that gets executed in the GitHub action. In this PR, we fix that by moving those to the pyproject.toml file.

Benefits:
* Being able to run `ruff check --fix` directly like we do for `black .` without having to specify the settings manually