### PR TITLE
Fix least_squares gamma batching

### DIFF
--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -122,11 +122,11 @@ def least_squares(
     Aty = AT(y)
 
     if gamma.ndim > 0:  # if batched gamma
-        if isinstance(y, TensorList):
-            batch_size = y[0].size(0)
+        if isinstance(Aty, TensorList):
+            batch_size = Aty[0].size(0)
             ndim = Aty[0].ndim
         else:
-            batch_size = y.size(0)
+            batch_size = Aty.size(0)
             ndim = Aty.ndim
 
         if gamma.size(0) != batch_size:

--- a/deepinv/optim/utils.py
+++ b/deepinv/optim/utils.py
@@ -88,7 +88,9 @@ def least_squares(
     :param torch.Tensor y: input tensor of shape (B, ...)
     :param torch.Tensor z: input tensor of shape (B, ...) or scalar.
     :param torch.Tensor init: (Optional) initial guess for the solver. If None, it is set to a tensor of zeros.
-    :param None, float, torch.Tensor gamma: (Optional) inverse regularization parameter. Can be batched (shape (B, ...)) or a scalar. If None, it is set to :math:`\infty` (no regularization).
+    :param None, float, torch.Tensor gamma: (Optional) inverse regularization parameter. Can be batched (shape (B, ...)) or a scalar.
+        If multi-dimensional tensor, then its shape must match that of :math:`A^{\top} y`.
+        If None, it is set to :math:`\infty` (no regularization).
     :param str solver: solver to be used, options are `'CG'`, `'BiCGStab'`, `'lsqr'` and `'minres'`.
     :param Callable AAT: (Optional) Efficient implementation of :math:`A(A^{\top}(x))`. If not provided, it is computed as :math:`A(A^{\top}(x))`.
     :param Callable ATA: (Optional) Efficient implementation of :math:`A^{\top}(A(x))`. If not provided, it is computed as :math:`A^{\top}(A(x))`.
@@ -119,17 +121,19 @@ def least_squares(
     if gamma.ndim > 0:  # if batched gamma
         if isinstance(y, TensorList):
             batch_size = y[0].size(0)
-            ndim = y[0].ndim
+            ndim = AT(y[0]).ndim
         else:
             batch_size = y.size(0)
-            ndim = y.ndim
+            ndim = AT(y).ndim
 
         if gamma.size(0) != batch_size:
             raise ValueError(
                 "If gamma is batched, its batch size must match the one of y."
             )
-        else:  # ensure gamma has ndim as y
+        elif gamma.ndim == 1:  # expand gamma to ATy
             gamma = gamma.view([gamma.size(0)] + [1] * (ndim - 1))
+        else:  # gamma already has shape
+            pass
 
     if solver == "lsqr":  # rectangular solver
         eta = 1 / gamma if gamma_provided else None

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -53,6 +53,7 @@ LINEAR_OPERATORS = [
     "deblur_valid",
     "super_resolution_circular",
     "MRI",
+    "MultiCoilMRI",
     "pansharpen_circular",
 ]  # this is a reduced list of linear operators for testing restoration models.
 
@@ -916,13 +917,13 @@ def test_restoration_models(
     device, pretrained, model_name, physics_name, channels, rng, whsize
 ):
 
-    if channels == 1 and physics_name in ["demosaicing", "MRI"]:
+    if channels == 1 and physics_name in ["demosaicing", "MRI", "MultiCoilMRI"]:
         pytest.skip(f"Skipping {model_name} with {physics_name} for 1 channel input.")
 
     if channels == 2 and physics_name == "demosaicing":
         pytest.skip(f"Skipping {model_name} with {physics_name} for 2 channel input.")
 
-    if channels == 3 and physics_name == "MRI":
+    if channels == 3 and physics_name in ["MRI", "MultiCoilMRI"]:
         pytest.skip(f"Skipping {model_name} with {physics_name} for 3 channel input.")
 
     if model_name == "varnet" or model_name == "modl" or model_name == "pannet":


### PR DESCRIPTION
Gamma in least_squares proposed in #785 was being reshaped to y rather than ATy. This breaks for when they are different shape e.g. in multicoil MRI. This fix forces least squares to not reshape when gamma is already shaped (e.g. as RAM already shapes it), otherwise reshape to ATy.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
