### PR TITLE
Fix the Messi image from examples

### DIFF
--- a/examples/optimization/demo_dip.py
+++ b/examples/optimization/demo_dip.py
@@ -28,11 +28,11 @@ from deepinv.utils import load_example
 # Load image from the internet
 # ----------------------------
 #
-# This example uses an image of the set3c dataset.
+# This example uses an image of Messi.
 
 device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
 
-x = load_example("leaves.png", img_size=32).to(device)
+x = load_example("messi.jpg", img_size=32).to(device)
 
 # Set the global random seed from pytorch to ensure reproducibility of the example.
 torch.manual_seed(0)

--- a/examples/optimization/demo_dip.py
+++ b/examples/optimization/demo_dip.py
@@ -18,24 +18,21 @@ optimizer.
 
 """
 
+# %%
 import deepinv as dinv
 from deepinv.utils.plotting import plot
 import torch
-from deepinv.utils import load_url_image
+from deepinv.utils import load_example
 
 # %%
 # Load image from the internet
 # ----------------------------
 #
-# This example uses an image of Lionel Messi from Wikipedia.
+# This example uses an image of the set3c dataset.
 
 device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
 
-url = (
-    "https://upload.wikimedia.org/wikipedia/commons/b/b4/"
-    "Lionel-Messi-Argentina-2022-FIFA-World-Cup_%28cropped%29.jpg"
-)
-x = load_url_image(url=url, img_size=32).to(device)
+x = load_example("leaves.png", img_size=32).to(device)
 
 # Set the global random seed from pytorch to ensure reproducibility of the example.
 torch.manual_seed(0)

--- a/examples/sampling/demo_custom_kernel.py
+++ b/examples/sampling/demo_custom_kernel.py
@@ -9,25 +9,22 @@ to accelerate the sampling.
 
 """
 
+# %%
 import torch
 from typing import Any
 import deepinv as dinv
 from deepinv.utils.plotting import plot
-from deepinv.utils.demo import load_url_image
+from deepinv.utils.demo import load_example
 
 # %%
 # Load image from the internet
 # ----------------------------
 #
-# This example uses an image of Lionel Messi from Wikipedia.
+# This example uses an image of the set3c dataset.
 
 device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
 
-url = (
-    "https://upload.wikimedia.org/wikipedia/commons/b/b4/"
-    "Lionel-Messi-Argentina-2022-FIFA-World-Cup_%28cropped%29.jpg"
-)
-x = load_url_image(url=url, img_size=32).to(device)
+x = load_example("leaves.png", img_size=32).to(device)
 
 # %%
 # Define forward operator and noise model

--- a/examples/sampling/demo_custom_kernel.py
+++ b/examples/sampling/demo_custom_kernel.py
@@ -20,11 +20,11 @@ from deepinv.utils.demo import load_example
 # Load image from the internet
 # ----------------------------
 #
-# This example uses an image of the set3c dataset.
+# This example uses an image of Messi.
 
 device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
 
-x = load_example("leaves.png", img_size=32).to(device)
+x = load_example("messi.jpg", img_size=32).to(device)
 
 # %%
 # Define forward operator and noise model

--- a/examples/sampling/demo_ddrm.py
+++ b/examples/sampling/demo_ddrm.py
@@ -22,11 +22,11 @@ from deepinv.utils.demo import load_example
 # Load example image from the internet
 # --------------------------------------------------------------
 #
-# This example uses an image of the set3c dataset.
+# This example uses an image of Messi.
 
 device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
 
-x = load_example("leaves.png", img_size=32).to(device)
+x = load_example("messi.jpg", img_size=32).to(device)
 
 
 # %%

--- a/examples/sampling/demo_ddrm.py
+++ b/examples/sampling/demo_ddrm.py
@@ -11,25 +11,22 @@ The DDRM method requires that:
 * The noise is Gaussian with known standard deviation (i.e., the noise model is :class:`deepinv.physics.GaussianNoise`).
 """
 
+# %%
 import deepinv as dinv
 from deepinv.utils.plotting import plot
 import torch
 import numpy as np
-from deepinv.utils.demo import load_url_image
+from deepinv.utils.demo import load_example
 
 # %%
 # Load example image from the internet
 # --------------------------------------------------------------
 #
-# This example uses an image of Lionel Messi from Wikipedia.
+# This example uses an image of the set3c dataset.
 
 device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
 
-url = (
-    "https://upload.wikimedia.org/wikipedia/commons/b/b4/"
-    "Lionel-Messi-Argentina-2022-FIFA-World-Cup_%28cropped%29.jpg"
-)
-x = load_url_image(url=url, img_size=32).to(device)
+x = load_example("leaves.png", img_size=32).to(device)
 
 
 # %%

--- a/examples/sampling/demo_sampling.py
+++ b/examples/sampling/demo_sampling.py
@@ -27,11 +27,11 @@ from deepinv.utils.demo import load_example
 # Load image from the internet
 # --------------------------------------------
 #
-# This example uses an image of the set3c dataset.
+# This example uses an image of Messi.
 
 device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
 
-x = load_example("leaves.png", img_size=32).to(device)
+x = load_example("messi.jpg", img_size=32).to(device)
 
 # %%
 # Define forward operator and noise model

--- a/examples/sampling/demo_sampling.py
+++ b/examples/sampling/demo_sampling.py
@@ -17,24 +17,21 @@ where :math:`z_k \sim \mathcal{N}(0, I)` is a Gaussian random variable, :math:`\
 The PnP-ULA method is described in the paper :footcite:t:`laumont2022bayesian`.
 """
 
+# %%
 import deepinv as dinv
 from deepinv.utils.plotting import plot
 import torch
-from deepinv.utils.demo import load_url_image
+from deepinv.utils.demo import load_example
 
 # %%
 # Load image from the internet
 # --------------------------------------------
 #
-# This example uses an image of Lionel Messi from Wikipedia.
+# This example uses an image of the set3c dataset.
 
 device = dinv.utils.get_freer_gpu() if torch.cuda.is_available() else "cpu"
 
-url = (
-    "https://upload.wikimedia.org/wikipedia/commons/b/b4/"
-    "Lionel-Messi-Argentina-2022-FIFA-World-Cup_%28cropped%29.jpg"
-)
-x = load_url_image(url=url, img_size=32).to(device)
+x = load_example("leaves.png", img_size=32).to(device)
 
 # %%
 # Define forward operator and noise model


### PR DESCRIPTION
As stated in issue #702 the CI appears to fail randomly with an error 403 whenever examples try to download an image from wikipedia, namely the image of Messi. 
I replaced it with the leaves image which is available on deepinv's huggingface, and provides interesting details even when center-cropped to 32 by 32. 

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
