### PR TITLE
Allow flexible mask shapes in splitting loss + fix splitting losses for multicoil MRI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 ^^^^^
 - Reduced CI python version tests (:gh:`746` by `Mathieu Terris`_)
 - Fix scaling issue in DiffusionSDE (:gh:`772` by `Minh Hai Nguyen`_)
+- All splitting losses fixed to work with changing image sizes and with multicoil MRI (:gh:`778` by `Andrew Wang`_)
 
 
 v0.3.4

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -35,7 +35,6 @@ class SplittingLoss(Loss):
     This loss was used for MRI in SSDU :footcite:t:`yaman2020self` for MRI, Noise2Inverse :footcite:t:`hendriksen2020noise2inverse` for CT, as well as numerous other papers.
     Note we implement the multi-mask strategy proposed by :footcite:t:`yaman2020self`.
 
-
     By default, the error is computed using the MSE metric, however any appropriate metric can be used.
 
     .. warning::
@@ -52,6 +51,10 @@ class SplittingLoss(Loss):
     .. note::
 
         To disable measurement splitting (and use the full input) at evaluation time, set ``eval_split_input=False``. This is done in SSDU :footcite:t:`yaman2020self`.
+
+    .. note::
+
+        This loss allows training over images of varying shapes.
 
     .. seealso::
 

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -328,8 +328,8 @@ class SplittingLoss(Loss):
             """
             Perform splitting at model output too, only at eval time
             """
