### PR TITLE
Fix least squares solvers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Changed
 
 Fixed
 ^^^^^
+- Fix device dirac_like and bilinear, bicubic and gaussian filters (:gh:`785` by `Julian Tachella`_)
+- Fix positivity + batching gamma least squares solvers (:gh:`785` by `Julian Tachella`_ and `Minh Hai Nguyen`_)
+- Fix and test RAM scaling issues (:gh:`785` by `Julian Tachella`_)
 - Reduced CI python version tests (:gh:`746` by `Mathieu Terris`_)
 - Fix scaling issue in DiffusionSDE (:gh:`772` by `Minh Hai Nguyen`_)
 

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -247,8 +247,8 @@ class RAM(Reconstructor, Denoiser):
 
         .. note::
 
-            The noise levels `sigma` and `gain` can be kept as `None` if a noise model with :class:`deepinv.physics.GaussianNoise`,
-            :class:`deepinv.physics.PoissonNoise` or :class:`deepinv.physics.PoissonGaussianNoise`
+            The noise levels `sigma` and `gain` can be kept as `None` if a noise model with :class:`GaussianNoise <deepinv.physics.GaussianNoise>`,
+            :class:`PoissonNoise <deepinv.physics.PoissonNoise>` or :class:`PoissonGaussianNoise <deepinv.physics.PoissonGaussianNoise>`
             is specified in the physics. If both are provided, the `sigma` and `gain` values provided to the model will be used.
 
         :param torch.Tensor y: measurements

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from pathlib import Path
-
+from warnings import warn
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -340,6 +340,10 @@ class RAM(Reconstructor, Denoiser):
                 sigma = sigma.abs().max()
         else:
             sigma = sigma / rescale_val
