### PR TITLE
Deprecate implicit filter-less downsampling

### DIFF
--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -31,7 +31,7 @@ class Downsampling(LinearPhysics):
     where :math:`h` is a low-pass filter and :math:`S` is a subsampling operator.
 
     :param torch.Tensor, str, None filter: Downsampling filter. It can be ``'gaussian'``, ``'bilinear'``, ``'bicubic'``
-        , ``'sinc'`` or a custom ``torch.Tensor`` filter. If ``None``, no filtering is applied.
+        , ``'sinc'`` or a custom ``torch.Tensor`` filter. If ``None``, no filtering is applied. Bicubic downsampling is a sensible default if you are not sure which filter to use.
     :param tuple[int], None img_size: optional size of the high resolution image `(C, H, W)`.
         If `tuple`, use this fixed image size.
         If `None`, override on-the-fly using input data size and `factor` (note that here, `A_adjoint` will
@@ -62,12 +62,18 @@ class Downsampling(LinearPhysics):
     def __init__(
         self,
         img_size=None,
-        filter=None,
+        filter="warn",
         factor=2,
         device="cpu",
         padding="circular",
         **kwargs,
     ):
+        if filter == "warn":
+            warn(
+                "Leaving the filter as default is deprecated and will be removed in future versions. Please specify filter=None for bare decimation, or one of the available filters (gaussian, bilinear, bicubic, sinc) for filtered downsampling. You can use filter=\"bicubic\" as a sensible anti-aliasing filter if you are not sure which one to use.",
+                stacklevel=2,
+            )
+            filter = None
         super().__init__(**kwargs)
         self.imsize = tuple(img_size) if isinstance(img_size, list) else img_size
         self.imsize_dynamic = (3, 128, 128)  # placeholder

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -70,7 +70,7 @@ class Downsampling(LinearPhysics):
     ):
         if filter == "warn":
             warn(
-                "Leaving the filter as default is deprecated and will be removed in future versions. Please specify filter=None for bare decimation, or one of the available filters (gaussian, bilinear, bicubic, sinc) for filtered downsampling. You can use filter=\"bicubic\" as a sensible anti-aliasing filter if you are not sure which one to use.",
+                'Leaving the filter as default is deprecated and will be removed in future versions. Please specify filter=None for bare decimation, or one of the available filters (gaussian, bilinear, bicubic, sinc) for filtered downsampling. You can use filter="bicubic" as a sensible anti-aliasing filter if you are not sure which one to use.',
                 stacklevel=2,
             )
             filter = None

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -2220,3 +2220,11 @@ def test_separate_noise_models():
     assert (
         physics2.noise_model.sigma == sigma2
     ), "Expected physics2 to be unchanged after updating physics1"
+
+
+def test_downsampling_default_filter_depreciation():
+    with pytest.warns(
+        UserWarning,
+        match="deprecated",
+    ):
+        _ = dinv.physics.Downsampling()

--- a/docs/source/user_guide/physics/intro.rst
+++ b/docs/source/user_guide/physics/intro.rst
@@ -175,7 +175,7 @@ can be done with :func:`deepinv.physics.stack`. The stacked operator is
     >>> import deepinv as dinv
     >>> x = torch.rand((1, 1, 8, 8))
     >>> physics1 = dinv.physics.BlurFFT(img_size=(1, 8, 8), filter=dinv.physics.blur.gaussian_blur(.2))
-    >>> physics2 = dinv.physics.Downsampling(img_size=(1, 8, 8), factor=2)
+    >>> physics2 = dinv.physics.Downsampling(img_size=(1, 8, 8), factor=2, filter=None)
     >>> physics3 = dinv.physics.stack(physics1, physics2)
     >>> physics3 = physics1.stack(physics2) # equivalent to the previous line
     >>> y = physics3(x) #
@@ -219,7 +219,7 @@ can be done by multiplying the operators:
     >>> import torch
     >>> import deepinv as dinv
     >>> x = torch.rand((1, 1, 8, 8))