-            out = 0
-            normalizer = torch.zeros_like(y)
+            out = 0.0
+            normalizer = 0.0
 
             for _ in range(self.eval_n_samples):
                 # Perform input masking

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -274,7 +274,10 @@ class SplittingLoss(Loss):
                     f"Mask generator not defined. Using new Bernoulli mask generator with shape {y.shape[-2:]}."
                 )
                 self.mask_generator = BernoulliSplittingMaskGenerator(
-                    img_size=(y.shape[1], *y.shape[-2:]), # (C, H, W) with no intermediate dims
+                    img_size=(
+                        y.shape[1],
+                        *y.shape[-2:],
+                    ),  # (C, H, W) with no intermediate dims
                     split_ratio=self.split_ratio,
                     pixelwise=self.pixelwise,
                     device=y.device,

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -270,9 +270,11 @@ class SplittingLoss(Loss):
             """
 
             if self.mask_generator is None:
-                warn("Mask generator not defined. Using new Bernoulli mask generator.")
+                warn(
+                    f"Mask generator not defined. Using new Bernoulli mask generator with shape {y.shape[-2:]}."
+                )
                 self.mask_generator = BernoulliSplittingMaskGenerator(
-                    img_size=y.shape[1:],
+                    img_size=(1,) + y.shape[-2:],
                     split_ratio=self.split_ratio,
                     pixelwise=self.pixelwise,
                     device=y.device,
@@ -301,9 +303,12 @@ class SplittingLoss(Loss):
 
             for _ in range(eval_n_samples):
                 # Perform input masking
+
                 mask = self.mask_generator.step(
                     y.size(0), input_mask=getattr(physics, "mask", None)
                 )["mask"]
+                # print(physics.mask.shape, mask.shape)
+
                 y1, physics1 = self.split(mask, y, physics)
 
                 # Forward pass

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -274,7 +274,7 @@ class SplittingLoss(Loss):
                     f"Mask generator not defined. Using new Bernoulli mask generator with shape {y.shape[-2:]}."
                 )
                 self.mask_generator = BernoulliSplittingMaskGenerator(
-                    img_size=(1,) + y.shape[-2:],
+                    img_size=(y.shape[1], *y.shape[-2:]), # (C, H, W) with no intermediate dims
                     split_ratio=self.split_ratio,
                     pixelwise=self.pixelwise,
                     device=y.device,

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -310,7 +310,6 @@ class SplittingLoss(Loss):
                 mask = self.mask_generator.step(
                     y.size(0), input_mask=getattr(physics, "mask", None)
                 )["mask"]
-                # print(physics.mask.shape, mask.shape)
 
                 y1, physics1 = self.split(mask, y, physics)
 

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -99,7 +99,9 @@ class WeightedSplittingLoss(SplittingLoss):
             """Weighted metric forward pass."""
 
             if y1.shape[-2:] != y2.shape[-2]:
-                raise ValueError("Metric input tensors should be same image size.")
+                raise ValueError(
+                    f"Metric input tensors should be same image size but got {y1.shape[-2:]}, {y2.shape[-2:]}."
+                )
 
             if self.weight.shape[1] != y1.shape[1]:
                 warn(

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -103,9 +103,9 @@ class WeightedSplittingLoss(SplittingLoss):
                     f"Metric input tensors should be same image size but got {y1.shape[-2:]}, {y2.shape[-2:]}."
                 )
 
-            if self.weight.shape[1] != y1.shape[1]:
+            if self.weight.shape[1] != y1.shape[-1]:
                 warn(
-                    f"WeightedSplittingLoss with weight width {self.weight.shape[1]} detected new y width {y1.shape[1]} in forward pass. Recalculating weight..."
+                    f"WeightedSplittingLoss with weight width {self.weight.shape[1]} detected new y width {y1.shape[-1]} in forward pass. Recalculating weight..."
                 )
                 self.weight = WeightedSplittingLoss.compute_weight(
                     mask_generator=self.mask_generator,

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -98,7 +98,7 @@ class WeightedSplittingLoss(SplittingLoss):
         def forward(self, y1, y2):
             """Weighted metric forward pass."""
 
-            if y1.shape[-2:] != y2.shape[-2]:
+            if y1.shape[-2:] != y2.shape[-2:]:
                 raise ValueError(
                     f"Metric input tensors should be same image size but got {y1.shape[-2:]}, {y2.shape[-2:]}."
                 )

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -243,7 +243,7 @@ class RobustSplittingLoss(WeightedSplittingLoss):
     @staticmethod
     def expand_mask(mask, y):
         """Expand mask intermediate dimensions to match those of y, where intermediate
-        dimensions are those (e.g. slice, coils, time) that are not the first two dims (batch, channel),
+        dimensions are those (e.g. depth, coils, time) that are not the first two dims (batch, channel),
         nor the final two dims (H, W).
         """
         return mask.view(

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -49,6 +49,8 @@ class WeightedSplittingLoss(SplittingLoss):
 
         Note also that we assume that all masks are 1D mask in the image width dimension repeated in all other dimensions.
 
+    If the input data varies in shape, the loss will dynamically recalculate the weight. However, this will be slower every time the weight must be recalculated.
+
     :param deepinv.physics.generator.BernoulliSplittingMaskGenerator mask_generator: splitting mask generator for further subsampling.
     :param deepinv.physics.generator.BaseMaskGenerator physics_generator: original mask generator used to generate the measurements.
     :param float eps: small value to avoid division by zero.
@@ -104,8 +106,9 @@ class WeightedSplittingLoss(SplittingLoss):
                 )
 
             if self.weight.shape[-1] != y1.shape[-1]:
+                # TODO these weights should be cached for a speed-up
                 warn(
-                    f"WeightedSplittingLoss with weight width {self.weight.shape[1]} detected new y width {y1.shape[-1]} in forward pass. Recalculating weight..."
+                    f"WeightedSplittingLoss with weight width {self.weight.shape[1]} detected new y width {y1.shape[-1]} in forward pass. Recalculating weight (this may take a second)..."
                 )
                 self.weight = WeightedSplittingLoss.compute_weight(
                     mask_generator=self.mask_generator,

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -103,7 +103,7 @@ class WeightedSplittingLoss(SplittingLoss):
 
             if self.weight.shape[1] != y1.shape[1]:
                 warn(
-                    "WeightedSplittingLoss detected new y shape in forward pass. Recalculating weight..."
+                    f"WeightedSplittingLoss with weight width {self.weight.shape[1]} detected new y width {y1.shape[1]} in forward pass. Recalculating weight..."
                 )
                 self.weight = WeightedSplittingLoss.compute_weight(
                     mask_generator=self.mask_generator,
@@ -128,12 +128,14 @@ class WeightedSplittingLoss(SplittingLoss):
         self.mask_generator = mask_generator
         self.physics_generator = physics_generator
         self.metric = self.WeightedMetric(
-            self.compute_weight(
+            mask_generator=mask_generator,
+            physics_generator=physics_generator,
+            weight=self.compute_weight(
                 mask_generator=mask_generator,
                 physics_generator=physics_generator,
                 eps=eps,
             ),
-            metric,
+            metric=metric,
         )
         self.normalize_loss = False
 

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -900,11 +900,16 @@ class LeastSquaresSolver(torch.autograd.Function):
 
         # Save tensors only
         gamma_orig_shape = gamma.shape
-        # For broadcasting with other tensors
-        if gamma.ndim > 0:
-            gamma = gamma.view(
-                -1, *[1] * (y.ndim - 1)
-            )  # reshape for broadcasting if needed
+        # For broadcasting with other tensors. Note we already have checked gamma shapes
+        # in forward, so the following is just for gamma batched but not shaped.
+        if gamma.ndim == 1:
+            if isinstance(solution, TensorList):
+                ndim = solution[0].ndim
+            else:
+                ndim = solution.ndim
+
+            gamma = gamma.view([gamma.size(0)] + [1] * (ndim - 1))
+
         ctx.save_for_backward(solution, y, z, gamma)
         # Save other non-tensor contexts
         ctx.physics = physics

--- a/deepinv/physics/generator/base.py
+++ b/deepinv/physics/generator/base.py
@@ -144,10 +144,11 @@ class PhysicsGenerator(nn.Module):
 
         return PhysicsGenerator(step=step)
 
-    def average(self, n: int = 2000, batch_size: int = 1) -> dict:
+    def average(self, n: int = 2000, batch_size: int = 1, **kwargs) -> dict:
         """Calculate average of physics generator.
         :param int n: number of samples to average over, defaults to 2000
         :param int n: number of samples to compute in parallel, higher means faster but more costly memory-wise, defaults to 1
+        :param kwargs: kwargs to pass to `step` method.
         :returns: A dictionary with the new parameters, that is ``{param_name: param_value}``.
         """
         assert n > 0, "n must be positive"
@@ -157,7 +158,7 @@ class PhysicsGenerator(nn.Module):
         n_processed = 0
         while n_processed < n:
             n_batch = min(n - n_processed, batch_size)
-            params = self.step(batch_size=n_batch)
+            params = self.step(batch_size=n_batch, **kwargs)
             n_processed += n_batch
             params_partial_sum = {
                 k: v.sum(0, keepdim=True) for (k, v) in params.items()

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -263,7 +263,9 @@ class MultiplicativeSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         self.split_generator = split_generator
 
     def batch_step(self, input_mask: torch.Tensor = None) -> dict:
-        mask = self.split_generator.step(batch_size=1)["mask"].squeeze(0)
+        mask = self.split_generator.step(batch_size=1, img_size=input_mask.shape[-2:])[
+            "mask"
+        ].squeeze(0)
         if isinstance(input_mask, torch.Tensor) and input_mask.numel() > 1:
             if input_mask.shape[-2:] == mask.shape[-2:]:
                 return mask * input_mask.to(self.device)

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -90,7 +90,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         self,
         batch_size=1,
         input_mask: torch.Tensor = None,
-        img_size: Optional[tuple] = None,
+        img_size: tuple | None = None,
         seed: int = None,
         **kwargs,
     ) -> dict:
@@ -181,7 +181,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         return pixelwise
 
     def batch_step(
-        self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None
+        self, input_mask: torch.Tensor = None, img_size: tuple | None = None
     ) -> dict:
         r"""
         Create one batch of splitting mask.
@@ -288,7 +288,7 @@ class MultiplicativeSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         self.split_generator = split_generator
 
     def batch_step(
-        self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None
+        self, input_mask: torch.Tensor = None, img_size: tuple | None = None
     ) -> dict:
         r"""
         Create one batch of splitting mask.
@@ -414,7 +414,7 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     def batch_step(
         self,
         input_mask: torch.Tensor = None,
-        img_size: Optional[tuple] = None,
+        img_size: tuple | None = None,
     ) -> dict:
         r"""
         Create one batch of splitting mask using Gaussian distribution.
@@ -527,7 +527,7 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         )
 
     def batch_step(
-        self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None
+        self, input_mask: torch.Tensor = None, img_size: tuple | None = None
     ) -> dict:
         r"""
         Create one batch of splitting mask.
@@ -588,7 +588,7 @@ class Artifact2ArtifactSplittingMaskGenerator(Phase2PhaseSplittingMaskGenerator)
     def batch_step(
         self,
         input_mask: torch.Tensor = None,
-        img_size: Optional[tuple] = None,
+        img_size: tuple | None = None,
         persist_prev: bool = False,
     ) -> dict:
         r"""

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -46,7 +46,13 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         >>> (mask[1] == 0).sum()/mask[1].numel()  # 0.1 < split_ratio < 0.9
         tensor(0.2905)
 
