### PR TITLE
(Micro-)optimize the soft-thresholding implementation

### DIFF
--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -269,9 +269,7 @@ class L1Prior(Prior):
         :param float gamma: stepsize of the proximity operator.
         :return torch.Tensor: proximity operator at :math:`x`.
         """
-        return torch.sign(x) * torch.max(
-            torch.abs(x) - ths * gamma, torch.zeros_like(x)
-        )
+        return (x.abs() - ths * gamma).clamp(min=0.0) * x.sign()
 
 
 class WaveletPrior(Prior):


### PR DESCRIPTION
The entry-wise operation `max(x, 0)` used in the soft-thresholding function is currently implemented as `torch.max(..., torch.zeros(...))` which is wasteful due to the allocation of a possibly large tensor filled with zeros instead of using a primitive that does the same, for instance `torch.clamp(..., min=0.0)`.

**Results**

A minimal benchmark gives a significant speed-up:

```
[OK] torch.allclose passed on 50 different inputs (device=cpu, dtype=torch.float32).
prox_orig: 784.99 μs/call
prox_new : 152.98 μs/call
Speedup (orig/new): 5.13×
```

The code, written by OpenAI's GPT-5-Thinking model:

```python
import time
import torch

def prox_orig(x, ths=1.0, gamma=1.0):
    return torch.sign(x) * torch.max(torch.abs(x) - ths * gamma, torch.zeros_like(x))

def prox_new(x, ths=1.0, gamma=1.0):
    return (x.abs() - ths * gamma).clamp(min=0.0) * x.sign()

# ---- helpers ----
def _sync(device: torch.device):
    if device.type == "cuda":
        torch.cuda.synchronize(device)
    elif device.type == "mps":
        # torch.mps.synchronize() exists when MPS is available; guard just in case
        try:
            torch.mps.synchronize()
        except AttributeError:
            pass

@torch.no_grad()
def bench(fn, xs, warmup_iters=20, iters=200):
    device = xs[0].device
    total = 0.0
    for x in xs:
        # warmup (do not time)
        for _ in range(warmup_iters):
            fn(x)
        _sync(device)
        t0 = time.perf_counter()
        for _ in range(iters):
            fn(x)
        _sync(device)
        total += time.perf_counter() - t0
    calls = len(xs) * iters
    return (total / calls) * 1e6  # μs/call

def main():
    # ---- config ----
    shape = (1, 3, 128, 128)
    ths = 1.0
    gamma = 1.0
    num_xs = 50          # number of different inputs
    warmup_iters = 20    # per-x warmup iterations (not timed)
    iters = 300          # per-x timed iterations

    device = torch.device(
        "cuda" if torch.cuda.is_available()
        else ("mps" if hasattr(torch.backends, "mps") and torch.backends.mps.is_available() else "cpu")
    )
    dtype = torch.float32

    # reproducible stream of different x's
    gen = torch.Generator(device=device).manual_seed(1234)
    xs = [torch.randn(shape, generator=gen, device=device, dtype=dtype) for _ in range(num_xs)]

    # ---- correctness check ----
    with torch.no_grad():
        for i, x in enumerate(xs):
            y1 = prox_orig(x, ths, gamma)
            y2 = prox_new(x, ths, gamma)
            if not torch.allclose(y1, y2):
                diff = (y1 - y2).abs().max().item()
                raise AssertionError(f"Mismatch at sample {i}, max |diff| = {diff}")
    print(f"[OK] torch.allclose passed on {num_xs} different inputs (device={device}, dtype={dtype}).")

    # ---- timing ----
    t_orig = bench(lambda x: prox_orig(x, ths, gamma), xs, warmup_iters, iters)
    t_new  = bench(lambda x: prox_new(x, ths, gamma),  xs, warmup_iters, iters)

    speedup = t_orig / t_new if t_new > 0 else float("inf")
    print(f"prox_orig: {t_orig:.2f} μs/call")
    print(f"prox_new : {t_new:.2f} μs/call")
    print(f"Speedup (orig/new): {speedup:.2f}×")

if __name__ == "__main__":
    torch.set_grad_enabled(False)
    main()

```