### PR TITLE
Fix the condition for break in compute_norm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -427,4 +427,4 @@ Authors
 .. _Keying Guo: https://github.com/g-keying
 .. _Sebastian Neumayer: https://www.tu-chemnitz.de/mathematik/invimg/index.en.php
 .. _Romain Vo: https://github.com/romainvo
-.. _Quentin Barthélemy Vo: https://github.com/qbarthelemy
+.. _Quentin Barthélemy: https://github.com/qbarthelemy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Fixed
 - Fix full-reference metrics used with measurement-only dataset (:gh:`622` by `Andrew Wang`_)
 - Batching DownsamplingGenerator in the case of multiple filters (:gh:`690` by `Matthieu Terris`_)
 - NaN motion blur generator (:gh:`685` by `Matthieu Terris`_)
+- Fix the condition for break in compute_norm (:gh:`699` by `Quentin Barthélemy`_)
 
 
 v0.3.3
@@ -426,3 +427,4 @@ Authors
 .. _Keying Guo: https://github.com/g-keying
 .. _Sebastian Neumayer: https://www.tu-chemnitz.de/mathematik/invimg/index.en.php
 .. _Romain Vo: https://github.com/romainvo
+.. _Quentin Barthélemy Vo: https://github.com/qbarthelemy


### PR DESCRIPTION
In current code, when the relative variation criterion is reached, `break` is achieved only if `verbose` is activated.
This PR separates these two conditions, first for the relative variation criterion for the `break`, and if so, `verbose` to print.

Also, I transformed the `for` loop into a `for-else` loop, to easily detect when convergence is not reached.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
