### PR TITLE
Update integration with ASTRA Toolbox

### DIFF
--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -359,7 +359,7 @@ class AutogradTransform(torch.autograd.Function):
 
 def create_projection_geometry(
     geometry_type: str,
-    detector_spacing: Union[int, tuple[int, int]],
+    detector_spacing: Union[float, tuple[float, float]],
     n_detector_pixels: Union[int, tuple[int, int]],
     angles: torch.Tensor,
     is_2d: bool = False,

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -126,7 +126,7 @@ class XrayTransform:
                 return self.projection_geometry["DistanceOriginDetector"]
 
     @property
-    def magnitude(self) -> float:
+    def magnification_factor(self) -> float:
         """The magnification factor induced by the fan/cone geometry."""
         if "cone" in self.projection_geometry["type"]:
             return (self.detector_radius + self.source_radius) / self.source_radius
@@ -196,7 +196,7 @@ class XrayTransform:
                 parent._backprojection(x, out)
                 if self.is_2d:
                     # necessary scaling in fanbeam to obtain decent approximated adjoint
-                    out /= parent.magnitude
+                    out /= parent.magnification_factor
 
                 return out
 

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -227,7 +227,7 @@ class XrayTransform:
         return _Adjoint()
 
     def _forward_projection(self, x: torch.Tensor, out: torch.Tensor) -> None:
-        import astra
+        import astra.experimental
 
         assert (
             x.shape == self.domain_shape
@@ -248,7 +248,7 @@ class XrayTransform:
         )
 
     def _backprojection(self, y: torch.Tensor, out: torch.Tensor) -> None:
-        import astra
+        import astra.experimental
 
         assert (
             y.shape == self.range_shape

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -82,9 +82,9 @@ class XrayTransform:
     def detector_cell_v_length(self) -> float:
         """The vertical length of a detector cell."""
         if "vec" in self.projection_geometry["type"]:
-            return np.sqrt(
-                (self.projection_geometry["Vectors"][0, [9, 10, 11]] ** 2).sum()
-            )
+            return np.linalg.norm(
+                self.projection_geometry["Vectors"][0, [9, 10, 11]],
+            ).item()
         else:
             return self.projection_geometry["DetectorSpacingY"]
 
@@ -92,9 +92,9 @@ class XrayTransform:
     def detector_cell_u_length(self) -> float:
         """The horizontal length of a detector cell."""
         if "vec" in self.projection_geometry["type"]:
-            return np.sqrt(
-                (self.projection_geometry["Vectors"][0, [6, 7, 8]] ** 2).sum()
-            )
+            return np.linalg.norm(
+                self.projection_geometry["Vectors"][0, [6, 7, 8]]
+            ).item()
         else:
             return self.projection_geometry["DetectorSpacingX"]
 
@@ -106,44 +106,24 @@ class XrayTransform:
     @property
     def source_radius(self) -> float:
         """The distance between the source and the axis of rotation."""
-        import astra
-
         if not hasattr(self, "_source_radius"):
             if "vec" in self.projection_geometry["type"]:
-                self._source_radius = np.sqrt(
-                    (
-                        astra.geom_2vec(self.projection_geometry)["Vectors"][
-                            :, [0, 1, 2]
-                        ]
-                        ** 2
-                    ).sum(axis=1)
-                ).mean()
+                return np.linalg.norm(
+                    self.projection_geometry["Vectors"][0, [0, 1, 2]],
+                ).item()
             else:
-                self._source_radius = self.projection_geometry["DistanceOriginSource"]
-
-        return self._source_radius
+                return self.projection_geometry["DistanceOriginSource"]
 
     @property
     def detector_radius(self) -> float:
         """The distance between the center of the detector and the axis of rotation."""
-        import astra
-
         if not hasattr(self, "_detector_radius"):
             if "vec" in self.projection_geometry["type"]:
-                self._detector_radius = np.sqrt(
-                    (
-                        astra.geom_2vec(self.projection_geometry)["Vectors"][
-                            :, [3, 4, 5]
-                        ]
-                        ** 2
-                    ).sum(axis=1)
-                ).mean()
+                return np.linalg.norm(
+                    self.projection_geometry["Vectors"][0, [3, 4, 5]],
+                ).item()
             else:
-                self._detector_radius = self.projection_geometry[
-                    "DistanceOriginDetector"
-                ]
-
-        return self._detector_radius
+                return self.projection_geometry["DistanceOriginDetector"]
 
     @property
     def magnitude(self) -> float:

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -384,13 +384,17 @@ def create_projection_geometry(
             )
     else:
         if geometry_vectors is None:
+            if isinstance(detector_spacing, (float, int)):
+                detector_spacing = (detector_spacing, detector_spacing)
             if len(detector_spacing) != 2:
                 raise ValueError(
-                    f"For 3D geometry, argument `detector_spacing` should be a tuple of 2 float the vertical and horizontal dimensions of a detector cell, got {len(detector_spacing)}"
+                    f"For 3D geometry, argument `detector_spacing` should be float or a tuple of size 2 specifying the vertical and horizontal dimensions of a detector cell, got len(detector_spacing)={len(detector_spacing)}"
                 )
+        if isinstance(n_detector_pixels, int):
+            n_detector_pixels = (n_detector_pixels, n_detector_pixels)
         if len(n_detector_pixels) != 2:
             raise ValueError(
-                f"For 3D geometry, argument `n_detector_pixels` should be a tuple of 2 int specifying the number of (columns,rows) in the detector grid {len(n_detector_pixels)}"
+                f"For 3D geometry, argument `n_detector_pixels` should be a int or tuple of size 2 specifying the number of (columns,rows) in the detector grid, got len(n_detector_pixels)={len(n_detector_pixels)}"
             )
 
     if geometry_parameters is not None:
@@ -484,7 +488,7 @@ def create_object_geometry(
     n_cols: int,
     n_slices: int = 1,
     is_2d: bool = True,
-    pixel_spacing: tuple[float, ...] = (1.0, 1.0),
+    pixel_spacing: Union[float, tuple[float, ...]] = 1.0,
     bounding_box: Optional[tuple[float, ...]] = None,
 ) -> dict[str, Any]:
     """Utility function that produces a "volume geometry", a dict of parameters
@@ -494,7 +498,7 @@ def create_object_geometry(
     :param int n_cols: Number of columns.
     :param int n_slices: Number of slices. It is automatically set to 1 when ``is_2d=True``.
     :param bool is_2D: Boolean specifying if the parameters define a 2D slice or a 3D volume.
-    :param tuple[float, ...] pixel_spacing: Dimensions of reconstruction cell along the axis [x,y,...].
+    :param float | tuple[float, ...] pixel_spacing: Dimensions of reconstruction cell along the axis [x,y,...].
     :param tuple[float, ...] bounding_box: Extent of the reconstruction area [min_x, max_x, min_y, max_y, ...]
     """
     import astra
@@ -506,9 +510,11 @@ def create_object_geometry(
                     f"For 2D geometry, argument `bounding_box` should be a tuple of size 4 for with (min_x,max_x,min_y,max_y), got len(bounding_box)={len(bounding_box)}"
                 )
         else:
+            if isinstance(pixel_spacing, (float, int)):
+                pixel_spacing = (pixel_spacing, pixel_spacing)
             if len(pixel_spacing) != 2:
                 raise ValueError(
-                    f"For 2D geometry, `pixel_spacing` should be a tuple of size 2 with dimensions (length_x,length_y) of a pixel, got len(pixel_spacing)={len(pixel_spacing)}"
+                    f"For 2D geometry, `pixel_spacing` should be a float or tuple of size 2 specifying (length_x,length_y) of a pixel, got len(pixel_spacing)={len(pixel_spacing)}"
                 )
     else:
         if bounding_box is not None:
@@ -517,9 +523,11 @@ def create_object_geometry(
                     f"For 3D geometry, argument `bounding_box` should be a tuple of size 6 for with (min_x,max_x,min_y,max_y,min_z,max_z), got len(bounding_box)={len(bounding_box)}"
                 )
         else:
+            if isinstance(pixel_spacing, (float, int)):
+                pixel_spacing = (pixel_spacing, pixel_spacing, pixel_spacing)
             if len(pixel_spacing) != 3:
                 raise ValueError(
-                    f"For 23 geometry, `pixel_spacing` should be a tuple of size 3 with dimensions (length_x,length_y, length_z) of a voxel, got len(pixel_spacing)={len(pixel_spacing)}"
+                    f"For 23 geometry, `pixel_spacing` should be float or a tuple of size 3 specifying (length_x,length_y,length_z) of a pixel, got len(pixel_spacing)={len(pixel_spacing)}"
                 )
 
     if is_2d:

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -277,6 +277,7 @@ def _create_astra_link(data: torch.Tensor) -> object:
     """
     import astra
 
+    assert data.device.type == "cuda", "Data must be on a CUDA device"
     assert data.is_contiguous(), "Data must be contiguous"
     assert data.dtype == torch.float32, "Data must be of type float32"
     assert len(data.shape) == 3, "Data must be 3D"

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -83,7 +83,7 @@ class XrayTransform:
         """The vertical length of a detector cell."""
         if "vec" in self.projection_geometry["type"]:
             return np.sqrt(
-                (self.projection_geometry["Vectors"][1, [6, 7, 8]] ** 2).sum()
+                (self.projection_geometry["Vectors"][0, [9, 10, 11]] ** 2).sum()
             )
         else:
             return self.projection_geometry["DetectorSpacingY"]

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -18,10 +18,10 @@ class XrayTransform:
 
         This transform does not handle batched and multi-channel inputs. It is
         handled by a custom :class:`torch.autograd.Function` that wraps the :class:`XrayTransform`.
-        To handle standard PyTorch pipelines, :class:`XrayTransform` is instanciated inside a :class:`deepinv.physics.TomographyWithAstra` operator.
+        To handle standard PyTorch pipelines, :class:`XrayTransform` is instantiated inside a :class:`deepinv.physics.TomographyWithAstra` operator.
 
-    :param dict[str, Any] projection_geometry: Dictionnary containing the parameters of the projection geometry. It is passed to the ``astra.create_projector()`` function to instanciate the projector.
-    :param dict[str, Any] object_geometry:  Dictionnary containing the parameters of the object geometry. It is passed to the ``astra.create_projector()`` function to instanciate the projector.
+    :param dict[str, Any] projection_geometry: Dictionary containing the parameters of the projection geometry. It is passed to the ``astra.create_projector()`` function to instantiate the projector.
+    :param dict[str, Any] object_geometry:  Dictionary containing the parameters of the object geometry. It is passed to the ``astra.create_projector()`` function to instantiate the projector.
     :param bool is_2d: Specifies if the geometry is flat (2D) or describe a real 3D reconstruction setup.
 
     .. note::
@@ -139,7 +139,7 @@ class XrayTransform:
         r"""Forward projection.
 
         :param torch.Tensor x: Tensor of shape [1,H,W] in 2D, or [D,H,W] in 3D.
-        :param torch.Tensor, None out: To avoid unecessary copies, provide tensor of shape [...,A,N]
+        :param torch.Tensor, None out: To avoid unnecessary copies, provide tensor of shape [...,A,N]
         to store output results
         :return: Sinogram of shape [1,A,N] in 2D or set of sinograms [V,A,N] in 3D.
         """
@@ -180,7 +180,7 @@ class XrayTransform:
                 r"""Backprojection.
 
                 :param torch.Tensor x: Tensor of shape [1,A,N] in 2D, or [V,A,N] in 3D.
-                :param torch.Tensor, None out: To avoid unecessary copies, provide tensor of shape [...,H,W]
+                :param torch.Tensor, None out: To avoid unnecessary copies, provide tensor of shape [...,H,W]
                 to store output results
                 :return: Image of shape [1,H,W] in 2D or volume [D,H,W] in 3D.
                 """
@@ -287,7 +287,7 @@ class AutogradTransform(torch.autograd.Function):
         """Forward autograd.
 
         The ``astra-toolbox`` does not handle batched computation, the transform
-        is applied sequantially by iterating over the batch and channel dimension
+        is applied sequentially by iterating over the batch and channel dimension
         (e.g. Learned Primal-Dual).
 
         :param torch.Tensor input: Batched with channel input Tensor of shape [B,C,...].
@@ -353,7 +353,7 @@ def create_projection_geometry(
     :param int | tuple[int, int]: In 2D the width of a detector cell. In 3D a 2-element tuple specifying the (vertical, horizontal) dimensions of a detector cell. (default: 1.0)
     :param torch.Tensor angles: Tensor containing angular positions in degrees.
     :param bool is_2d: Boolean specifying if the parameters define a 2D slice or a 3D volume.
-    :param dict[str, str], None geometry_parameters: Contains extra parameters specific to certain geometries. When ``geometry_type='fanbeam'`` or  ``'conebeam'``, the dictionnary should contains the keys
+    :param dict[str, str], None geometry_parameters: Contains extra parameters specific to certain geometries. When ``geometry_type='fanbeam'`` or  ``'conebeam'``, the dictionary should contains the keys
 
         - "source_radius" distance between the x-ray source and the rotation axis, denoted :math:`D_{s0}` (default: 80.)
 
@@ -527,7 +527,7 @@ def create_object_geometry(
                 pixel_spacing = (pixel_spacing, pixel_spacing, pixel_spacing)
             if len(pixel_spacing) != 3:
                 raise ValueError(
-                    f"For 23 geometry, `pixel_spacing` should be float or a tuple of size 3 specifying (length_x,length_y,length_z) of a pixel, got len(pixel_spacing)={len(pixel_spacing)}"
+                    f"For 2D geometry, `pixel_spacing` should be float or a tuple of size 3 specifying (length_x,length_y,length_z) of a pixel, got len(pixel_spacing)={len(pixel_spacing)}"
                 )
 
     if is_2d:

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -329,13 +329,12 @@ class TomographyWithAstra(LinearPhysics):
         The :class:`deepinv.physics.functional.XrayTransform` used in :class:`deepinv.physics.TomographyWithAstra` sequentially processes batch elements, which can make the 2D parallel beam operator significantly slower than its native torch counterpart with :class:`deepinv.physics.Tomography` (though still more memory-efficient).
 
     :param tuple[int, ...] img_size: Shape of the object grid, either a 2 or 3-element tuple, for respectively 2D or 3D.
-    :param int num_angles: Number of angular positions sampled uniformly in ``angular_range``. (default: 180)
-    :param int | tuple[int, ...], None num_detectors: In 2D, specify an integer for a single line of detector cells. In 3D, specify a 2-element tuple for (row,col) shape of the detector. (default: None)
-    :param tuple[float, float] angular_range: Angular range, defaults to ``(0, torch.pi)``.
+    :param int angles: Number of angular positions sampled uniformly in ``angular_range`` or a Tensor containing angular positions in degrees. (default: 180)
+    :param int | tuple[int, ...], None n_detector_pixels: In 2D, specify an integer for a single line of detector cells. In 3D, specify a 2-element tuple for (row,col) shape of the detector. (default: None)
+    :param tuple[float, float] angular_range: Angular range, defaults to ``(0, 180)``.
     :param float | tuple[float, float] detector_spacing: In 2D the width of a detector cell. In 3D a 2-element tuple specifying the (vertical, horizontal) dimensions of a detector cell. (default: 1.0)
-    :param tuple[float, ...] object_spacing: In 2D, the (x,y) dimensions of a pixel in the reconstructed image. In 3D, the (x,y,z) dimensions of a voxel. (default: ``(1.,1.)``)
+    :param tuple[float, ...] pixel_spacing: In 2D, the (x,y) dimensions of a pixel in the reconstructed image. In 3D, the (x,y,z) dimensions of a voxel. (default: ``(1.,1.)``)
     :param tuple[float, ...], None bounding_box: Axis-aligned bounding-box of the reconstruction area [min_x, max_x, min_y, max_y, ...]. Optional argument, if specified, overrides argument ``object_spacing``. (default: None)
-    :param torch.Tensor, None angles: Tensor containing angular positions in radii. Optional, if specified, overrides arguments ``num_angles`` and ``angular_range``. (default: None)
     :param str geometry_type: The type of geometry among ``'parallel'``, ``'fanbeam'`` in 2D and ``'parallel'`` and ``'conebeam'`` in 3D. (default: ``'parallel'``)
     :param dict[str, Any] geometry_parameters: Contains extra parameters specific to certain geometries. When ``geometry_type='fanbeam'`` or  ``'conebeam'``, the dictionnary should contains the keys
 
@@ -353,7 +352,7 @@ class TomographyWithAstra(LinearPhysics):
 
         - ``(vx, vy, vz)``: the vertical unit vector of the detector.
 
-        When specified, ``geometry_vectors`` overrides ``detector_spacing``, ``num_angles``/``angles`` and ``geometry_parameters``. It is particularly useful to build the geometry for the `Walnut-CBCT dataset <https://zenodo.org/records/2686726>`_, where the acquisition parameters are provided via such vectors.
+        When specified, ``geometry_vectors`` overrides ``detector_spacing``, ``angles`` and ``geometry_parameters``. It is particularly useful to build the geometry for the `Walnut-CBCT dataset <https://zenodo.org/records/2686726>`_, where the acquisition parameters are provided via such vectors.
     :param bool normalize: If ``True`` :func:`A` and :func:`A_adjoint` are normalized so that the operator has unit norm. (default: ``False``)
     :param torch.device | str device: The operator only supports CUDA computation. (default: ``torch.device('cuda')``)
 
@@ -371,9 +370,9 @@ class TomographyWithAstra(LinearPhysics):
             >>> x = torch.randn(1, 1, 5, 5, device='cuda') # Define random 5x5 image
             >>> physics = TomographyWithAstra(
             ...        img_size=(5,5),
-            ...        num_angles=10,
+            ...        angles=10,
             ...        angular_range=(0, 2*torch.pi),
-            ...        num_detectors=5,
+            ...        n_detector_pixels=5,
             ...        detector_spacing=2.0,
             ...        geometry_type='fanbeam',
             ...        geometry_parameters={
@@ -405,8 +404,8 @@ class TomographyWithAstra(LinearPhysics):
             >>> physics = TomographyWithAstra(
             ...        img_size=(5,5,5),
             ...        angles = angles,
-            ...        num_detectors=(5,5),
-            ...        object_spacing=(1.0,1.0,1.0),
+            ...        n_detector_pixels=(5,5),
+            ...        pixel_spacing=(1.0,1.0,1.0),
             ...        detector_spacing=(2.0,2.0),
             ...        geometry_type='conebeam',
             ...        geometry_parameters={
@@ -440,13 +439,12 @@ class TomographyWithAstra(LinearPhysics):
     def __init__(
         self,
         img_size: tuple[int, ...],
-        num_angles: int = 180,
-        num_detectors: Optional[Union[int, tuple[int, ...]]] = None,
+        angles: Union[int, torch.Tensor] = 180,
+        n_detector_pixels: Optional[Union[int, tuple[int, ...]]] = None,
         angular_range: tuple[float, float] = (0, torch.pi),
         detector_spacing: Union[float, tuple[float, float]] = 1.0,
-        object_spacing: tuple[float, ...] = (1.0, 1.0),
+        pixel_spacing: tuple[float, ...] = (1.0, 1.0),
         bounding_box: Optional[tuple[float, ...]] = None,
-        angles: Optional[torch.Tensor] = None,
         geometry_type: str = "parallel",
         geometry_parameters: dict[str, Any] = MappingProxyType(
             {
@@ -477,29 +475,29 @@ class TomographyWithAstra(LinearPhysics):
 
         self.img_size = img_size
         self.is_2d = len(img_size) == 2
-        self.num_detectors = (
+        self.n_detector_pixels = (
             math.ceil(math.sqrt(2) * img_size[0])
-            if num_detectors is None
-            else num_detectors
+            if n_detector_pixels is None
+            else n_detector_pixels
         )
         self.geometry_type = geometry_type
         self.normalize = False
         self.device = device
 
-        if angles is None:
-            angles = torch.linspace(*angular_range, steps=num_angles + 1)[:-1]
+        if isinstance(angles, int):
+            angles = torch.linspace(*angular_range, steps=angles + 1)[:-1]
 
         self.object_geometry = create_object_geometry(
             *img_size,
             bounding_box=bounding_box,
-            spacing=object_spacing,
+            pixel_spacing=pixel_spacing,
             is_2d=self.is_2d,
         )
 
         self.projection_geometry = create_projection_geometry(
             geometry_type=geometry_type,
             detector_spacing=detector_spacing,
-            n_detector_pixels=self.num_detectors,
+            n_detector_pixels=self.n_detector_pixels,
             angles=angles,
             is_2d=self.is_2d,
             geometry_parameters=geometry_parameters,

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -548,9 +548,6 @@ class TomographyWithAstra(LinearPhysics):
         """
         import astra
 
-        # NOTE: This import is used by its side effects.
-        from astra import experimental  # noqa: F401
-
         sinogram_scaled = torch.clone(sinogram)
         is_3d = len(sinogram.shape) == 5
 

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -333,7 +333,7 @@ class TomographyWithAstra(LinearPhysics):
     :param int | tuple[int, ...], None n_detector_pixels: In 2D, specify an integer for a single line of detector cells. In 3D, specify a 2-element tuple for (row,col) shape of the detector. (default: None)
     :param tuple[float, float] angular_range: Angular range, defaults to ``(0, 180)``.
     :param float | tuple[float, float] detector_spacing: In 2D the width of a detector cell. In 3D a 2-element tuple specifying the (vertical, horizontal) dimensions of a detector cell. (default: 1.0)
-    :param tuple[float, ...] pixel_spacing: In 2D, the (x,y) dimensions of a pixel in the reconstructed image. In 3D, the (x,y,z) dimensions of a voxel. (default: ``(1.,1.)``)
+    :param float | tuple[float, ...] pixel_spacing: In 2D, the (x,y) dimensions of a pixel in the reconstructed image. In 3D, the (x,y,z) dimensions of a voxel. Scalar value is interpreted as the same dimension along all axes (default: 1.0)
     :param tuple[float, ...], None bounding_box: Axis-aligned bounding-box of the reconstruction area [min_x, max_x, min_y, max_y, ...]. Optional argument, if specified, overrides argument ``object_spacing``. (default: None)
     :param str geometry_type: The type of geometry among ``'parallel'``, ``'fanbeam'`` in 2D and ``'parallel'`` and ``'conebeam'`` in 3D. (default: ``'parallel'``)
     :param dict[str, Any] geometry_parameters: Contains extra parameters specific to certain geometries. When ``geometry_type='fanbeam'`` or  ``'conebeam'``, the dictionnary should contains the keys
@@ -443,7 +443,7 @@ class TomographyWithAstra(LinearPhysics):
         n_detector_pixels: Optional[Union[int, tuple[int, ...]]] = None,
         angular_range: tuple[float, float] = (0, torch.pi),
         detector_spacing: Union[float, tuple[float, float]] = 1.0,
-        pixel_spacing: tuple[float, ...] = (1.0, 1.0),
+        pixel_spacing: Union[float, tuple[float, ...]] = 1.0,
         bounding_box: Optional[tuple[float, ...]] = None,
         geometry_type: str = "parallel",
         geometry_parameters: dict[str, Any] = MappingProxyType(

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -336,7 +336,7 @@ class TomographyWithAstra(LinearPhysics):
     :param float | tuple[float, ...] pixel_spacing: In 2D, the (x,y) dimensions of a pixel in the reconstructed image. In 3D, the (x,y,z) dimensions of a voxel. Scalar value is interpreted as the same dimension along all axes (default: 1.0)
     :param tuple[float, ...], None bounding_box: Axis-aligned bounding-box of the reconstruction area [min_x, max_x, min_y, max_y, ...]. Optional argument, if specified, overrides argument ``object_spacing``. (default: None)
     :param str geometry_type: The type of geometry among ``'parallel'``, ``'fanbeam'`` in 2D and ``'parallel'`` and ``'conebeam'`` in 3D. (default: ``'parallel'``)
-    :param dict[str, Any] geometry_parameters: Contains extra parameters specific to certain geometries. When ``geometry_type='fanbeam'`` or  ``'conebeam'``, the dictionnary should contains the keys
+    :param dict[str, Any] geometry_parameters: Contains extra parameters specific to certain geometries. When ``geometry_type='fanbeam'`` or  ``'conebeam'``, the dictionary should contains the keys
 
         - ``"source_radius"``: the distance between the x-ray source and the rotation axis, denoted :math:`D_{s0}`, (default: 80.),
 
@@ -535,7 +535,7 @@ class TomographyWithAstra(LinearPhysics):
 
     def fbp_weighting(self, sinogram: torch.Tensor) -> torch.Tensor:
         r"""Scales the computation by the inverse number of views and
-        object-to-dector cell ratio.
+        object-to-detector cell ratio.
 
         In conebeam 3D, compute FDK weights to correct inflated distances due to
         tilted rays. Given coordinate :math:`(x,y)`  of a detector cell, the corresponding

--- a/deepinv/tests/test_external_libraries.py
+++ b/deepinv/tests/test_external_libraries.py
@@ -141,3 +141,24 @@ class TestTomographyWithAstra:
             loss = torch.linalg.norm(physics.A(pred) - Ax)
             loss.backward()
             assert pred.grad is not None
+        
+        ## --- Test geometry properties ---
+        if is_2d:
+            assert physics.measurement_shape == (32, 32)
+            assert physics.xray_transform.domain_shape == (1, 16, 16)
+            assert physics.xray_transform.range_shape == (1, 32, 32)
+        else:
+            assert physics.measurement_shape == (32, 32, 32)
+            assert physics.xray_transform.domain_shape == (16, 16, 16)
+            assert physics.xray_transform.range_shape == (32, 32, 32)
+        assert physics.num_angles == 32
+        assert physics.xray_transform.object_cell_volume == pytest.approx(1.0)
+        assert physics.xray_transform.detector_cell_u_length == pytest.approx(1.0)
+        assert physics.xray_transform.detector_cell_v_length == pytest.approx(1.0)
+        assert physics.xray_transform.detector_cell_area == pytest.approx(1.0)
+        if geometry_type in ["fanbeam", "conebeam"]:
+            assert physics.xray_transform.source_radius == pytest.approx(80.0)
+            assert physics.xray_transform.detector_radius == pytest.approx(20.0)
+            assert physics.xray_transform.magnification_factor == pytest.approx(1.25)
+        else:
+            assert physics.xray_transform.magnification_factor == pytest.approx(1.0)

--- a/deepinv/tests/test_external_libraries.py
+++ b/deepinv/tests/test_external_libraries.py
@@ -45,14 +45,14 @@ class TestTomographyWithAstra:
         ## Test 2d transforms
         if is_2d:
             img_size = (16, 16)
-            num_detectors = 2 * img_size[0]
+            n_detector_pixels = 2 * img_size[0]
             num_angles = 2 * img_size[0]
             physics = dinv.physics.TomographyWithAstra(
                 img_size=img_size,
-                num_detectors=num_detectors,
-                num_angles=num_angles,
+                n_detector_pixels=n_detector_pixels,
+                angles=num_angles,
                 angular_range=(
-                    (0, torch.pi) if geometry_type == "parallel" else (0, 2 * torch.pi)
+                    (0, 180) if geometry_type == "parallel" else (0, 360)
                 ),
                 geometry_type=geometry_type,
                 normalize=normalize,
@@ -62,18 +62,18 @@ class TestTomographyWithAstra:
         else:
             ## Test 3d transforms
             img_size = (16, 16, 16)
-            num_detectors = (32, 32)
+            n_detector_pixels = (32, 32)
             num_angles = 2 * img_size[0]
             physics = dinv.physics.TomographyWithAstra(
                 img_size=img_size,
-                num_angles=num_angles,
+                angles=num_angles,
                 angular_range=(
-                    (0, torch.pi) if geometry_type == "parallel" else (0, 2 * torch.pi)
+                    (0, 180) if geometry_type == "parallel" else (0, 360)
                 ),
-                num_detectors=num_detectors,
+                n_detector_pixels=n_detector_pixels,
                 geometry_type=geometry_type,
                 detector_spacing=(1.0, 1.0),
-                object_spacing=(1.0, 1.0, 1.0),
+                pixel_spacing=(1.0, 1.0, 1.0),
                 normalize=normalize,
                 device=device,
             )

--- a/examples/external-libraries/_demo_astra_tomography.py
+++ b/examples/external-libraries/_demo_astra_tomography.py
@@ -71,11 +71,11 @@ noise_model = LogPoissonNoise(mu=mu, N0=N0)
 data_fidelity = LogPoissonLikelihood(mu=mu, N0=N0)
 physics = TomographyWithAstra(
     img_size=(img_size, img_size),
-    num_angles=num_angles,
+    angles=num_angles,
     device=device,
     noise_model=noise_model,
     geometry_type="fanbeam",
-    num_detectors=2 * img_size,
+    n_detector_pixels=2 * img_size,
     geometry_parameters={"source_radius": 800.0, "detector_radius": 200.0},
 )
 observation = physics(test_imgs)


### PR DESCRIPTION
This PR updates integration with ASTRA Toolbox introduced in (#474).

One thing I'm not completely certain about is a breaking change in the interface of `TomographyWithAstra` physics introduced by 47e1ba84feb7973dab9d248c8fcaa267623fb5e3. The motivation there is to make it as close as possible to the existing PyTorch-based `Tomography` physics, which should make it simpler to use the new ASTRA-based physics as a drop-in replacement. However, I'm not sure if it's worth a breaking change.

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
