### PR TITLE
Diffusion sde scaling of denoiser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Changed
 Fixed
 ^^^^^
 - Reduced CI python version tests (:gh:`746` by `Mathieu Terris`_)
-- Fix scalling issue in DiffusionSDE (:gh:`TODO` by `Minh Hai Nguyen`_)
+- Fix scaling issue in DiffusionSDE (:gh:`772` by `Minh Hai Nguyen`_)
 
 
 v0.3.4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changed
 Fixed
 ^^^^^
 - Reduced CI python version tests (:gh:`746` by `Mathieu Terris`_)
+- Fix scalling issue in DiffusionSDE (:gh:`TODO` by `Minh Hai Nguyen`_)
 
 
 v0.3.4
@@ -47,7 +48,6 @@ Fixed
 - Fix the condition for break in compute_norm (:gh:`699` by `Quentin Barthélemy`_)
 - Python 3.9 backward compatibility and zip_strict (:gh:`707` by `Andrew Wang`_)
 - Fix numerical instability of Bicgstab solver(:gh:`739` by `Minh Hai Nguyen`_)
-
 
 
 v0.3.3

--- a/deepinv/models/guided_diffusion.py
+++ b/deepinv/models/guided_diffusion.py
@@ -43,7 +43,7 @@ class ADMUNet(Denoiser):
         using Pytorch's default initialization. If ``pretrained='download'``, the weights will be downloaded from an
         online repository (the default model is a conditional model trained on ImageNet at 64x64 resolution (`imagenet64-cond`) with default architecture).
         Finally, ``pretrained`` can also be set as a path to the user's own pretrained weights.
-        In this case, the model is supposed to be trained on `[0,1]` pixels, if it was trained on `[-1, 1]` pixels, the user should set the attribute `_train_on_minus_one_one` to `True` after loading the weights.
+        In this case, the model is supposed to be trained on `[0,1]` pixels, if it was trained on `[-1, 1]` pixels, the user should set the attribute `_was_trained_on_minus_one_one` to `True` after loading the weights.
         See :ref:`pretrained-weights <pretrained-weights>` for more details.
     :param float pixel_std: The standard deviation of the normalized pixels (to `[0, 1]` for example) of the data distribution. Default to `0.75`.
     :param torch.device device: Instruct our module to be either on cpu or on gpu. Default to ``None``, which suggests working on cpu.
@@ -190,14 +190,14 @@ class ADMUNet(Denoiser):
                     url, map_location=lambda storage, loc: storage, file_name=name
                 )
 
-                self._train_on_minus_one_one = True  # Pretrained on [-1,1]
+                self._was_trained_on_minus_one_one = True  # Pretrained on [-1,1]
                 self.pixel_std = 0.5
             else:
                 ckpt = torch.load(pretrained, map_location=lambda storage, loc: storage)
-                self._train_on_minus_one_one = False  # Pretrained on [0,1]
+                self._was_trained_on_minus_one_one = False  # Pretrained on [0,1]
             self.load_state_dict(ckpt, strict=True)
         else:
-            self._train_on_minus_one_one = False
+            self._was_trained_on_minus_one_one = False
         self.eval()
         if device is not None:
             self.to(device)
@@ -222,7 +222,7 @@ class ADMUNet(Denoiser):
         )
 
         # Rescale [0,1] input to [-1,-1]
-        if getattr(self, "_train_on_minus_one_one", False):
+        if getattr(self, "_was_trained_on_minus_one_one", False):
             x = (x - 0.5) * 2.0
             sigma = sigma * 2.0
 
@@ -240,7 +240,7 @@ class ADMUNet(Denoiser):
         D_x = c_skip * x + c_out * F_x
 
         # Rescale [-1,1] output to [0,-1]
-        if getattr(self, "_train_on_minus_one_one", False):
+        if getattr(self, "_was_trained_on_minus_one_one", False):
             return (D_x + 1.0) / 2.0
         else:
             return D_x

--- a/deepinv/models/ncsnpp.py
+++ b/deepinv/models/ncsnpp.py
@@ -46,7 +46,7 @@ class NCSNpp(Denoiser):
         using Pytorch's default initialization. If ``pretrained='download'``, the weights will be downloaded from an
         online repository (the default model trained on FFHQ at 64x64 resolution (`ffhq64-uncond-ve`) with default architecture).
         Finally, ``pretrained`` can also be set as a path to the user's own pretrained weights.
