### PR TITLE
Urgent fix #666

### DIFF
--- a/deepinv/datasets/skmtea.py
+++ b/deepinv/datasets/skmtea.py
@@ -1,6 +1,5 @@
 from typing import Sequence, Union, Callable
 from pathlib import Path
-from natsort import natsorted
 from tqdm import tqdm
 import h5py
 import numpy as np
@@ -8,6 +7,13 @@ import torch
 import torch.nn.functional as F
 from deepinv.datasets.fastmri import FastMRISliceDataset
 from deepinv.physics.mri import MRIMixin
+
+try:
+    from natsort import natsorted
+except ImportError:  # pragma: no cover
+    natsorted = ImportError(
+        "natsort is not available. In order to use SKMTEASliceDataset, please install the natsort package with `pip install natsort`."
+    )  # pragma: no cover
 
 
 class SKMTEASliceDataset(FastMRISliceDataset, MRIMixin):


### PR DESCRIPTION
Fixes deepinv install without optional dependencies failing because natsort isn't getting caught in skmtea dataset. Sorry!

Thank you for contributing to DeepInverse!

Please refer to our [contributing guidelines](https://deepinv.github.io/deepinv/contributing.html) for full instructions on how to contribute, including writing tests, documentation and code style.

Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action
has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/documentation.yml). Look for the workflow run corresponding to your pull request.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