+            if hasattr(physics.noise_model, "sigma"):
+                warn(
+                    "Both sigma provided to the model and a noise model in the physics. The sigma provided to the model will be used."
+                )
 
         if gain is None:
             gain = (
@@ -352,6 +356,10 @@ class RAM(Reconstructor, Denoiser):
                 gain = gain.abs().max()
         else:
             gain = gain / rescale_val
+            if hasattr(physics.noise_model, "gain"):
+                warn(
+                    "Both gain provided to the model and a noise model in the physics. The gain provided to the model will be used."
+                )
 
         if not isinstance(sigma, torch.Tensor) and not isinstance(sigma, TensorList):
             sigma = torch.tensor(sigma, device=device)

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -175,6 +175,8 @@ class RAM(Reconstructor, Denoiser):
         snr = num / (sigma + 1e-4)  # SNR equivariant
         gamma = 1 / (1e-4 + 1 / (snr * f**2))
         gamma = gamma[(...,) + (None,) * (x.dim() - 1)]
+        gamma = gamma * self.fact_realign
+        gamma = gamma.clamp(min=1e-8)  # clamp to avoid negative or zero gamma
         model_input = physics.prox_l2(x, y, gamma=gamma * self.fact_realign)
 
         return model_input

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -247,9 +247,9 @@ class RAM(Reconstructor, Denoiser):
 
         .. note::
 
-            The noise levels `(sigma and gain)` can be kept as None if a :class:`deepinv.physics.GaussianNoise`
+            The noise levels `sigma` and `gain` can be kept as `None` if a :class:`deepinv.physics.GaussianNoise`,
             :class:`deepinv.physics.PoissonNoise` or :class:`deepinv.physics.PoissonGaussianNoise` noise model with
-            is specified in the physics. If both are provided, the `(sigma, gain)` values provided to the model will be used.
+            is specified in the physics. If both are provided, the `sigma` and `gain` values provided to the model will be used.
 
         :param torch.Tensor y: measurements
         :param deepinv.physics.Physics physics: forward operator

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -247,8 +247,8 @@ class RAM(Reconstructor, Denoiser):
 
         .. note::
 
-            The noise levels `sigma` and `gain` can be kept as `None` if a :class:`deepinv.physics.GaussianNoise`,
-            :class:`deepinv.physics.PoissonNoise` or :class:`deepinv.physics.PoissonGaussianNoise` noise model with
+            The noise levels `sigma` and `gain` can be kept as `None` if a noise model with :class:`deepinv.physics.GaussianNoise`,
+            :class:`deepinv.physics.PoissonNoise` or :class:`deepinv.physics.PoissonGaussianNoise`
             is specified in the physics. If both are provided, the `sigma` and `gain` values provided to the model will be used.
 
         :param torch.Tensor y: measurements

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -37,6 +37,18 @@ class RAM(Reconstructor, Denoiser):
     :param str device: Device to which the model should be moved. If None, the model will be created on the default device.
     :param bool, str pretrained: If `True`, the model will be initialized with pretrained weights. If `str`, load from file.
     :param float sigma_threshold: Threshold (minimum value) for the noise level. Default is 1e-3.
+
+    |sep|
+
+      >>> import deepinv as dinv
+      >>> x = dinv.utils.load_example("butterfly.png")
+      >>> physics = dinv.physics.Downsampling(filter="bicubic")
+      >>> y = physics(x)
+      >>> model = dinv.models.RAM(pretrained=True) # or any of the models listed below
+      >>> x_hat = model(y, physics) # Model inference
+      >>> dinv.metric.PSNR()(x_hat, x)
+      tensor([31.9902])
+
     """
 
     def __init__(

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from warnings import warn
 from pathlib import Path
 
 import torch

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -253,8 +253,8 @@ class RAM(Reconstructor, Denoiser):
 
         :param torch.Tensor y: measurements
         :param deepinv.physics.Physics physics: forward operator
-        :param float, torch.Tensor sigma: Gaussian noise level. Ignored if noise_model already specified in physics.
-        :param float, torch.Tensor gain: Poisson noise level. Ignored if noise_model already specified in physics.
+        :param float, torch.Tensor sigma: Gaussian noise level.
+        :param float, torch.Tensor gain: Poisson noise level.
         :return: torch.Tensor: reconstructed signal estimate
         """
         if physics is None and sigma is None and gain is None:

--- a/deepinv/optim/__init__.py
+++ b/deepinv/optim/__init__.py
@@ -40,3 +40,5 @@ from .distance import (
     LogPoissonLikelihoodDistance,
     ZeroDistance,
 )
+
+from . import utils

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -116,12 +116,19 @@ def least_squares(
                 "Continuing anyway..."
             )
     if gamma.ndim > 0:  # if batched gamma
-        if gamma.size(0) != y.size(0):
+        if isinstance(y, TensorList):
+            batch_size = y[0].size(0)
+            ndim = y[0].ndim
+        else:
+            batch_size = y.size(0)
+            ndim = y.ndim
+
+        if gamma.size(0) != batch_size:
             raise ValueError(
                 "If gamma is batched, its batch size must match the one of y."
             )
         else:  # ensure gamma has ndim as y
-            gamma = gamma.view([gamma.size(0)] + [1] * (y.ndim - 1))
+            gamma = gamma.view([gamma.size(0)] + [1] * (ndim - 1))
 
     if solver == "lsqr":  # rectangular solver
         eta = 1 / gamma if not no_gamma else None

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -400,6 +400,7 @@ def _sym_ortho(a, b):
     ``1/eps`` in some important places.
 
     """
+    a, b = torch.broadcast_tensors(a, b)
     if torch.any(b == 0):
         return torch.sign(a), 0, a.abs()
     elif torch.any(a == 0):
@@ -510,6 +511,13 @@ def lsqr(
         eta = 0.0
     if not isinstance(eta, Tensor):
         eta = torch.tensor(eta, device=device)
+    if eta.ndim > 0:  # if batched eta
+        if eta.size(0) != b.size(0):
+            raise ValueError(
+                "If eta is batched, its batch size must match the one of b."
+            )
+        else:  # ensure eta has ndim as b
+            eta = eta.squeeze()
 
     if torch.any(eta < 0):
         raise ValueError(

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -93,22 +93,22 @@ def least_squares(
 
     if gamma is None:
         gamma = torch.tensor(0.0, device=y.device)
-        zero_gamma = True
+        no_gamma = True
     else:
-        zero_gamma = False
+        no_gamma = False
 
     if not isinstance(gamma, Tensor):
         gamma = torch.tensor(gamma, device=y.device)
 
-    if torch.any(gamma < 0):
+    if torch.any(gamma <= 0):
         warnings.warn(
-            "Regularization parameter of least squares problem (gamma) should be non-negative."
+            "Regularization parameter of least squares problem (gamma) should be positive."
             "Otherwise, the problem can become non-convex and the solvers are not designed for that."
             "Continuing anyway..."
         )
 
     if solver == "lsqr":  # rectangular solver
-        eta = 1 / gamma if not zero_gamma else None
+        eta = 1 / gamma if not no_gamma else None
         x, _ = lsqr(
             A,
             AT,
@@ -135,7 +135,7 @@ def least_squares(
             if ATA is None:
                 ATA = lambda x: AT(A(x))
 
-            if not zero_gamma:
+            if not no_gamma:
                 b = AT(y) + 1 / gamma * z
                 H = lambda x: ATA(x) + 1 / gamma * x
                 overcomplete = False
@@ -182,7 +182,7 @@ def least_squares(
                 f"Solver {solver} not recognized. Choose between 'CG', 'lsqr' and 'BiCGStab'."
             )
 
-        if zero_gamma and not overcomplete and not complete:
+        if no_gamma and not overcomplete and not complete:
             x = AT(x)
     return x
 

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -109,15 +109,15 @@ def least_squares(
     else:
         no_gamma = False
 
-    if not isinstance(gamma, Tensor):
-        gamma = torch.tensor(gamma, device=y.device)
+        if not isinstance(gamma, Tensor):
+            gamma = torch.tensor(gamma, device=y.device)
 
-    if torch.any(gamma <= 0):
-        warnings.warn(
-            "Regularization parameter of least squares problem (gamma) should be positive."
-            "Otherwise, the problem can become non-convex and the solvers are not designed for that."
-            "Continuing anyway..."
-        )
+        if torch.any(gamma <= 0):
+            warnings.warn(
+                "Regularization parameter of least squares problem (gamma) should be positive."
+                "Otherwise, the problem can become non-convex and the solvers are not designed for that."
+                "Continuing anyway..."
+            )
 
     if solver == "lsqr":  # rectangular solver
         eta = 1 / gamma if not no_gamma else None

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -1093,15 +1093,16 @@ def least_squares_implicit_backward(
     else:
         trigger = torch.ones(1, device=y.device, dtype=y.dtype)
     extra_kwargs = kwargs if kwargs else None
+    dtype = y.dtype if not torch.is_complex(y) else y.real.dtype
     if gamma is None:
-        gamma = torch.zeros((), device=y.device, dtype=y.dtype)
+        gamma = torch.zeros((), device=y.device, dtype=dtype)
     if isinstance(gamma, Tensor) and gamma.ndim > 0:
         if gamma.size(0) != y.size(0):
             raise ValueError(
                 "If gamma is batched, its batch size must match the one of y."
             )
     if not isinstance(gamma, Tensor):
-        gamma = torch.as_tensor(gamma, device=y.device, dtype=y.dtype)
+        gamma = torch.as_tensor(gamma, device=y.device, dtype=dtype)
     return LeastSquaresSolver.apply(physics, y, z, init, gamma, trigger, extra_kwargs)
 
 

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 from deepinv.utils.tensorlist import TensorList
 from deepinv.utils.compat import zip_strict
 import warnings
-from typing import Callable, Union, TYPE_CHECKING
+from typing import Callable, Union
 
 
 def check_conv(X_prev, X, it, crit_conv="residual", thres_conv=1e-3, verbose=False):

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -60,8 +60,8 @@ def least_squares(
     The solution depends on the regularization parameter :math:`\gamma`:
 
     - If :math:`\gamma = \infty` (default), it solves the unregularized least squares problem :math:`\min_x \|Ax-y\|^2`.
-        - If :math:`A` is overcomplete (more rows than columns), it computes the minimum norm solution :math:`x = A^{\top}(AA^{\top})^{-1}y`.
-        - If :math:`A` is undercomplete (more columns than rows), it computes the least squares solution :math:`x = (A^{\top}A)^{-1}A^{\top}y`.
+        - If :math:`A` is overcomplete (rows>=columns), it computes the minimum norm solution :math:`x = A^{\top}(AA^{\top})^{-1}y`.
+        - If :math:`A` is undercomplete (columns>rows), it computes the least squares solution :math:`x = (A^{\top}A)^{-1}A^{\top}y`.
     - If :math:`0 < \gamma < \infty`, it computes the least squares solution :math:`x = (A^{\top}A + \frac{1}{\gamma}I)^{-1}(A^{\top}y + \frac{1}{\gamma}z)`.
 
     .. warning::

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -57,6 +57,18 @@ def least_squares(
     The solvers are stopped either when :math:`\|Ax-y\| \leq \text{tol} \times \|y\|` or
     when the maximum number of iterations is reached.
 
+    The solution depends on the regularization parameter :math:`\gamma`:
+
+    - If :math:`\gamma = \infty` (default), it solves the unregularized least squares problem :math:`\min_x \|Ax-y\|^2`.
+        - If :math:`A` is overcomplete (more rows than columns), it computes the minimum norm solution :math:`x = A^{\top}(AA^{\top})^{-1}y`.
+        - If :math:`A` is undercomplete (more columns than rows), it computes the least squares solution :math:`x = (A^{\top}A)^{-1}A^{\top}y`.
+    - If :math:`0 < \gamma < \infty`, it computes the least squares solution :math:`x = (A^{\top}A + \frac{1}{\gamma}I)^{-1}(A^{\top}y + \frac{1}{\gamma}z)`.
+
+    .. warning::
+
+        If :math:`\gamma \leq 0`, the problem can become non-convex and the solvers are not designed for that.
+        A warning is raised, but solvers continue anyway (except for LSQR, which cannot be used for negative :math:`\gamma`).
+
     Available solvers are:
 
     - `'CG'`: `Conjugate Gradient <https://en.wikipedia.org/wiki/Conjugate_gradient_method>`_.
@@ -490,6 +502,8 @@ def lsqr(
         else:
             return v * alpha.view(Atb_shape)
 
+    if eta is None:
+        eta = 0.0
     if not isinstance(eta, Tensor):
         eta = torch.tensor(eta, device=device)
 

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -59,7 +59,7 @@ def least_squares(
 
     The solution depends on the regularization parameter :math:`\gamma`:
 
-    - If :math:`\gamma = \infty` (default), it solves the unregularized least squares problem :math:`\min_x \|Ax-y\|^2`.
+    - If `gamma=None` (:math:`\gamma = \infty`), it solves the unregularized least squares problem :math:`\min_x \|Ax-y\|^2`.
         - If :math:`A` is overcomplete (rows>=columns), it computes the minimum norm solution :math:`x = A^{\top}(AA^{\top})^{-1}y`.
         - If :math:`A` is undercomplete (columns>rows), it computes the least squares solution :math:`x = (A^{\top}A)^{-1}A^{\top}y`.
     - If :math:`0 < \gamma < \infty`, it computes the least squares solution :math:`x = (A^{\top}A + \frac{1}{\gamma}I)^{-1}(A^{\top}y + \frac{1}{\gamma}z)`.

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -242,14 +242,16 @@ class Downsampling(LinearPhysics):
             if isinstance(filter, torch.Tensor):
                 filter = filter.to(self.device)
             elif filter == "gaussian":
-                filter = gaussian_blur(sigma=(self.factor, self.factor)).to(self.device)
+                filter = gaussian_blur(
+                    sigma=(self.factor, self.factor), device=self.device
+                )
             elif filter == "bilinear":
-                filter = bilinear_filter(self.factor).to(self.device)
+                filter = bilinear_filter(self.factor, device=self.device)
             elif filter == "bicubic":
-                filter = bicubic_filter(self.factor).to(self.device)
+                filter = bicubic_filter(self.factor, device=self.device)
             elif filter == "sinc":
-                filter = sinc_filter(self.factor, length=4 * self.factor).to(
-                    self.device
+                filter = sinc_filter(
+                    self.factor, length=4 * self.factor, device=self.device
                 )
 
             self.register_buffer("filter", filter)
@@ -636,7 +638,7 @@ class SpaceVaryingBlur(LinearPhysics):
         super().update_parameters(**kwargs)
 
 
-def gaussian_blur(sigma=(1, 1), angle=0):
+def gaussian_blur(sigma=(1, 1), angle=0, device="cpu"):
     r"""
     Gaussian blur filter.
 
@@ -663,6 +665,7 @@ def gaussian_blur(sigma=(1, 1), angle=0):
     :param float, tuple[float] sigma: standard deviation of the gaussian filter. If sigma is a float the filter is isotropic, whereas
         if sigma is a tuple of floats (sigma_x, sigma_y) the filter is anisotropic.
     :param float angle: rotation angle of the filter in degrees (only useful for anisotropic filters)
+    :param str device: cpu or cuda
     """
     if isinstance(sigma, (int, float)):
         sigma = (sigma, sigma)
@@ -671,7 +674,7 @@ def gaussian_blur(sigma=(1, 1), angle=0):
     c = int(s / 0.3 + 1)
     k_size = 2 * c + 1
 
-    delta = torch.arange(k_size)
+    delta = torch.arange(k_size, device=device)
 
     x, y = torch.meshgrid(delta, delta, indexing="ij")
     x = x - c
@@ -760,7 +763,7 @@ def sinc_filter(factor=2, length=11, windowed=True, device="cpu"):
     return filter
 
 
-def bilinear_filter(factor=2):
+def bilinear_filter(factor=2, device="cpu"):
     r"""
     Bilinear filter.
 
@@ -778,17 +781,18 @@ def bilinear_filter(factor=2):
     for :math:`x, y \in {-\text{factor} + 0.5, -\text{factor} + 0.5 + 1/\text{factor}, \ldots, \text{factor} - 0.5}`.
 
     :param int factor: downsampling factor
+    :param str device: cpu or cuda
     """
     if isinstance(factor, torch.Tensor):
         factor = factor.cpu().item()
-    x = torch.arange(start=-factor + 0.5, end=factor, step=1) / factor
+    x = torch.arange(start=-factor + 0.5, end=factor, step=1, device=device) / factor
     w = 1 - x.abs()
     w = torch.outer(w, w)
     w = w / torch.sum(w)
     return w.unsqueeze(0).unsqueeze(0)
 
 
-def bicubic_filter(factor=2):
+def bicubic_filter(factor=2, device="cpu"):
     r"""
     Bicubic filter.
 
@@ -807,10 +811,14 @@ def bicubic_filter(factor=2):
     for :math:`x, y \in {-2\text{factor} + 0.5, -2\text{factor} + 0.5 + 1/\text{factor}, \ldots, 2\text{factor} - 0.5}`.
 
     :param int factor: downsampling factor
+    :param str device: cpu or cuda
     """
     if isinstance(factor, torch.Tensor):
         factor = factor.cpu().item()
-    x = torch.arange(start=-2 * factor + 0.5, end=2 * factor, step=1) / factor
+    x = (
+        torch.arange(start=-2 * factor + 0.5, end=2 * factor, step=1, device=device)
+        / factor
+    )
     a = -0.5
     x = x.abs()
     w = ((a + 2) * x.pow(3) - (a + 3) * x.pow(2) + 1) * (x <= 1)

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -856,6 +856,55 @@ def test_varnet(varnet_type, device):
     assert psnr(x_init, x) < psnr(x_hat, x)
 
 
+@pytest.mark.parametrize("use_physics", [True, False])
+@pytest.mark.parametrize("scale", [-5, 5])
+def test_ram_scale(scale, device, use_physics):
+    model = dinv.models.RAM(device=device)
+    imsize = (1, 64, 64)
+
+    batch_size = 2
+    sigma = torch.ones(batch_size, device=device) * 0.1  # batch
+    scale = 10**scale
+    if use_physics:
+        physics = dinv.physics.Denoising(dinv.physics.GaussianNoise(sigma))
+    else:
+        physics = dinv.physics.Blur(
+            filter=dinv.physics.blur.gaussian_blur(),
+            noise_model=dinv.physics.GaussianNoise(sigma),
+            device=device,
+        )
+
+    # make batch with 2 elements to test batch processing
+    x = (
+        DummyCircles(imsize=imsize, samples=1)[0]
+        .unsqueeze(0)
+        .repeat(batch_size, 1, 1, 1)
+        .to(device)
+    )
+    y = physics(x)
+
+    if use_physics:
+        x_hat1 = model(y, physics)
+        # scale first element only
+        sigma[0] = sigma[0] * scale
+        y[0] = y[0] * scale
+        physics.update(sigma=sigma)
+        x_hat2 = model(y, physics)
+        # rescale back the first element
+        x_hat2[0] = x_hat2[0] / scale
+    else:
+        x_hat1 = model(y, sigma=sigma)
+        # scale first element only
+        sigma[0] = sigma[0] * scale
+        y[0] = y[0] * scale
+        x_hat2 = model(y, sigma=sigma)
+        # rescale back the first element
+        x_hat2[0] = x_hat2[0] / scale
+
+    psnr = dinv.metric.PSNR()(x_hat1, x_hat2)
+    assert torch.all(psnr > 30)  # they should be almost equal
+
+
 LIST_IMAGE_WHSIZE = [(32, 37), (25, 129)]
 
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -857,14 +857,13 @@ def test_varnet(varnet_type, device):
 
 
 @pytest.mark.parametrize("use_physics", [True, False])
-@pytest.mark.parametrize("scale", [-5, 5])
+@pytest.mark.parametrize("scale", [1e-5, 1e5])
 def test_ram_scale(scale, device, use_physics):
     model = dinv.models.RAM(device=device)
     imsize = (1, 64, 64)
 
     batch_size = 2
     sigma = torch.ones(batch_size, device=device) * 0.1  # batch
-    scale = 10**scale
     if use_physics:
         physics = dinv.physics.Denoising(dinv.physics.GaussianNoise(sigma))
     else:

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -906,7 +906,10 @@ def test_restoration_models(
         if physics is not None:
             physics.noise_model = dinv.physics.GaussianNoise(0.01, rng=rng)
 
-    x = DummyCircles(imsize=imsize, samples=1)[0].unsqueeze(0)
+    x = DummyCircles(imsize=imsize, samples=1)[0].unsqueeze(0).to(device)
+
+    # make batch with > 1 element to test batch processing
+    x = x.repeat(2, 1, 1, 1)
 
     if physics is not None:
         y = physics(x)

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -906,10 +906,10 @@ def test_restoration_models(
         if physics is not None:
             physics.noise_model = dinv.physics.GaussianNoise(0.01, rng=rng)
 
-    x = DummyCircles(imsize=imsize, samples=1)[0].unsqueeze(0).to(device)
+    x = DummyCircles(imsize=imsize, samples=2)
 
     # make batch with > 1 element to test batch processing
-    x = x.repeat(2, 1, 1, 1)
+    x = next(iter(DataLoader(x, batch_size=2))).to(device)
 
     if physics is not None:
         y = physics(x)

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1005,7 +1005,7 @@ def test_condition_number(device):
 @pytest.mark.parametrize("solver", solvers)
 def test_least_squares_implicit_backward(device, solver, physics_name):
     # Check that the backward gradient matches the finite difference gradient
-    batch_size = 2  # TODO: test batching
+    batch_size = 2  # test batching
     prev_deterministic = torch.are_deterministic_algorithms_enabled()
     torch.use_deterministic_algorithms(True)
 

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -995,7 +995,7 @@ def test_condition_number(device):
     assert rel_error < 0.1
 
 
-@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize(
     "physics_name",
     [

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -890,7 +890,10 @@ least_squares_physics = ["inpainting", "super_resolution_circular", "deblur_vali
 @pytest.mark.parametrize("physics_name", least_squares_physics)
 @pytest.mark.parametrize("solver", solvers)
 @pytest.mark.parametrize("implicit_backward_solver", [False, True])
-def test_least_square_solvers(device, solver, physics_name, implicit_backward_solver):
+@pytest.mark.parametrize("gamma_scalar", [False, True])
+def test_least_square_solvers(
+    device, solver, physics_name, implicit_backward_solver, gamma_scalar
+):
     batch_size = 4
 
     physics, img_size, _, _ = find_operator(physics_name, device=device)
@@ -908,7 +911,10 @@ def test_least_square_solvers(device, solver, physics_name, implicit_backward_so
     ).all()
 
     z = x.clone()
-    gamma = 1.0
+    if gamma_scalar:
+        gamma = 1.0
+    else:
+        gamma = torch.ones((batch_size, 1, 1, 1), device=device)
 
     x_hat = physics.prox_l2(z, y, gamma=gamma, solver=solver, tol=1e-6, max_iter=100)
 

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1023,10 +1023,7 @@ def test_least_squares_implicit_backward(device, solver, physics_name):
     y.requires_grad_(True)
     z = torch.randn_like(x).requires_grad_(True)
     gamma = (
-        torch.ones(
-            (batch_size, 1, 1, 1), dtype=dtype, device=device, requires_grad=True
-        )
-        * 0.4
+        torch.ones((batch_size,), dtype=dtype, device=device, requires_grad=True) * 0.4
     )
     init = torch.zeros_like(z).requires_grad_(False)
 

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -15,6 +15,7 @@ from deepinv.optim.utils import least_squares_implicit_backward
 from functools import partial
 import copy
 
+
 def custom_init_CP(y, physics):
     x_init = physics.A_adjoint(y)
     u_init = y

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1005,7 +1005,7 @@ def test_condition_number(device):
 @pytest.mark.parametrize("solver", solvers)
 def test_least_squares_implicit_backward(device, solver, physics_name):
     # Check that the backward gradient matches the finite difference gradient
-    batch_size = 1
+    batch_size = 1  # TODO: test batching
     prev_deterministic = torch.are_deterministic_algorithms_enabled()
     torch.use_deterministic_algorithms(True)
 
@@ -1022,7 +1022,12 @@ def test_least_squares_implicit_backward(device, solver, physics_name):
     # Check gradients w.r.t y, z, gamma
     y.requires_grad_(True)
     z = torch.randn_like(x).requires_grad_(True)
-    gamma = torch.tensor(0.4, dtype=dtype, requires_grad=True)
+    gamma = (
+        torch.ones(
+            (batch_size, 1, 1, 1), dtype=dtype, device=device, requires_grad=True
+        )
+        * 0.4
+    )
     init = torch.zeros_like(z).requires_grad_(False)
 
     # This check can be quite slow since it needs to compute finite differences in all directions

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -13,7 +13,7 @@ from deepinv.tests.test_physics import find_operator
 from deepinv.optim.utils import least_squares_implicit_backward
 
 from functools import partial
-
+import copy
 
 def custom_init_CP(y, physics):
     x_init = physics.A_adjoint(y)
@@ -1044,73 +1044,73 @@ def test_least_squares_implicit_backward(device, solver, physics_name):
 
     # Enable gradients w.r.t physics parameters
     # We only do this for physics that have a continuous parameterization w.r.t its parameters
-    # buffers = copy.deepcopy(dict(physics.named_buffers()))
-    # parameters = {k: v for k, v in buffers.items() if k in params}
-    # for k, v in parameters.items():
-    #     if isinstance(v, torch.Tensor) and v.dtype in [
-    #         torch.float16,
-    #         torch.float32,
-    #         torch.float64,
-    #     ]:
-    #         parameters[k] = v.requires_grad_(True)
+    buffers = copy.deepcopy(dict(physics.named_buffers()))
+    parameters = {k: v for k, v in buffers.items() if k in params}
+    for k, v in parameters.items():
+        if isinstance(v, torch.Tensor) and v.dtype in [
+            torch.float16,
+            torch.float32,
+            torch.float64,
+        ]:
+            parameters[k] = v.requires_grad_(True)
 
-    # # Compute gradient with implicit backward, when calling `.backward()`, it will use the custom jvp defined in least_squares_implicit_backward
-    # init = torch.zeros_like(z)
-    # with torch.enable_grad():
-    #     physics.update_parameters(**parameters)
-    #     sol = least_squares_implicit_backward(
-    #         physics, y, z, init, gamma, solver=solver, tol=1e-6, max_iter=50
-    #     )
-    #     # simple loss
-    #     loss = (sol - 1).pow(2).sum()
-    #     loss.backward()
+    # Compute gradient with implicit backward, when calling `.backward()`, it will use the custom jvp defined in least_squares_implicit_backward
+    init = torch.zeros_like(z)
+    with torch.enable_grad():
+        physics.update_parameters(**parameters)
+        sol = least_squares_implicit_backward(
+            physics, y, z, init, gamma, solver=solver, tol=1e-6, max_iter=50
+        )
+        # simple loss
+        loss = (sol - 1).pow(2).sum()
+        loss.backward()
 
-    # # Check that all physics parameters have a gradient and close to finite difference gradient
-    # for k, v in parameters.items():
-    #     if isinstance(v, torch.Tensor) and v.dtype in [
-    #         torch.float16,
-    #         torch.float32,
-    #         torch.float64,
-    #     ]:
-    #         assert v.requires_grad == True
-    #         assert v.grad is not None
-    #         assert torch.all(~torch.isnan(v.grad))
+    # Check that all physics parameters have a gradient and close to finite difference gradient
+    for k, v in parameters.items():
+        if isinstance(v, torch.Tensor) and v.dtype in [
+            torch.float16,
+            torch.float32,
+            torch.float64,
+        ]:
+            assert v.requires_grad == True
+            assert v.grad is not None
+            assert torch.all(~torch.isnan(v.grad))
 
-    #         # Only check a few random entries for large parameters
-    #         num_samples = min(10, v.numel())
-    #         idx_flat = torch.randperm(v.numel())[:num_samples]
-    #         delta = 1e-6
-    #         implicit_grad = v.grad.detach().clone().contiguous()
-    #         expected_grad = torch.ones_like(v).view(-1)
+            # Only check a few random entries for large parameters
+            num_samples = min(10, v.numel())
+            idx_flat = torch.randperm(v.numel())[:num_samples]
+            delta = 1e-6
+            implicit_grad = v.grad.detach().clone().contiguous()
+            expected_grad = torch.ones_like(v).view(-1)
 
-    #         with torch.no_grad():
-    #             for idx in idx_flat:
-    #                 v_p = v.detach().clone().view(-1)
-    #                 v_m = v.detach().clone().view(-1)
-    #                 v_p[idx] += delta
-    #                 v_m[idx] -= delta
-    #                 v_p = v_p.view_as(v)
-    #                 v_m = v_m.view_as(v)
-    #                 physics.update_parameters(**{k: v_p})
-    #                 sol_p = least_squares_implicit_backward(
-    #                     physics, y, z, init, gamma, solver=solver, tol=1e-6, max_iter=50
-    #                 )
-    #                 loss_p = (sol_p - 1).pow(2).sum()
+            with torch.no_grad():
+                for idx in idx_flat:
+                    v_p = v.detach().clone().view(-1)
+                    v_m = v.detach().clone().view(-1)
+                    v_p[idx] += delta
+                    v_m[idx] -= delta
+                    v_p = v_p.view_as(v)
+                    v_m = v_m.view_as(v)
+                    physics.update_parameters(**{k: v_p})
+                    sol_p = least_squares_implicit_backward(
+                        physics, y, z, init, gamma, solver=solver, tol=1e-6, max_iter=50
+                    )
+                    loss_p = (sol_p - 1).pow(2).sum()
 
-    #                 physics.update_parameters(**{k: v_m})
-    #                 sol_m = least_squares_implicit_backward(
-    #                     physics, y, z, init, gamma, solver=solver, tol=1e-6, max_iter=50
-    #                 )
-    #                 loss_m = (sol_m - 1).pow(2).sum()
+                    physics.update_parameters(**{k: v_m})
+                    sol_m = least_squares_implicit_backward(
+                        physics, y, z, init, gamma, solver=solver, tol=1e-6, max_iter=50
+                    )
+                    loss_m = (sol_m - 1).pow(2).sum()
 
-    #                 expected_grad[idx] = (loss_p - loss_m) / (2 * delta)
+                    expected_grad[idx] = (loss_p - loss_m) / (2 * delta)
 
-    #         torch.testing.assert_close(
-    #             implicit_grad.view(-1)[idx_flat],
-    #             expected_grad[idx_flat],
-    #             rtol=5e-2,
-    #             atol=5e-2,
-    #             msg=f"Gradient w.r.t physics parameter {k} does not match finite difference gradient. Between {implicit_grad.view(-1)[idx_flat]} and {expected_grad[idx_flat]}.",
-    #         )
+            torch.testing.assert_close(
+                implicit_grad.view(-1)[idx_flat],
+                expected_grad[idx_flat],
+                rtol=5e-2,
+                atol=5e-2,
+                msg=f"Gradient w.r.t physics parameter {k} does not match finite difference gradient. Between {implicit_grad.view(-1)[idx_flat]} and {expected_grad[idx_flat]}.",
+            )
 
-    # torch.use_deterministic_algorithms(prev_deterministic)
+    torch.use_deterministic_algorithms(prev_deterministic)

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -995,6 +995,7 @@ def test_condition_number(device):
     assert rel_error < 0.1
 
 
+@pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize(
     "physics_name",
     [
@@ -1003,9 +1004,8 @@ def test_condition_number(device):
     ],
 )
 @pytest.mark.parametrize("solver", solvers)
-def test_least_squares_implicit_backward(device, solver, physics_name):
+def test_least_squares_implicit_backward(device, solver, physics_name, batch_size):
     # Check that the backward gradient matches the finite difference gradient
-    batch_size = 2  # test batching
     prev_deterministic = torch.are_deterministic_algorithms_enabled()
     torch.use_deterministic_algorithms(True)
 
@@ -1023,7 +1023,7 @@ def test_least_squares_implicit_backward(device, solver, physics_name):
     y.requires_grad_(True)
     z = torch.randn_like(x).requires_grad_(True)
     gamma = (
-        torch.ones((batch_size,), dtype=dtype, device=device, requires_grad=True) * 0.4
+        torch.rand((batch_size,), dtype=dtype, device=device, requires_grad=True) + 0.1
     )
     init = torch.zeros_like(z).requires_grad_(False)
 

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -175,10 +175,13 @@ def test_tensorlist_methods(tensorlist):
 
 @pytest.mark.parametrize("shape", [(1, 1, 3, 3), (1, 1, 5, 5)])
 @pytest.mark.parametrize("length", [1, 2, 3, 4, 5])
-def test_dirac_like(shape, length):
-    rng = torch.Generator().manual_seed(0)
-    x = [torch.randn(shape, generator=rng) for _ in range(length)]
+def test_dirac_like(shape, length, device):
+    rng = torch.Generator(device=device).manual_seed(0)
+    x = [torch.randn(shape, generator=rng, device=device) for _ in range(length)]
     h = deepinv.utils.dirac_like(x)
+
+    assert h.device == x[0].device
+
     y = deepinv.utils.TensorList(
         [
             deepinv.physics.functional.conv2d(xi, hi, padding="circular")

--- a/deepinv/utils/tensorlist.py
+++ b/deepinv/utils/tensorlist.py
@@ -328,13 +328,14 @@ def zeros_like(x):
         return TensorList([torch.zeros_like(xi) for xi in x])
 
 
-def dirac(shape):
+def dirac(shape, device="cpu"):
     r"""
     Returns a :class:`torch.Tensor` with a Dirac delta at the center.
 
     :param tuple shape: shape of the output tensor.
+    :param str device: device of the output tensor.
     """
-    out = torch.zeros(shape)
+    out = torch.zeros(shape, device=device)
     center = tuple([s // 2 for s in shape[-2:]])
     slices = [slice(None)] * (len(shape) - 2) + list(center)
     out[slices] = 1
@@ -347,9 +348,9 @@ def dirac_like(x):
     with the same type as x, filled with zeros.
     """
     if isinstance(x, torch.Tensor):
-        return dirac(x.shape)
+        return dirac(x.shape, device=x.device)
     else:
-        return TensorList([dirac(xi.shape) for xi in x])
+        return TensorList([dirac(xi.shape, device=xi.device) for xi in x])
 
 
 def ones_like(x):

--- a/docs/source/user_guide/reconstruction/pretrained-models.rst
+++ b/docs/source/user_guide/reconstruction/pretrained-models.rst
@@ -23,7 +23,7 @@ These models can be set-up in one line and perform inference in another line:
   >>> model = dinv.models.RAM(pretrained=True) # or any of the models listed below
   >>> x_hat = model(y, physics) # Model inference
   >>> dinv.metric.PSNR()(x_hat, x)
-  tensor([31.9825])
+  tensor([31.9902])
 
 .. list-table:: Pretrained reconstructors
    :header-rows: 1

--- a/examples/unfolded/demo_unfolded_constant_memory.py
+++ b/examples/unfolded/demo_unfolded_constant_memory.py
@@ -34,7 +34,7 @@ Let :math:`M` denote the inverse :math:`\left( A_\theta^T A_\theta + \frac{1}{\g
     \left( \frac{\partial h}{\partial \gamma} \right)^{\top} v          &=   (h - z)^\top M  v / \gamma^2 \\
     \left( \frac{\partial h}{\partial \theta} \right)^{\top} v          &= \frac{\partial p}{\partial \theta} 
     
-where :math:`p =  (y - A_\theta h)^{\top} A_\theta M v ` and :math:`\frac{\partial p}{\partial \theta}` can be computed using the standard backpropagation mechanism (autograd).
+where :math:`p =  (y - A_\theta h)^{\top} A_\theta M v` and :math:`\frac{\partial p}{\partial \theta}` can be computed using the standard backpropagation mechanism (autograd).
 
 .. note::
 


### PR DESCRIPTION
[least_squares](https://deepinv.github.io/deepinv/api/stubs/deepinv.optim.utils.least_squares.html#deepinv.optim.utils.least_squares) solvers have an optional regularization parameter `gamma` that can be either None, a scalar, or a tensor. The tensor version is used in cases where the regularization is different across elements in a batch. There are multiple checks on gamma, such as [this one](https://github.com/deepinv/deepinv/blob/6d99da8d90f6ab0216b36b460415faa7677044be/deepinv/optim/utils.py#L171), which assume that `gamma` is a scalar and generate an error if it is not. This is particularly problematic since it breaks `RAM` and other solvers when deployed on a batch.

Solves #786  and #770 

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