-    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, M) or (M,)
+        Generate splitting mask with new 2D shape than that given at initialization
+
+        >>> gen.step(img_size=(71, 73))["mask"].shape
+        torch.Size([1, 1, 71, 73])
+
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, M) or (M,).
+        Note this can be overriden on-the-fly by passing in `img_size` or `input_mask` arguments to `step`.
     :param float split_ratio: ratio of values to be kept.
     :param bool pixelwise: Apply the mask in a pixelwise fashion, i.e., zero all channels in a given pixel simultaneously.
     :param bool random_split_ratio: if True, `split_ratio` is randomly sampled from `[min_split_ratio, max_split_ratio]` at each step.
@@ -96,7 +102,7 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
 
         :param int batch_size: batch_size. If None, no batch dimension is created. If input_mask passed and has its own batch dimension > 1, batch_size is ignored.
         :param torch.Tensor, None input_mask: optional mask to be split. If None, all pixels are considered. If not None, only pixels where mask==1 are considered. input_mask shape can optionally include a batch dimension.
-        :param tuple img_size: optionally reset the 2D image size on-the-fly, must be of form (H, W).
+        :param tuple img_size: if not `None`, generate masks of this 2D image shape and override `img_size` attribute, must be of form `(H, W)`.
         :param int seed: the seed for the random number generator.
 
         :return: dictionary with key **'mask'**: tensor of size ``(batch_size, *img_size)`` with values in {0, 1}.