-        In this case, the model is supposed to be trained on `[0,1]` pixels, if it was trained on `[-1, 1]` pixels, the user should set the attribute `_train_on_minus_one_one` to `True` after loading the weights.
+        In this case, the model is supposed to be trained on `[0,1]` pixels, if it was trained on `[-1, 1]` pixels, the user should set the attribute `_was_trained_on_minus_one_one` to `True` after loading the weights.
         See :ref:`pretrained-weights <pretrained-weights>` for more details.
     :param float pixel_std: The standard deviation of the normalized pixels (to `[0, 1]` for example) of the data distribution. Default to `0.75`.
     :param torch.device device: Instruct our module to be either on cpu or on gpu. Default to ``None``, which suggests working on cpu.
@@ -231,14 +231,14 @@ class NCSNpp(Denoiser):
                 ckpt = torch.hub.load_state_dict_from_url(
                     url, map_location=lambda storage, loc: storage, file_name=name
                 )
-                self._train_on_minus_one_one = True  # Pretrained on [-1,1]s
+                self._was_trained_on_minus_one_one = True  # Pretrained on [-1,1]s
                 self.pixel_std = 0.5
             else:
                 ckpt = torch.load(pretrained, map_location=lambda storage, loc: storage)
-                self._train_on_minus_one_one = False
+                self._was_trained_on_minus_one_one = False
             self.load_state_dict(ckpt, strict=True)
         else:
-            self._train_on_minus_one_one = False
+            self._was_trained_on_minus_one_one = False
         self.eval()
         if device is not None:
             self.to(device)
@@ -324,7 +324,7 @@ class NCSNpp(Denoiser):
         )
 
         # Rescale [0,1] input to [-1,-1]
-        if getattr(self, "_train_on_minus_one_one", False):
+        if getattr(self, "_was_trained_on_minus_one_one", False):
             x = (x - 0.5) * 2.0
             sigma = sigma * 2.0
         c_skip = self.pixel_std**2 / (sigma**2 + self.pixel_std**2)
@@ -343,7 +343,7 @@ class NCSNpp(Denoiser):
 
         D_x = D_x.to(dtype)
         # Rescale [-1,1] output to [0,-1]
-        if getattr(self, "_train_on_minus_one_one", False):
+        if getattr(self, "_was_trained_on_minus_one_one", False):
             return (D_x + 1.0) / 2.0
         else:
             return D_x

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -140,17 +140,17 @@ class DiffusionSDE(BaseSDE):
     :param Callable alpha: a scalar weighting the diffusion term. :math:`\alpha = 0` corresponds to the ODE sampling and :math:`\alpha > 0` corresponds to the SDE sampling.
     :param deepinv.models.Denoiser: a denoiser used to provide an approximation of the score at time :math:`t` :math:`\nabla \log p_t`.
     :param deepinv.sampling.BaseSDESolver solver: the solver for solving the SDE.
-    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising and mapped back afterward. 
-        Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`); 
-        set `False` only if the denoiser natively expects [-1, 1]. 
-        This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range. 
+    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising and mapped back afterward.
+        Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`);
+        set `False` only if the denoiser natively expects [-1, 1].
+        This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range.
         Default: `True`.
     :param torch.dtype dtype: data type of the computation, except for the ``denoiser`` which will use ``torch.float32``.
         We recommend using `torch.float64` for better stability and less numerical error when solving the SDE in discrete time, since
         most computation cost is from evaluating the ``denoiser``, which will be always computed in ``torch.float32``.
     :param torch.device device: device on which the computation is performed.
     :param \*args: additional arguments for the :class:`deepinv.sampling.BaseSDE`.
