### PR TITLE
Small MCMRI enhancements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Current
 New Features
 ^^^^^^^^^^^^
 - Add statistics for SAR imaging + fix variance of GammaNoise in doc (:gh:`740` by `Louise Friot Giroux`)
+- Multi-coil MRI coil-map estimation acceleration via CuPy (:gh:`789` by `Andrew Wang`_)
 
 Changed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Current
 New Features
 ^^^^^^^^^^^^
 - Add statistics for SAR imaging + fix variance of GammaNoise in doc (:gh:`740` by `Louise Friot Giroux`)
-- Multi-coil MRI coil-map estimation acceleration via CuPy (:gh:`789` by `Andrew Wang`_)
+- Multi-coil MRI coil-map estimation acceleration via CuPy (:gh:`781` by `Andrew Wang`_)
 
 Changed
 ^^^^^^^

--- a/deepinv/physics/mri.py
+++ b/deepinv/physics/mri.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional, Union
 from warnings import warn
 import numpy as np
 import torch

--- a/deepinv/physics/mri.py
+++ b/deepinv/physics/mri.py
@@ -422,6 +422,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
         if use_cupy:  # pragma: no cover
             try:
                 import cupy as cp
+
                 use_cupy = cp.cuda.is_available()
             except ImportError:
                 warnings.warn(
@@ -438,12 +439,14 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
 
             cupy_maps = cp.stack(
                 [
-                    EspiritCalib(yb, calib_size, show_pbar=False, device=cupy_y.device).run()
+                    EspiritCalib(
+                        yb, calib_size, show_pbar=False, device=cupy_y.device
+                    ).run()
                     for yb in cupy_y
                 ]
-            ) 
+            )
             torch_maps = torch.from_dlpack(cupy_maps)
-        
+
         else:
             device = sp.Device(-1)
             maps = np.stack(
@@ -452,7 +455,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
                     for yb in complex_y.numpy(force=True)
                 ]
             )
-            
+
             torch_maps = torch.from_numpy(maps)
 
         return torch_maps

--- a/deepinv/physics/mri.py
+++ b/deepinv/physics/mri.py
@@ -386,7 +386,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
         except ImportError:  # pragma: no cover
             raise ImportError(
                 "sigpy is required to simulate coil maps. Install it using pip install sigpy"
-            )  # pragma: no cover
+            )
 
         coil_maps = birdcage_maps(
             (n_coils,)
@@ -395,32 +395,54 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
         return torch.tensor(coil_maps).type(torch.complex64)
 
     @staticmethod
-    def estimate_coil_maps(y: Tensor, calib_size: int = 24) -> Tensor:
+    def estimate_coil_maps(
+        y: Tensor, calib_size: int = 24, use_cupy: bool = False
+    ) -> Tensor:
         """Estimate coil sensitivity maps using ESPIRiT.
 
         This was proposed in `ESPIRiT — An Eigenvalue Approach to Autocalibrating Parallel MRI: Where SENSE meets GRAPPA <https://onlinelibrary.wiley.com/doi/10.1002/mrm.24751>`_.
 
         Note this uses a suboptimal undifferentiable unbatched implementation provided by `sigpy`.
 
+        Optionally use `cupy` to accelerate on GPU, only if `cupy` is installed and a GPU is available.
+
         :param torch.Tensor y: multi-coil kspace measurements with shape [B,2,N,...,H,W] where N is coil dimension.
         :param int calib_size: optional square auto-calibration size in pixels, used by `sigpy`.
+        :param bool use_cupy: whether to attempt to use cupy for GPU acceleration.
         :return: torch.Tensor of coil maps of complex dtype and shape [B,N,...,H,W]
         """
         try:
             from sigpy.mri.app import EspiritCalib
-        except ImportError:
+            import sigpy as sp  # pragma: no cover
+        except ImportError:  # pragma: no cover
             raise ImportError(
                 "sigpy is required to estimate sens maps. Install it using pip install sigpy"
             )
 
-        return torch.from_numpy(
-            np.stack(
-                [
-                    EspiritCalib(yb, calib_size, show_pbar=False).run()
-                    for yb in MRIMixin.to_torch_complex(y).numpy()
-                ]
-            )
+        device = sp.Device(-1)
+        if use_cupy:  # pragma: no cover
+            try:
+                import cupy
+
+                device = sp.Device(0) if cupy.cuda.is_available() else sp.Device(-1)
+            except ImportError:
+                pass
+
+        maps = np.stack(
+            [
+                EspiritCalib(yb, calib_size, show_pbar=False, device=device).run()
+                for yb in MRIMixin.to_torch_complex(y).numpy()
+            ]
         )
+        if use_cupy:  # pragma: no cover
+            try:
+                import cupy
+
+                maps = cupy.asnumpy(maps)
+            except (ImportError, ModuleNotFoundError):
+                pass
+
+        return torch.from_numpy(maps)
 
 
 class DynamicMRI(MRI, TimeMixin):

--- a/deepinv/physics/mri.py
+++ b/deepinv/physics/mri.py
@@ -1,4 +1,5 @@
 from typing import Optional, Union
+from warnings import warn
 import numpy as np
 import torch
 from torch import Tensor
@@ -425,7 +426,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
 
                 use_cupy = cp.cuda.is_available()
             except ImportError:
-                warnings.warn(
+                warn(
                     "cupy is not installed, using cpu for coil map estimation. Install cupy to speed up computation."
                 )
                 use_cupy = False

--- a/deepinv/utils/mixins.py
+++ b/deepinv/utils/mixins.py
@@ -240,7 +240,9 @@ class MRIMixin:
         return cropped
 
     @staticmethod
-    def rss(x: Tensor, multicoil: bool = True, three_d: bool = False) -> Tensor:
+    def rss(
+        x: Tensor, multicoil: bool = True, mag: bool = True, three_d: bool = False
+    ) -> Tensor:
         r"""Perform root-sum-square reconstruction on multicoil data, defined as
 
         .. math::
@@ -254,6 +256,8 @@ class MRIMixin:
             real and imaginary channels
         :param bool multicoil: if ``True``, assume ``x`` is of shape (B,2,N,...),
             and reduce over coil dimension N too.
+        :param bool mag: if `False`, do not reduce over the complex dimension. Rarely used.
+        :param bool three_d: used only for validating input shape, set to `True` if input is 3D data.
         """
         assert (
             x.shape[1] == 2 and not x.is_complex()
@@ -265,5 +269,12 @@ class MRIMixin:
             len(x.shape) == 4 + mc_dim + th_dim
         ), "x should be of shape (B,2,...) for singlecoil data or (B,2,N,...) for multicoil data."
 
-        ss = x.pow(2).sum(dim=1, keepdim=True)
-        return ss.sum(dim=2).sqrt() if multicoil else ss.sqrt()
+        ss = x.pow(2)
+
+        if mag:
+            ss = ss.sum(dim=1, keepdim=True)
+
+        if multicoil:
+            ss = ss.sum(dim=2)
+
+        return ss.sqrt()


### PR DESCRIPTION
- Coil map estimation in MCMRI now accelerated via cupy if available and desired
- RSS recon allows you to not reduce over channels (idk why this would be useful but it offers more generality)

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