@@ -181,9 +187,9 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         Create one batch of splitting mask.
 
         :param torch.Tensor, None input_mask: optional mask to be split. If ``None``, all pixels are considered. If not ``None``, only pixels where ``mask==1`` are considered. Batch dimension should not be included in shape.
-        :param tuple img_size: optionally reset the 2D image size on-the-fly, must be of form (H, W).
+        :param tuple img_size: if not `None`, generate masks of this 2D image shape and override `img_size` attribute, must be of form `(H, W)`.
+        :return: mask without batch dimension of shape specified either by `img_size`, `input_mask`, or class attribute `img_size`.
         """
-
         pixelwise = self.check_pixelwise(input_mask)
         img_size = (
             self.img_size if img_size is None else self.img_size[:-2] + img_size[-2:]
@@ -241,7 +247,7 @@ class MultiplicativeSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     .. seealso::
 
         :class:`deepinv.loss.mri.WeightedSplittingLoss`
-            K-weighted splitting loss proposed in `Millard and Chiew <https://pmc.ncbi.nlm.nih.gov/articles/PMC7614963/>`_,
+            K-weighted splitting loss proposed in :footcite:t:`millard2023theoretical`,
             where this splitting mask generator is used for self-supervised learning.
 
     |sep|
@@ -256,7 +262,8 @@ class MultiplicativeSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         >>> mask_generator.step(batch_size=2, input_mask=orig_mask)["mask"].shape
         torch.Size([2, 1, 128, 128])
 
-    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W).
+        Note this can be overriden on-the-fly by passing in `img_size` or `input_mask` arguments to `step`.
     :param deepinv.physics.generator.BaseMaskGenerator split_generator: mask generator used for multiplicative splitting
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: torch random number generator.
@@ -283,7 +290,13 @@ class MultiplicativeSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     def batch_step(
         self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None
     ) -> dict:
+        r"""
+        Create one batch of splitting mask.
 
