### PR TITLE
Add norm test for multicoil MRI

### DIFF
--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -844,6 +844,16 @@ def test_FastMRISliceDataset(download_fastmri):
     assert params["coil_maps"].shape == (n_coils, *kspace_shape)
     assert dataset.transform.get_acs() == 17  # ACS via mask generator
 
+    physics_estim = MultiCoilMRI(**params)
+    x0 = torch.randn(1, 2, *kspace_shape)
+    assert physics_estim.adjointness_test(x0) < 1e-3
+    assert (
+        torch.abs(
+            physics.compute_norm(x0, max_iter=1000, tol=1e-6, verbose=False) - 1.0
+        )
+        < 1e-3
+    )
+
     # Test prewhitening and normalising
     dataset = FastMRISliceDataset(
         root=data_dir,

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -62,6 +62,7 @@ OPERATORS = [
     "MRI",
     "DynamicMRI",
     "MultiCoilMRI",
+    "MultiCoilMRIBirdcage",
     "3DMRI",
     "3DMultiCoilMRI",
     "aliased_pansharpen",
@@ -192,6 +193,10 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
             n_coils
         )  # B,N,H,W where N is coil dimension
         p = MultiCoilMRI(coil_maps=maps, img_size=img_size, device=device)
+        params = ["mask", "coil_maps"]
+    elif name == "MultiCoilMRIBirdcage":
+        img_size = (2, 17, 11) if imsize is None else imsize  # C,H,W
+        p = MultiCoilMRI(coil_maps=7, img_size=img_size, device=device)
         params = ["mask", "coil_maps"]
     elif name == "3DMultiCoilMRI":
         img_size = (


### PR DESCRIPTION
Currently multicoil MRI is only tested with flat maps. 

This PR adds more physics tests for multicoil MRI when:
- Coil maps are synthetically generated with sigpy birdcage
- Coil maps are estimated with espirit

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