-    :param \*\*kwargs: additional keyword arguments for the :class:`deepinv.sampling.BaseSDE`. 
+    :param \*\*kwargs: additional keyword arguments for the :class:`deepinv.sampling.BaseSDE`.
     """
 
     def __init__(
@@ -502,12 +502,12 @@ class PosteriorDiffusion(Reconstructor):
         We recommend using `torch.float64` for better stability and less numerical error when solving the SDE in discrete time, since most computation cost is from evaluating the ``denoiser``, which will be always computed in ``torch.float32``.
     :param torch.device device: the device for the computations.
     :param bool verbose: whether to display a progress bar during the sampling process, optional. Default to `False`.
-    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising  and mapped back afterward. 
-        Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`); 
-        set `False` only if the denoiser natively expects [-1, 1]. 
-        This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range. 
+    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising  and mapped back afterward.
+        Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`);
+        set `False` only if the denoiser natively expects [-1, 1].
+        This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range.
         Default: `True`.
-    
+
     """
 
     def __init__(

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -10,7 +10,13 @@ from deepinv.sampling.sde_solver import BaseSDESolver, SDEOutput
 from deepinv.sampling.noisy_datafidelity import NoisyDataFidelity
 from copy import deepcopy
 
+
 class _WrapperDenoiserMinusOneOne(nn.Module):
+    """
+    A wrapper for denoisers trained on [0, 1] images to be used with [-1, 1] images.
+    This is important for diffusion sampling
+    """
+
     def __init__(self, denoiser: nn.Module):
         super().__init__()
         self.denoiser = denoiser
@@ -22,6 +28,7 @@ class _WrapperDenoiserMinusOneOne(nn.Module):
         # Scale back to [-1, 1]
         denoised = denoised_01 * 2 - 1
         return denoised
+
 
 class BaseSDE(nn.Module):
     r"""
@@ -133,10 +140,14 @@ class DiffusionSDE(BaseSDE):
     :param Callable alpha: a scalar weighting the diffusion term. :math:`\alpha = 0` corresponds to the ODE sampling and :math:`\alpha > 0` corresponds to the SDE sampling.
     :param deepinv.models.Denoiser: a denoiser used to provide an approximation of the score at time :math:`t` :math:`\nabla \log p_t`.
     :param deepinv.sampling.BaseSDESolver solver: the solver for solving the SDE.
+    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising and mapped back afterward. Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`); set `False` only if the denoiser
+    natively expects [-1, 1]. This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range. Default: `True`.
     :param torch.dtype dtype: data type of the computation, except for the ``denoiser`` which will use ``torch.float32``.
         We recommend using `torch.float64` for better stability and less numerical error when solving the SDE in discrete time, since
         most computation cost is from evaluating the ``denoiser``, which will be always computed in ``torch.float32``.
     :param torch.device device: device on which the computation is performed.
+    :param \*args: additional arguments for the :class:`deepinv.sampling.BaseSDE`.
+    :param \*\*kwargs: additional keyword arguments for the :class:`deepinv.sampling.BaseSDE`.
     """
 
     def __init__(
@@ -146,7 +157,7 @@ class DiffusionSDE(BaseSDE):
         alpha: float = 1.0,
         denoiser: nn.Module = None,
         solver: BaseSDESolver = None,
-        minus_one_one: bool = False,
+        minus_one_one: bool = True,
         dtype=torch.float64,
         device=torch.device("cpu"),
         *args,
@@ -173,7 +184,11 @@ class DiffusionSDE(BaseSDE):
         self.forward_drift = forward_drift
         self.forward_diffusion = forward_diffusion
         self.solver = solver
-        self.denoiser = deepcopy(denoiser) if not minus_one_one else _WrapperDenoiserMinusOneOne(deepcopy(denoiser))
+        self.denoiser = (
+            deepcopy(denoiser)
+            if not minus_one_one
+            else _WrapperDenoiserMinusOneOne(deepcopy(denoiser))
+        )
         self.minus_one_one = minus_one_one
 
     def score(self, x: Tensor, t: Union[Tensor, float], *args, **kwargs) -> Tensor:
@@ -249,7 +264,8 @@ class VarianceExplodingDiffusion(DiffusionSDE):
         We recommend using `torch.float64` for better stability and less numerical error when solving the SDE in discrete time, since
         most computation cost is from evaluating the ``denoiser``, which will be always computed in ``torch.float32``.
     :param torch.device device: device on which the computation is performed.
-
+    :param \*args: additional arguments for the :class:`deepinv.sampling.DiffusionSDE`.
+    :param \*\*kwargs: additional keyword arguments for the :class:`deepinv.sampling.DiffusionSDE`.
 
     """
 
@@ -362,7 +378,8 @@ class VariancePreservingDiffusion(DiffusionSDE):
         We recommend using `torch.float64` for better stability and less numerical error when solving the SDE in discrete time, since
         most computation cost is from evaluating the ``denoiser``, which will be always computed in ``torch.float32``.
     :param torch.device device: device on which the computation is performed.
-
+    :param \*args: additional arguments for the :class:`deepinv.sampling.DiffusionSDE`.
+    :param \*\*kwargs: additional keyword arguments for the :class:`deepinv.sampling.DiffusionSDE`.
 
     """
 
@@ -481,7 +498,9 @@ class PosteriorDiffusion(Reconstructor):
     :param torch.dtype dtype: the data type of the sampling solver, except for the ``denoiser`` which will use ``torch.float32``.
         We recommend using `torch.float64` for better stability and less numerical error when solving the SDE in discrete time, since most computation cost is from evaluating the ``denoiser``, which will be always computed in ``torch.float32``.
     :param torch.device device: the device for the computations.
-    :param bool verbose: whether to display a progress bar during the sampling process, optional. Default to False.
+    :param bool verbose: whether to display a progress bar during the sampling process, optional. Default to `False`.
+    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising and mapped back afterward. Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`); set `False` only if the denoiser
+    natively expects [-1, 1]. This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range. Default: `True`.
     """
 
     def __init__(
@@ -493,7 +512,7 @@ class PosteriorDiffusion(Reconstructor):
         dtype=torch.float64,
         device=torch.device("cpu"),
         verbose: bool = False,
-        minus_one_one: bool = False,
+        minus_one_one: bool = True,
         *args,
         **kwargs,
     ):
@@ -508,8 +527,8 @@ class PosteriorDiffusion(Reconstructor):
         if denoiser is None:
             denoiser = deepcopy(sde.denoiser)
         if minus_one_one:
-            denoiser = _WrapperDenoiserMinusOneOne(denoiser) 
-        
+            denoiser = _WrapperDenoiserMinusOneOne(denoiser)
+
         self.sde.denoiser = denoiser
         if hasattr(self.data_fidelity, "denoiser"):
             self.data_fidelity.denoiser = denoiser
@@ -585,7 +604,6 @@ class PosteriorDiffusion(Reconstructor):
         solution = self.solver.sample(
             self.posterior,
             x_init,
-            seed,
             y=y,
             physics=physics,
             timesteps=timesteps,

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -140,14 +140,17 @@ class DiffusionSDE(BaseSDE):
     :param Callable alpha: a scalar weighting the diffusion term. :math:`\alpha = 0` corresponds to the ODE sampling and :math:`\alpha > 0` corresponds to the SDE sampling.
     :param deepinv.models.Denoiser: a denoiser used to provide an approximation of the score at time :math:`t` :math:`\nabla \log p_t`.
     :param deepinv.sampling.BaseSDESolver solver: the solver for solving the SDE.
-    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising and mapped back afterward. Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`); set `False` only if the denoiser
-    natively expects [-1, 1]. This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range. Default: `True`.
+    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising and mapped back afterward. 
+        Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`); 
+        set `False` only if the denoiser natively expects [-1, 1]. 
+        This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range. 
+        Default: `True`.
     :param torch.dtype dtype: data type of the computation, except for the ``denoiser`` which will use ``torch.float32``.
         We recommend using `torch.float64` for better stability and less numerical error when solving the SDE in discrete time, since
         most computation cost is from evaluating the ``denoiser``, which will be always computed in ``torch.float32``.
     :param torch.device device: device on which the computation is performed.
     :param \*args: additional arguments for the :class:`deepinv.sampling.BaseSDE`.
-    :param \*\*kwargs: additional keyword arguments for the :class:`deepinv.sampling.BaseSDE`.
+    :param \*\*kwargs: additional keyword arguments for the :class:`deepinv.sampling.BaseSDE`. 
     """
 
     def __init__(
@@ -499,8 +502,12 @@ class PosteriorDiffusion(Reconstructor):
         We recommend using `torch.float64` for better stability and less numerical error when solving the SDE in discrete time, since most computation cost is from evaluating the ``denoiser``, which will be always computed in ``torch.float32``.
     :param torch.device device: the device for the computations.
     :param bool verbose: whether to display a progress bar during the sampling process, optional. Default to `False`.
-    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising and mapped back afterward. Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`); set `False` only if the denoiser
-    natively expects [-1, 1]. This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range. Default: `True`.
+    :param bool minus_one_one: If `True`, wrap the denoiser so that SDE states `x` in [-1, 1] are converted to [0, 1] before denoising  and mapped back afterward. 
+        Set `True` for denoisers trained on [0, 1] (all denoisers in :class:`deepinv.models.Denoiser`); 
+        set `False` only if the denoiser natively expects [-1, 1]. 
+        This affects only the denoiser interface and usually improves quality when matched to the denoiser's training range. 
+        Default: `True`.
+    
     """
 
     def __init__(

--- a/examples/sampling/demo_diffusion_sde.py
+++ b/examples/sampling/demo_diffusion_sde.py
@@ -81,7 +81,7 @@ num_steps = 150
 rng = torch.Generator(device).manual_seed(42)
 timesteps = torch.linspace(1, 0.001, num_steps)
 solver = EulerSolver(timesteps=timesteps, rng=rng)
-
+minus_one_one = False
 
 sigma_min = 0.005
 sigma_max = 5
@@ -108,6 +108,7 @@ model = PosteriorDiffusion(
     dtype=dtype,
     device=device,
     verbose=True,
+    minus_one_one=minus_one_one,
 )
 x, trajectory = model(
     y=None,
@@ -177,7 +178,7 @@ mask[..., 24:40, 24:40] = 0.0
 physics = dinv.physics.Inpainting(img_size=x.shape[1:], mask=mask, device=device)
 y = physics(x)
 
-weight = 1.0  # guidance strength
+weight = 3.0  # guidance strength
 dps_fidelity = DPSDataFidelity(denoiser=denoiser, weight=weight)
 
 model = PosteriorDiffusion(
@@ -188,6 +189,7 @@ model = PosteriorDiffusion(
     dtype=dtype,
     device=device,
     verbose=True,
+    minus_one_one=minus_one_one,
 )
 
 # To perform posterior sampling, we need to provide the measurements, the physics and the solver.
@@ -283,6 +285,7 @@ model = PosteriorDiffusion(
     device=device,
     dtype=dtype,
     verbose=True,
+    minus_one_one=minus_one_one,
 )
 
 x_hat_vp, trajectory = model(
@@ -398,6 +401,7 @@ model = PosteriorDiffusion(
     dtype=dtype,
     device=device,
     verbose=True,
+    minus_one_one=minus_one_one,
 )
 
 # To perform posterior sampling, we need to provide the measurements, the physics and the solver.

--- a/examples/sampling/demo_diffusion_sde.py
+++ b/examples/sampling/demo_diffusion_sde.py
@@ -81,7 +81,6 @@ num_steps = 150
 rng = torch.Generator(device).manual_seed(42)
 timesteps = torch.linspace(1, 0.001, num_steps)
 solver = EulerSolver(timesteps=timesteps, rng=rng)
-minus_one_one = False
 
 sigma_min = 0.005
 sigma_max = 5
@@ -108,7 +107,6 @@ model = PosteriorDiffusion(
     dtype=dtype,
     device=device,
     verbose=True,
-    minus_one_one=minus_one_one,
 )
 x, trajectory = model(
     y=None,
@@ -189,7 +187,6 @@ model = PosteriorDiffusion(
     dtype=dtype,
     device=device,
     verbose=True,
-    minus_one_one=minus_one_one,
 )
 
 # To perform posterior sampling, we need to provide the measurements, the physics and the solver.
@@ -285,7 +282,6 @@ model = PosteriorDiffusion(
     device=device,
     dtype=dtype,
     verbose=True,
-    minus_one_one=minus_one_one,
 )
 
 x_hat_vp, trajectory = model(
@@ -401,7 +397,6 @@ model = PosteriorDiffusion(
     dtype=dtype,
     device=device,
     verbose=True,
-    minus_one_one=minus_one_one,
 )
 
 # To perform posterior sampling, we need to provide the measurements, the physics and the solver.


### PR DESCRIPTION
This PR fixes #736 related to the scaling of input/output of denoiser in a diffusion sampling. 
By default, all deepinv denoisers accept [0,1] input, but in diffusion, using [-1,1] input give better results (due to initial Gaussian noise and added Gaussian noise at each iteration).

Below a the results by running [this example](https://deepinv.github.io/deepinv/auto_examples/sampling/demo_diffusion_sde.html) :

- Before: 

<img width="9000" height="3000" alt="posterior_sample_ve_vp" src="https://github.com/user-attachments/assets/7b003f2c-92c8-496d-b9fb-b124cdda14cb" />
<img width="9000" height="3000" alt="posterior_sample" src="https://github.com/user-attachments/assets/25f5b956-5fff-45cb-80bf-4322e3e3f93f" />
<img width="9000" height="3000" alt="posterior_sample_DRUNet" src="https://github.com/user-attachments/assets/2abde912-e289-4343-85dd-931341405453" />

- After  

<img width="9000" height="3000" alt="posterior_sample_ve_vp" src="https://github.com/user-attachments/assets/96b2ef12-9df1-4ef5-bf59-6d82c21660d0" />
<img width="9000" height="3000" alt="posterior_sample" src="https://github.com/user-attachments/assets/376c81b3-c988-4be7-8354-6793370b6e8d" />
<img width="9000" height="3000" alt="posterior_sample_DRUNet" src="https://github.com/user-attachments/assets/0af1f4c4-ae46-45d4-80c9-cea7b6b5bccc" />


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