-    >>> physics1 = dinv.physics.Downsampling(img_size=(1, 8, 8), factor=2)
+    >>> physics1 = dinv.physics.Downsampling(img_size=(1, 8, 8), factor=2, filter=None)
     >>> physics2 = dinv.physics.BlurFFT(img_size=(1, 4, 4), filter=dinv.physics.blur.gaussian_blur(.2))
     >>> physics = physics2 * physics1
     >>> y = physics(x) # equivalent to y = physics2(physics1.A(x))

--- a/docs/source/user_guide/reconstruction/pretrained-models.rst
+++ b/docs/source/user_guide/reconstruction/pretrained-models.rst
@@ -23,7 +23,7 @@ These models can be set-up in one line and perform inference in another line:
   >>> model = dinv.models.RAM(pretrained=True) # or any of the models listed below
   >>> x_hat = model(y, physics) # Model inference
   >>> dinv.metric.PSNR()(x_hat, x)
-  tensor([22.9831])
+  tensor([31.9825])
 
 .. list-table:: Pretrained reconstructors
    :header-rows: 1

--- a/docs/source/user_guide/reconstruction/pretrained-models.rst
+++ b/docs/source/user_guide/reconstruction/pretrained-models.rst
@@ -18,7 +18,7 @@ These models can be set-up in one line and perform inference in another line:
 
   >>> import deepinv as dinv
   >>> x = dinv.utils.load_example("butterfly.png")
-  >>> physics = dinv.physics.Downsampling(filter=None)
+  >>> physics = dinv.physics.Downsampling(filter="bicubic")
   >>> y = physics(x)
   >>> model = dinv.models.RAM(pretrained=True) # or any of the models listed below
   >>> x_hat = model(y, physics) # Model inference

--- a/docs/source/user_guide/reconstruction/pretrained-models.rst
+++ b/docs/source/user_guide/reconstruction/pretrained-models.rst
@@ -18,7 +18,7 @@ These models can be set-up in one line and perform inference in another line:
 
   >>> import deepinv as dinv
   >>> x = dinv.utils.load_example("butterfly.png")
-  >>> physics = dinv.physics.Downsampling()
+  >>> physics = dinv.physics.Downsampling(filter=None)
   >>> y = physics(x)
   >>> model = dinv.models.RAM(pretrained=True) # or any of the models listed below
   >>> x_hat = model(y, physics) # Model inference

--- a/examples/physics/demo_physics_tour.py
+++ b/examples/physics/demo_physics_tour.py
@@ -248,7 +248,9 @@ plot([x, y], titles=["signal", "measurement"])
 # The downsampling class :class:`deepinv.physics.Downsampling` is associated with a downsampling operator.
 
 
-physics = dinv.physics.Downsampling(img_size=img_size, factor=2, device=device, filter=None)
+physics = dinv.physics.Downsampling(
+    img_size=img_size, factor=2, device=device, filter=None
+)
 
 
 y = physics(x)

--- a/examples/physics/demo_physics_tour.py
+++ b/examples/physics/demo_physics_tour.py
@@ -249,7 +249,7 @@ plot([x, y], titles=["signal", "measurement"])
 
 
 physics = dinv.physics.Downsampling(
-    img_size=img_size, factor=2, device=device, filter=None
+    img_size=img_size, factor=2, device=device, filter="bicubic"
 )
 
 

--- a/examples/physics/demo_physics_tour.py
+++ b/examples/physics/demo_physics_tour.py
@@ -248,7 +248,7 @@ plot([x, y], titles=["signal", "measurement"])
 # The downsampling class :class:`deepinv.physics.Downsampling` is associated with a downsampling operator.
 
 
-physics = dinv.physics.Downsampling(img_size=img_size, factor=2, device=device)
+physics = dinv.physics.Downsampling(img_size=img_size, factor=2, device=device, filter=None)
 
 
 y = physics(x)


### PR DESCRIPTION
Towards #717

I used `filter="warn"` as the new default following https://scikit-learn.org/dev/developers/contributing.html#change-the-default-value-of-a-parameter