### PR TITLE
add self-sup eval + history fixes

### DIFF
--- a/examples/self-supervised-learning/demo_artifact2artifact.py
+++ b/examples/self-supervised-learning/demo_artifact2artifact.py
@@ -201,6 +201,10 @@ model = loss.adapt_model(model)
 # train from scratch, simply comment out the model loading code and
 # increase the number of epochs.
 #
+# .. tip::
+#
+#       We can use the same self-supervised loss for evaluation, as it does not require clean images,
+#       to monitor the training process (e.g. for early stopping).
 
 optimizer = torch.optim.Adam(model.parameters(), lr=1e-3, weight_decay=1e-8)
 
@@ -222,7 +226,7 @@ trainer = dinv.Trainer(
     losses=loss,
     optimizer=optimizer,
     train_dataloader=train_dataloader,
-    metrics=[dinv.metric.PSNR(), dinv.metric.SSIM()],
+    metrics=loss,
     online_measurements=True,
     device=device,
     save_path=None,
@@ -239,7 +243,7 @@ model = trainer.train()
 #
 
 trainer.plot_images = True
-trainer.test(test_dataloader)
+trainer.test(test_dataloader, metrics=[dinv.metric.PSNR(), dinv.metric.SSIM()])
 
 # %%
 # :References:

--- a/examples/self-supervised-learning/demo_ei_transforms.py
+++ b/examples/self-supervised-learning/demo_ei_transforms.py
@@ -105,6 +105,10 @@ physics = dinv.physics.Inpainting((3, 256, 256), mask=0.6, device=device)
 #
 #       We only train for a single epoch in the demo, but it is recommended to train multiple epochs in practice.
 #
+# .. tip::
+#
+#       We can use the same self-supervised loss for evaluation, as it does not require clean images,
+#       to monitor the training process (e.g. for early stopping).
 
 model = dinv.models.UNet(
     in_channels=3, out_channels=3, scales=2, circular_padding=True, batch_norm=False
@@ -125,6 +129,8 @@ model = dinv.Trainer(
     eval_dataloader=test_dataloader,
     epochs=1,
     losses=losses,
+    metrics=losses,
+    early_stop=True,  # we can use early stopping as we have a validation set
     optimizer=optimizer,
     verbose=True,
     show_progress_bar=False,

--- a/examples/self-supervised-learning/demo_equivariant_imaging.py
+++ b/examples/self-supervised-learning/demo_equivariant_imaging.py
@@ -158,7 +158,10 @@ optimizer.load_state_dict(ckpt["optimizer"])
 # Train the network
 # --------------------------------------------
 #
-
+# .. tip::
+#
+#       We can use the same self-supervised loss for evaluation, as it does not require clean images,
+#       to monitor the training process (e.g. for early stopping).
 
 verbose = True  # print training information
 
@@ -178,6 +181,9 @@ trainer = dinv.Trainer(
     losses=losses,
     optimizer=optimizer,
     train_dataloader=train_dataloader,
+    eval_dataloader=test_dataloader,
+    metrics=losses,
+    early_stop=True,  # early stop using the self-supervised loss on the test set
     plot_images=True,
     device=device,
     save_path=str(CKPT_DIR / operation),
@@ -194,7 +200,7 @@ model = trainer.train()
 #
 #
 
-trainer.test(test_dataloader)
+trainer.test(test_dataloader, metrics=dinv.metric.PSNR())
 
 # %%
 # :References:

--- a/examples/self-supervised-learning/demo_multioperator_imaging.py
+++ b/examples/self-supervised-learning/demo_multioperator_imaging.py
@@ -160,8 +160,10 @@ optimizer.load_state_dict(ckpt["optimizer"])
 # Train the network
 # --------------------------------------------
 #
+# .. tip::
 #
-
+#       We can use the same self-supervised loss for evaluation, as it does not require clean images,
+#       to monitor the training process (e.g. for early stopping).
 
 verbose = True  # print training information
 
@@ -185,6 +187,8 @@ trainer = dinv.Trainer(
     device=device,
     train_dataloader=train_dataloader,
     eval_dataloader=test_dataloader,
+    metrics=losses,
+    early_stop=True,  # early stop using the self-supervised loss on the test set
     save_path=str(CKPT_DIR / operation),
     verbose=verbose,
     plot_images=True,
@@ -200,7 +204,7 @@ model = trainer.train()
 # --------------------------------------------
 #
 
-trainer.test(test_dataloader)
+trainer.test(test_dataloader, metrics=dinv.metric.PSNR())
 
 # %%
 # :References:

--- a/examples/self-supervised-learning/demo_n2n_denoising.py
+++ b/examples/self-supervised-learning/demo_n2n_denoising.py
@@ -144,7 +144,10 @@ optimizer.load_state_dict(ckpt["optimizer"])
 # Train the network
 # --------------------------------------------
 #
+# .. tip::
 #
+#       We can use the same self-supervised loss for evaluation, as it does not require clean images,
+#       to monitor the training process (e.g. for early stopping).
 
 verbose = True  # print training information
 
@@ -166,6 +169,8 @@ trainer = dinv.Trainer(
     device=device,
     train_dataloader=train_dataloader,
     eval_dataloader=test_dataloader,
+    metrics=loss,
+    early_stop=True,  # early stop using the self-supervised loss on the test set
     plot_images=True,
     save_path=str(CKPT_DIR / operation),
     verbose=verbose,
@@ -180,7 +185,7 @@ model = trainer.train()
 #
 #
 
-trainer.test(test_dataloader)
+trainer.test(test_dataloader, metrics=dinv.metric.PSNR())
 
 # %%
 # :References:

--- a/examples/self-supervised-learning/demo_r2r_denoising.py
+++ b/examples/self-supervised-learning/demo_r2r_denoising.py
@@ -149,6 +149,11 @@ if noise_name == "poisson":
 # --------------------------------------------
 #
 #
+# .. tip::
+#
+#       We can use the same self-supervised loss for evaluation, as it does not require clean images,
+#       to monitor the training process (e.g. for early stopping).
+
 
 verbose = True  # print training information
 
@@ -170,11 +175,13 @@ trainer = dinv.Trainer(
     optimizer=optimizer,
     device=device,
     train_dataloader=train_dataloader,
-    eval_dataloader=None,
+    eval_dataloader=test_dataloader,
+    early_stop=True,  # early stop using the self-supervised loss on the test set
+    metrics=loss,
     plot_images=True,
     save_path=str(CKPT_DIR / operation),
     verbose=verbose,
-    show_progress_bar=False,  # disable progress bar for better vis in sphinx gallery.
+    show_progress_bar=True,  # disable progress bar for better vis in sphinx gallery.
 )
 
 # Train the network
@@ -186,8 +193,7 @@ model = trainer.train()
 # --------------------------------------------
 #
 #
-
-trainer.test(test_dataloader)
+trainer.test(test_dataloader, metrics=dinv.metric.PSNR())
 
 # %%
 # :References:

--- a/examples/self-supervised-learning/demo_splitting_loss.py
+++ b/examples/self-supervised-learning/demo_splitting_loss.py
@@ -147,6 +147,10 @@ optimizer.load_state_dict(ckpt["optimizer"])
 # Train and test network
 # ----------------------
 #
+# .. tip::
+#
+#       We can use the same self-supervised loss for evaluation, as it does not require clean images,
+#       to monitor the training process (e.g. for early stopping).
 
 trainer = dinv.Trainer(
     model=model,
@@ -156,6 +160,9 @@ trainer = dinv.Trainer(
     optimizer=optimizer,
     device=device,
     train_dataloader=train_dataloader,
+    eval_dataloader=test_dataloader,
+    metrics=loss,
+    early_stop=True,  # we can use early stopping as we have a validation loss
     plot_images=False,
     save_path=None,
     verbose=True,
@@ -173,7 +180,7 @@ model = trainer.train()
 #
 
 trainer.plot_images = True
-trainer.test(test_dataloader)
+trainer.test(test_dataloader, metrics=dinv.metric.PSNR())
 
 
 # %%
@@ -183,7 +190,7 @@ trainer.test(test_dataloader)
 #
 
 model.eval_n_samples = 1
-trainer.test(test_dataloader)
+trainer.test(test_dataloader, metrics=dinv.metric.PSNR())
 
 
 # %%
@@ -194,7 +201,7 @@ trainer.test(test_dataloader)
 #
 
 model.eval_split_input = False
-trainer.test(test_dataloader)
+trainer.test(test_dataloader, metrics=dinv.metric.PSNR())
 
 # %%
 # :References:

--- a/examples/self-supervised-learning/demo_sure_denoising.py
+++ b/examples/self-supervised-learning/demo_sure_denoising.py
@@ -152,7 +152,10 @@ optimizer.load_state_dict(ckpt["optimizer"])
 # Train the network
 # --------------------------------------------
 #
+# .. tip::
 #
+#       We can use the same self-supervised loss for evaluation, as it does not require clean images,
+#       to monitor the training process (e.g. for early stopping).
 
 verbose = True  # print training information
 
@@ -174,6 +177,8 @@ trainer = dinv.Trainer(
     device=device,
     train_dataloader=train_dataloader,
     eval_dataloader=test_dataloader,
+    metrics=loss,
+    early_stop=True,  # early stop using the self-supervised loss on the test set
     plot_images=True,
     save_path=str(CKPT_DIR / operation),
     verbose=verbose,
@@ -190,4 +195,4 @@ model = trainer.train()
 #
 #
 
-trainer.test(test_dataloader)
+trainer.test(test_dataloader, metrics=dinv.metric.PSNR())


### PR DESCRIPTION
This PR removes model.eval() from the evaluation phase of the trainer, to allow for self-supervised evaluation and early stopping. 

- I also modified the self-supervised examples accordingly. 
- I've added history loss saving, which was missing for some weird reason

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
