### PR TITLE
Fix behaviour of Tomography operator when normalize=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ New Features
 Changed
 ^^^^^^^
 - (Breaking) Make HDF5Dataset similar to Trainer in the unsupervised setting by using NaNs for ground truths instead of a copy of the measurements (:gh:`761` by `Jérémy Scanvic`_)
+- (Breaking) Normalize the Tomography operator with proper spectral norm computation. Set the default normalization behavior to ``True`` for both CT operators (:gh:`715` by `Romain Vo`_)
 
 Fixed
 ^^^^^

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -227,7 +227,7 @@ class XrayTransform:
         return _Adjoint()
 
     def _forward_projection(self, x: torch.Tensor, out: torch.Tensor) -> None:
-        import astra
+        import astra.experimental
 
         assert (
             x.shape == self.domain_shape
@@ -248,7 +248,7 @@ class XrayTransform:
         )
 
     def _backprojection(self, y: torch.Tensor, out: torch.Tensor) -> None:
-        import astra
+        import astra.experimental
 
         assert (
             y.shape == self.range_shape

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -93,24 +93,24 @@ class Tomography(LinearPhysics):
         >>> seed = torch.manual_seed(0)  # Random seed for reproducibility
         >>> x = torch.randn(1, 1, 4, 4)  # Define random 4x4 image
         >>> angles = torch.linspace(0, 45, steps=3)
-        >>> physics = Tomography(angles=angles, img_width=4, circle=True)
+        >>> physics = Tomography(angles=angles, img_width=4, circle=True, normalize=True)
         >>> physics(x)
-        tensor([[[[ 0.0000, -0.1791, -0.1719],
-                  [-0.5713, -0.4521, -0.5177],
-                  [ 0.0340,  0.1448,  0.2334],
-                  [ 0.0000, -0.0448, -0.0430]]]])
+        tensor([[[[ 0.0000, -0.0780, -0.0748],
+                [-0.2487, -0.1968, -0.2254],
+                [ 0.0148,  0.0631,  0.1016],
+                [ 0.0000, -0.0195, -0.0187]]]])
 
         Tomography operator with 3 uniformly sampled angles in [0, 360] for 3x3 image:
 
         >>> from deepinv.physics import Tomography
         >>> seed = torch.manual_seed(0)  # Random seed for reproducibility
         >>> x = torch.randn(1, 1, 4, 4)  # Define random 4x4 image
-        >>> physics = Tomography(angles=3, img_width=4, circle=True)
+        >>> physics = Tomography(angles=3, img_width=4, circle=True, normalize=True)
         >>> physics(x)
-        tensor([[[[ 0.0000, -0.1806,  0.0500],
-                  [-0.5713, -0.6076, -0.6815],
-                  [ 0.0340,  0.3175,  0.0167],
-                  [ 0.0000, -0.0452,  0.0989]]]])
+        tensor([[[[ 0.0000, -0.0788,  0.0218],
+                [-0.2492, -0.2651, -0.2973],
+                [ 0.0148,  0.1385,  0.0073],
+                [ 0.0000, -0.0197,  0.0432]]]])
 
 
     """
@@ -412,7 +412,8 @@ class TomographyWithAstra(LinearPhysics):
             ...        geometry_parameters={
             ...            'source_radius': 20.,
             ...            'detector_radius': 20.
-            ...        }
+            ...        },
+            ...        normalize=False
             ...    )
             >>> sinogram = physics(x)
             >>> print(sinogram)
@@ -445,7 +446,8 @@ class TomographyWithAstra(LinearPhysics):
             ...        geometry_parameters={
             ...            'source_radius': 20.,
             ...            'detector_radius': 20.
-            ...       }
+            ...       },
+            ...        normalize=False
             ...    )
             >>> sinogram = physics(x)
             >>> print(sinogram)

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -55,7 +55,7 @@ class Tomography(LinearPhysics):
     :param bool fbp_interpolate_boundary: the :func:`filtered back-projection <deepinv.physics.Tomography.A_dagger>` usually contains streaking artifacts on the boundary due to padding. For ``fbp_interpolate_boundary=True``
         these artifacts are corrected by cutting off the outer two pixels of the FBP and recovering them by interpolating the remaining image. This option
         only makes sense if ``circle`` is set to ``False``. Hence it will be ignored if ``circle`` is True.
-    :param bool normalize: If ``True`` :func:`A` and :func:`A_adjoint` are normalized so that the operator has unit norm. (default: ``False``)
+    :param bool normalize: If ``True`` :func:`A <deepinv.physics.Tomography.A>` and :func:`A_adjoint <deepinv.physics.Tomography.A_adjoint>` are normalized so that the operator has unit norm. (default: ``False``)
     :param bool fan_beam: If ``True``, use fan beam geometry, if ``False`` use parallel beam
     :param dict fan_parameters: Only used if fan_beam is ``True``. Contains the parameters defining the scanning geometry. The dict should contain the keys:
 

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -207,8 +207,6 @@ class Tomography(LinearPhysics):
         :param torch.Tensor x: input of shape [B,C,H,W]
         :return: measurement of shape [B,C,A,N], with A the number of angular positions, and N the number of detector cells.
         """
-        if self.img_width is None:
-            self.img_width = x.shape[-1]
         if self.fan_beam or self.adjoint_via_backprop:
             output = self.radon(x)
         else:
@@ -271,10 +269,6 @@ class Tomography(LinearPhysics):
         :return: scaled back-projection of shape [B,C,H,W]
         """
         if self.fan_beam or self.adjoint_via_backprop:
-            if self.img_width is None:
-                raise ValueError(
-                    "Image size unknown. Apply forward operator or add it for initialization."
-                )
             # lazy implementation for the adjoint...
             if (
                 self._auto_grad_adjoint_fn is None

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -93,24 +93,24 @@ class Tomography(LinearPhysics):
         >>> seed = torch.manual_seed(0)  # Random seed for reproducibility
         >>> x = torch.randn(1, 1, 4, 4)  # Define random 4x4 image
         >>> angles = torch.linspace(0, 45, steps=3)
-        >>> physics = Tomography(angles=angles, img_width=4, circle=True, normalize=True)
+        >>> physics = Tomography(angles=angles, img_width=4, circle=True, normalize=False)
         >>> physics(x)
-        tensor([[[[ 0.0000, -0.0780, -0.0748],
-                  [-0.2487, -0.1968, -0.2254],
-                  [ 0.0148,  0.0631,  0.1016],
-                  [ 0.0000, -0.0195, -0.0187]]]])
+        tensor([[[[ 0.0000, -0.1791, -0.1719],
+                  [-0.5713, -0.4521, -0.5177],
+                  [ 0.0340,  0.1448,  0.2334],
+                  [ 0.0000, -0.0448, -0.0430]]]])
 
         Tomography operator with 3 uniformly sampled angles in [0, 360] for 3x3 image:
 
         >>> from deepinv.physics import Tomography
         >>> seed = torch.manual_seed(0)  # Random seed for reproducibility
         >>> x = torch.randn(1, 1, 4, 4)  # Define random 4x4 image
-        >>> physics = Tomography(angles=3, img_width=4, circle=True, normalize=True)
+        >>> physics = Tomography(angles=3, img_width=4, circle=True, normalize=False)
         >>> physics(x)
-        tensor([[[[ 0.0000, -0.0788,  0.0218],
-                  [-0.2492, -0.2651, -0.2973],
-                  [ 0.0148,  0.1385,  0.0073],
-                  [ 0.0000, -0.0197,  0.0432]]]])
+        tensor([[[[ 0.0000, -0.1806,  0.0500],
+                  [-0.5713, -0.6076, -0.6815],
+                  [ 0.0340,  0.3175,  0.0167],
+                  [ 0.0000, -0.0452,  0.0989]]]])
 
 
     """

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -96,9 +96,9 @@ class Tomography(LinearPhysics):
         >>> physics = Tomography(angles=angles, img_width=4, circle=True, normalize=True)
         >>> physics(x)
         tensor([[[[ 0.0000, -0.0780, -0.0748],
-                [-0.2487, -0.1968, -0.2254],
-                [ 0.0148,  0.0631,  0.1016],
-                [ 0.0000, -0.0195, -0.0187]]]])
+                  [-0.2487, -0.1968, -0.2254],
+                  [ 0.0148,  0.0631,  0.1016],
+                  [ 0.0000, -0.0195, -0.0187]]]])
 
         Tomography operator with 3 uniformly sampled angles in [0, 360] for 3x3 image:
 