+        :param torch.Tensor, None input_mask: optional mask to be split. If ``None``, all pixels are considered. If not ``None``, only pixels where ``mask==1`` are considered. Batch dimension should not be included in shape.
+        :param tuple img_size: if not `None`, generate masks of this 2D image shape and override `img_size` attribute, must be of form `(H, W)`.
+        :return: mask without batch dimension of shape specified either by `img_size`, `input_mask`, or class attribute `img_size`.
+        """
         if isinstance(input_mask, torch.Tensor) and input_mask.numel() > 1:
 
             mask = self.split_generator.step(
@@ -328,7 +341,10 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         >>> gen.step(batch_size=2, input_mask=physics.mask)["mask"].shape
         torch.Size([2, 1, 3, 3])
 
-    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W)
+    See :class:`deepinv.physics.generator.BernoulliSplittingMaskGenerator` for further examples.
+
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension e.g. of shape (C, H, W) or (C, T, H, W).
+        Note this can be overriden on-the-fly by passing in `img_size` or `input_mask` arguments to `step`.
     :param float split_ratio: ratio of values to be kept (i.e. ones).
     :param bool pixelwise: Apply the mask in a pixelwise fashion, i.e., zero all channels in a given pixel simultaneously.
     :param float std_scale: scale parameter of 2D Gaussian, in pixels.
@@ -405,8 +421,9 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
 
         Adapted from https://github.com/byaman14/SSDU/blob/main/masks/ssdu_masks.py from SSDU :footcite:t:`yaman2020self`.
 
-        :param torch.Tensor, None input_mask: optional mask to be split. If None, all pixels are considered. If not None, only pixels where mask==1 are considered. No batch dim in shape.
-        :param tuple img_size: optionally reset the 2D image size on-the-fly, must be of form (H, W).
+        :param torch.Tensor, None input_mask: optional mask to be split. If ``None``, all pixels are considered. If not ``None``, only pixels where ``mask==1`` are considered. Batch dimension should not be included in shape.
+        :param tuple img_size: if not `None`, generate masks of this 2D image shape and override `img_size` attribute, must be of form `(H, W)`.
+        :return: mask without batch dimension of shape specified either by `img_size`, `input_mask`, or class attribute `img_size`.
         """
         pixelwise = self.check_pixelwise()
         _T = self.img_size[1] if len(self.img_size) > 3 else 1
@@ -488,7 +505,8 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
 
     If input_mask not passed, a blank input mask is used instead.
 
