### PR TITLE
Small fix in the user guide on Markov Chain Monte Carlo

### DIFF
--- a/docs/source/user_guide/reconstruction/sampling.rst
+++ b/docs/source/user_guide/reconstruction/sampling.rst
@@ -213,8 +213,8 @@ or with a user-defined one (an instance of :class:`deepinv.sampling.SamplingIter
 
 ::
 
-    model = dinv.sampling.sampling_builder(iteration="ULA", prior=prior, data_fidelity=data_fidelity,
-                                    params = {"step_size": step_size, "alpha": alpha, "sigma": sigma}, max_iter=max_iter)
+    model = dinv.sampling.sampling_builder(iterator="ULA", prior=prior, data_fidelity=data_fidelity,
+                                           params_algo={"step_size": step_size, "alpha": alpha, "sigma": sigma}, max_iter=max_iter)
     x_hat = model(y, physics)
 
 


### PR DESCRIPTION
If I am not mistaken, the arguments to `sampling_builder` changed at some point and that was not reflected in the respective user guide so far.
