### PR TITLE
Remove factor check in downsampling init

### DIFF
--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -69,9 +69,6 @@ class Downsampling(LinearPhysics):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        if not isinstance(factor, (int, float)):
-            raise ValueError("Downsampling factor must be an integer")
-
         self.imsize = tuple(img_size) if isinstance(img_size, list) else img_size
         self.imsize_dynamic = (3, 128, 128)  # placeholder
         self.padding = padding


### PR DESCRIPTION
Factor doesn't need to be checked in downsampling init as it's checked in check_factor which is called by update_parameters.

Currently this causes a bug when one initialises downsampling with a tensor factor, which may arise when you have e.g. `params = {"factor":tensor([2])}; physics = Downsampling(**params)` where your params are batched (returned by a dataloader).

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