-    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W).
+        Note this can be overriden on-the-fly by passing in `img_size` or `input_mask` arguments to `step`.
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: unused.
     """
@@ -511,6 +529,13 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
     def batch_step(
         self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None
     ) -> dict:
+        r"""
+        Create one batch of splitting mask.
+
+        :param torch.Tensor, None input_mask: optional mask to be split. If ``None``, all pixels are considered. If not ``None``, only pixels where ``mask==1`` are considered. Batch dimension should not be included in shape.
+        :param tuple img_size: if not `None`, generate masks of this 2D image shape and override `img_size` attribute, must be of form `(H, W)`.
+        :return: mask without batch dimension of shape specified either by `img_size`, `input_mask`, or class attribute `img_size`.
+        """
         if len(self.img_size) != 4:
             raise ValueError("Default img_size must be of shape (C, T, H, W)")
 
@@ -536,14 +561,12 @@ class Artifact2ArtifactSplittingMaskGenerator(Phase2PhaseSplittingMaskGenerator)
     To be exclusively used with :class:`deepinv.loss.mri.Artifact2ArtifactLoss`.
     Randomly selects a chunk from dynamic data (i.e. data of shape (B, C, T, H, W)) in the T dimension and puts zeros in the rest of the mask.
 
-    When ``step`` called with ``persist_prev``, the selected chunk will be different from the previous time it was called.
-    This is used so input chunk is compared to a different output chunk.
-
     Artifact2Artifact was introduced by :footcite:t:`liu2020rare`.
 
     If input_mask not passed, a blank input mask is used instead.
 
-    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W)
+    :param tuple[int] img_size: size of the tensor to be masked without batch dimension of shape (C, T, H, W).
+        Note this can be overriden on-the-fly by passing in `img_size` or `input_mask` arguments to `step`.
     :param int, tuple[int] split_size: time-length of chunk. Must divide ``img_size[1]`` exactly. If ``tuple``, one is randomly selected each time.
     :param str, torch.device device: device where the tensor is stored (default: 'cpu').
     :param torch.Generator rng: torch random number generator.
@@ -568,6 +591,15 @@ class Artifact2ArtifactSplittingMaskGenerator(Phase2PhaseSplittingMaskGenerator)
         img_size: Optional[tuple] = None,
         persist_prev: bool = False,
     ) -> dict:
+        r"""
+        Create one batch of splitting mask.
+
+        :param torch.Tensor, None input_mask: optional mask to be split. If ``None``, all pixels are considered. If not ``None``, only pixels where ``mask==1`` are considered. Batch dimension should not be included in shape.
+        :param tuple img_size: if not `None`, generate masks of this 2D image shape and override `img_size` attribute, must be of form `(H, W)`.
+        :param bool persist_prev: if `True`, the selected chunk will be different from the previous time it was called. This is used so input chunk is compared to a different output chunk. Default to `False`.
+        :return: mask without batch dimension of shape specified either by `img_size`, `input_mask`, or class attribute `img_size`.
+        """
+
         def rand_select(arr):
             return arr[
                 torch.randint(
@@ -577,6 +609,14 @@ class Artifact2ArtifactSplittingMaskGenerator(Phase2PhaseSplittingMaskGenerator)
 
         # Do Phase2Phase step to check input dimensions
         _ = super().batch_step(input_mask=input_mask, img_size=None)
+
+        if not isinstance(input_mask, torch.Tensor) or input_mask.numel() <= 1:
+            img_size = (
+                self.img_size
+                if img_size is None
+                else self.img_size[:-2] + img_size[-2:]
+            )
+            input_mask = torch.ones(img_size, device=self.device)
 
         # Choose split_size
         split_size = self.split_size

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -81,7 +81,12 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         self.max_split_ratio = max_split_ratio
 
     def step(
-        self, batch_size=1, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None, seed: int = None, **kwargs
+        self,
+        batch_size=1,
+        input_mask: torch.Tensor = None,
+        img_size: Optional[tuple] = None,
+        seed: int = None,
+        **kwargs,
     ) -> dict:
         r"""
         Generate a random mask.
@@ -102,7 +107,9 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         if input_mask is not None and img_size is not None:
             raise ValueError("Only input_mask or img_size can be passed, but not both.")
 
-        if isinstance(input_mask, torch.Tensor) and len(input_mask.shape) > len(self.img_size):
+        if isinstance(input_mask, torch.Tensor) and len(input_mask.shape) > len(
+            self.img_size
+        ):
             input_mask = input_mask.to(self.device)
             if input_mask.shape[0] > 1:
                 # Batch dim exists in input_mask and it's > 1
@@ -123,7 +130,9 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
                     inp = input_mask[b]
                 elif isinstance(input_mask, torch.Tensor):
                     inp = input_mask
-                outs.append(self.batch_step(input_mask=inp, img_size=img_size, **kwargs))
+                outs.append(
+                    self.batch_step(input_mask=inp, img_size=img_size, **kwargs)
+                )
             mask = torch.stack(outs)
         else:
             mask = self.batch_step(input_mask=input_mask, img_size=img_size, **kwargs)
@@ -165,7 +174,9 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
 
         return pixelwise
 
-    def batch_step(self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None) -> dict:
+    def batch_step(
+        self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None
+    ) -> dict:
         r"""
         Create one batch of splitting mask.
 
@@ -174,7 +185,9 @@ class BernoulliSplittingMaskGenerator(PhysicsGenerator):
         """
 
         pixelwise = self.check_pixelwise(input_mask)
-        img_size = self.img_size if img_size is None else self.img_size[:-2] + img_size[-2:]
+        img_size = (
+            self.img_size if img_size is None else self.img_size[:-2] + img_size[-2:]
+        )
 
         if self.random_split_ratio:
             self.split_ratio = (
@@ -267,13 +280,15 @@ class MultiplicativeSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         )
         self.split_generator = split_generator
 