@@ -108,9 +108,9 @@ class Tomography(LinearPhysics):
         >>> physics = Tomography(angles=3, img_width=4, circle=True, normalize=True)
         >>> physics(x)
         tensor([[[[ 0.0000, -0.0788,  0.0218],
-                [-0.2492, -0.2651, -0.2973],
-                [ 0.0148,  0.1385,  0.0073],
-                [ 0.0000, -0.0197,  0.0432]]]])
+                  [-0.2492, -0.2651, -0.2973],
+                  [ 0.0148,  0.1385,  0.0073],
+                  [ 0.0000, -0.0197,  0.0432]]]])
 
 
     """

--- a/deepinv/tests/test_external_libraries.py
+++ b/deepinv/tests/test_external_libraries.py
@@ -12,17 +12,14 @@ class TestTomographyWithAstra:
     def dummy_projection(cls, x: torch.Tensor, out: torch.Tensor) -> None:
         out[:] = 1.0
 
+    @pytest.mark.parametrize("normalize", [True, False, None])
     @pytest.mark.parametrize(
-        "is_2d,geometry_type,normalize",
+        "is_2d,geometry_type",
         [
-            (True, "parallel", False),
-            (True, "parallel", True),
-            (True, "fanbeam", False),
-            (True, "fanbeam", True),
-            (False, "parallel", False),
-            (False, "parallel", True),
-            (False, "conebeam", False),
-            (False, "conebeam", True),
+            (True, "parallel"),
+            (True, "fanbeam"),
+            (False, "parallel"),
+            (False, "conebeam"),
         ],
     )
     def test_tomography_with_astra_logic(self, is_2d, geometry_type, normalize):
@@ -117,6 +114,10 @@ class TestTomographyWithAstra:
                 loss.backward()
                 assert pred.grad is not None
 
+                if normalize is None:
+                    # when normalize is not set by the user, it should default to True
+                    assert physics.normalize is True
+
         else:
             ## --- Test adjointness ---
             Ax = physics.A(x)
@@ -141,3 +142,11 @@ class TestTomographyWithAstra:
             loss = torch.linalg.norm(physics.A(pred) - Ax)
             loss.backward()
             assert pred.grad is not None
+
+            if normalize:
+                assert abs(physics.compute_norm(x) - 1.0) < 1e-3
+
+            if normalize is None:
+                # when normalize is not set by the user, it should default to True
+                assert physics.normalize is True
+                assert abs(physics.compute_norm(x) - 1.0) < 1e-3

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1316,8 +1316,13 @@ def test_tomography(
     )
 
     x = torch.randn(imsize, device=device).unsqueeze(0)
+
     if adjoint_via_backprop:
         assert physics.adjointness_test(x).abs() < 1e-3
+
+    if normalize:
+        assert abs(physics.compute_norm(x) - 1.0) < 1e-3
+
     r = physics.A_adjoint(physics.A(x)) * torch.pi / (2 * len(physics.radon.theta))
     y = physics.A(r)
     error = (physics.A_dagger(y) - r).flatten().mean().abs()

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1315,7 +1315,7 @@ def test_tomography(
         parallel_computation=parallel_computation,
     )
 
-    x = torch.randn(imsize, device=device).unsqueeze(0)
+    x = torch.randn(imsize, device=device, generator=torch.Generator(device).manual_seed(0)).unsqueeze(0)
 
     if adjoint_via_backprop:
         assert physics.adjointness_test(x).abs() < 1e-3

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1287,7 +1287,7 @@ def test_reset_noise(device):
     assert physics.noise_model.sigma == 0.2
 
 
-@pytest.mark.parametrize("normalize", [True, False])
+@pytest.mark.parametrize("normalize", [True, False, None])
 @pytest.mark.parametrize("parallel_computation", [True, False])
 @pytest.mark.parametrize("fan_beam", [True, False])
 @pytest.mark.parametrize("circle", [True, False])
@@ -1328,6 +1328,11 @@ def test_tomography(
         assert physics.adjointness_test(x).abs() < 1e-3
 
     if normalize:
+        assert abs(physics.compute_norm(x) - 1.0) < 1e-3
+
+    if normalize is None:
+        # when normalize is not set by the user, it should default to True
+        assert physics.normalize is True
         assert abs(physics.compute_norm(x) - 1.0) < 1e-3
 
     r = physics.A_adjoint(physics.A(x)) * torch.pi / (2 * len(physics.radon.theta))

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1315,7 +1315,9 @@ def test_tomography(
         parallel_computation=parallel_computation,
     )
 
-    x = torch.randn(imsize, device=device, generator=torch.Generator(device).manual_seed(0)).unsqueeze(0)
+    x = torch.randn(
+        imsize, device=device, generator=torch.Generator(device).manual_seed(0)
+    ).unsqueeze(0)
 
     if adjoint_via_backprop:
         assert physics.adjointness_test(x).abs() < 1e-3


### PR DESCRIPTION
Remove the ad-hoc procedure use to normalize the Tomography operator, i.e. the procedure did not yield an operator with a spectral norm equal to one (checked with `compute_norm`).

Instead of scaling each call to `A` and `A_adjoint` by the `img_width`, the operator norm is computed during initialization and stored afterwards to scale every computation.

**Warning**: this will break backward compatibility with any network/method optimized with normalize=True, e.g. I encountered the problem with RAM (@tachella @matthieutrs ). Not sure how you want to handle this ? 
- An easy solution for the user is to manually set the `operator_norm` attribute to whatever value is needed, thus overwriting the value computed during initialization.

PS: I also fixed a small bug related to the import chain of `astra.experimental` in `deepinv/physics/functional/astra.py` (not covered by the mock test as it deliberately skips these calls), everything should work fine now.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