-    def batch_step(self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None) -> dict:
+    def batch_step(
+        self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None
+    ) -> dict:
 
         if isinstance(input_mask, torch.Tensor) and input_mask.numel() > 1:
 
-            mask = self.split_generator.step(batch_size=1, img_size=input_mask.shape[-2:])[
-                "mask"
-            ].squeeze(0)
+            mask = self.split_generator.step(
+                batch_size=1, img_size=input_mask.shape[-2:]
+            )["mask"].squeeze(0)
 
             if input_mask.shape[-2:] == mask.shape[-2:]:
                 return mask * input_mask.to(self.device)
@@ -282,7 +297,9 @@ class MultiplicativeSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
                     f"Input mask should be same shape as generated mask, but input has shape {input_mask.shape} and generated has shape {mask.shape}"
                 )
         else:
-            mask = self.split_generator.step(batch_size=1, img_size=img_size)["mask"].squeeze(0)
+            mask = self.split_generator.step(batch_size=1, img_size=img_size)[
+                "mask"
+            ].squeeze(0)
             return mask
 
 
@@ -378,7 +395,11 @@ class GaussianSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
         )
         return gaussian
 
-    def batch_step(self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None,) -> dict:
+    def batch_step(
+        self,
+        input_mask: torch.Tensor = None,
+        img_size: Optional[tuple] = None,
+    ) -> dict:
         r"""
         Create one batch of splitting mask using Gaussian distribution.
 
@@ -487,7 +508,9 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
             rng=rng,
         )
 
-    def batch_step(self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None) -> dict:
+    def batch_step(
+        self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None
+    ) -> dict:
         if len(self.img_size) != 4:
             raise ValueError("Default img_size must be of shape (C, T, H, W)")
 
@@ -495,7 +518,11 @@ class Phase2PhaseSplittingMaskGenerator(BernoulliSplittingMaskGenerator):
             raise ValueError("input_mask must be same shape as default img_size")
 
         if not isinstance(input_mask, torch.Tensor) or input_mask.numel() <= 1:
-            img_size = self.img_size if img_size is None else self.img_size[:-2] + img_size[-2:]
+            img_size = (
+                self.img_size
+                if img_size is None
+                else self.img_size[:-2] + img_size[-2:]
+            )
             input_mask = torch.ones(img_size, device=self.device)
 
         mask_out = torch.zeros_like(input_mask)
@@ -536,7 +563,10 @@ class Artifact2ArtifactSplittingMaskGenerator(Phase2PhaseSplittingMaskGenerator)
         self.prev_split_size = None
 
     def batch_step(
-        self, input_mask: torch.Tensor = None, img_size: Optional[tuple] = None, persist_prev: bool = False,
+        self,
+        input_mask: torch.Tensor = None,
+        img_size: Optional[tuple] = None,
+        persist_prev: bool = False,
     ) -> dict:
         def rand_select(arr):
             return arr[

--- a/deepinv/physics/generator/mri.py
+++ b/deepinv/physics/generator/mri.py
@@ -104,7 +104,7 @@ class BaseMaskGenerator(PhysicsGenerator, ABC):
 
         :param int batch_size: batch_size.
         :param int seed: optional: the seed for the random number generator, to reseed on-the-fly.
-        :param tuple img_size: optionally reset the 2D image size on-the-fly, must be of form (H, W).
+        :param tuple img_size: if not `None`, generate masks of this 2D image shape and override `img_size` attribute, must be of form `(H, W)`.
 
         :return: dictionary with key **'mask'**: tensor of size (batch_size, C, H, W) or (batch_size, C, T, H, W) with values in {0, 1}.
         :rtype: dict
@@ -210,7 +210,7 @@ class PolyOrderMaskGenerator(BaseMaskGenerator):
 
     The mask is repeated across channels and randomly varies across batch dimension.
 
-    Algorithm taken from `Millard and Chiew <https://pmc.ncbi.nlm.nih.gov/articles/PMC7614963/>`_.
+    Algorithm taken from :footcite:t:`millard2023theoretical`.
 
     :Examples:
 

--- a/deepinv/tests/test_generators.py
+++ b/deepinv/tests/test_generators.py
@@ -490,6 +490,10 @@ def test_inpainting_generators(
         29,
     )
 
+    # Raise error if input_mask and img_size both passed
+    with pytest.raises(ValueError):
+        gen.step(img_size=(20, 20), input_mask=(2, 20, 20))
+
 
 @pytest.mark.parametrize("num_channels", NUM_CHANNELS)
 @pytest.mark.parametrize("device", DEVICES)

--- a/deepinv/tests/test_generators.py
+++ b/deepinv/tests/test_generators.py
@@ -484,6 +484,12 @@ def test_inpainting_generators(
     )
     correct_pixelwise(mask3)
 
+    # Adapt to new img sizes
+    assert gen.step(batch_size=batch_size, img_size=(73, 29))["mask"].shape[-2:] == (
+        73,
+        29,
+    )
+
 
 @pytest.mark.parametrize("num_channels", NUM_CHANNELS)
 @pytest.mark.parametrize("device", DEVICES)

--- a/deepinv/tests/test_loss.py
+++ b/deepinv/tests/test_loss.py
@@ -492,11 +492,6 @@ def test_measplit(device, loss_name, rng, imsize, physics_name):
             eval_n_samples=eval_n_samples,
         )
     elif loss_name == "splitting_eval_split_input_output":
-        if physics_name == "MultiCoilMRI":
-            pytest.skip(
-                "splitting at input and output invalid when y and x have different shapes."
-            )
-
         eval_n_samples = 1
         loss = dinv.loss.SplittingLoss(
             split_ratio=0.7,

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -991,6 +991,13 @@ def test_restoration_models(
     else:
         pytest.skip(f"Skipping PSNR test for {model_name} with {physics_name}.")
 
+    if physics is not None and whsize == LIST_IMAGE_WHSIZE[0]:
+        # Test backward pass
+        l = dinv.loss.SupLoss()(x=x, x_net=model(y, physics))
+        l.backward()
+    else:
+        pytest.skip(f"Skipping backward test for {physics_name} physics and {imsize}.")
+
 
 def test_pannet():
     hrms_shape = (8, 16, 16)  # C,H,W

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -884,7 +884,12 @@ def test_datafid_stacking(imsize, device):
 
 
 solvers = ["CG", "BiCGStab", "lsqr", "minres"]
-least_squares_physics = ["inpainting", "super_resolution_circular", "deblur_valid"]
+least_squares_physics = [
+    "inpainting",
+    "super_resolution_circular",
+    "deblur_valid",
+    "MultiCoilMRI",
+]
 
 
 @pytest.mark.parametrize("physics_name", least_squares_physics)

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -945,10 +945,10 @@ DTYPES = [torch.float32, torch.complex64]
 
 @pytest.mark.parametrize("solver", solvers)
 @pytest.mark.parametrize("dtype", DTYPES)
-def test_linear_system(device, solver, dtype):
+def test_linear_system(device, solver, dtype, rng):
     # test the solution of linear systems with random matrices
     batch_size = 2
-    mat = torch.randn((32, 32), dtype=dtype, device=device)
+    mat = torch.randn((32, 32), dtype=dtype, device=device, generator=rng)
     if solver == "CG":
         # CG is only for hermite positive definite matrices
         mat = mat.adjoint() @ mat
@@ -959,7 +959,7 @@ def test_linear_system(device, solver, dtype):
     if solver == "BiCGStab" and torch.is_complex(mat):
         # bicgstab currently doesn't work for complex-valued systems
         return
-    b = torch.randn((batch_size, 32), dtype=dtype, device=device)
+    b = torch.randn((batch_size, 32), dtype=dtype, device=device, generator=rng)
 
     A = lambda x: (mat @ x.T).T
     AT = lambda x: (mat.adjoint() @ x.T).T


### PR DESCRIPTION
- Allow flexible mask shapes in splitting loss (e.g. for FastMRI data)
- Fix splitting losses for multicoil MRI (i.e. where there is an extra dim in y but not in mask)
- Fix backward pass for least squares when gamma is batched but y.ndim !=x.ndim

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
