### PR TITLE
fix trainer load nans for batch_size > 1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Fixed
 - Fix and test RAM scaling issues (:gh:`785` by `Julian Tachella`_)
 - Reduced CI python version tests (:gh:`746` by `Mathieu Terris`_)
 - Fix scaling issue in DiffusionSDE (:gh:`772` by `Minh Hai Nguyen`_)
+- Trainer treats batch of nans as no ground truth (:gh:`793` by `Andrew Wang`_)
 
 
 v0.3.4

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -531,6 +531,7 @@ def dummy_model(device):
 @pytest.mark.parametrize("measurements", [True, False])
 @pytest.mark.parametrize("online_measurements", [True, False])
 @pytest.mark.parametrize("generate_params", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 2])
 def test_dataloader_formats(
     non_blocking_plots,
     imsize,
@@ -540,6 +541,7 @@ def test_dataloader_formats(
     ground_truth,
     measurements,
     online_measurements,
+    batch_size,
     rng,
     tmpdir,
 ):
@@ -597,7 +599,7 @@ def test_dataloader_formats(
 
     model = dummy_model
     dataset = DummyDataset()
-    dataloader = DataLoader(dataset, batch_size=1)
+    dataloader = DataLoader(dataset, batch_size=batch_size)
     physics = dinv.physics.Inpainting(img_size=imsize, mask=1.0, device=device)
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-1)
     losses = dinv.loss.MCLoss() if not ground_truth else dinv.loss.SupLoss()
@@ -614,7 +616,7 @@ def test_dataloader_formats(
         epochs=1,
         physics=physics,
         physics_generator=generator2,
-        metrics=dinv.loss.MCLoss(),
+        metrics=dinv.metric.PSNR(),
         online_measurements=online_measurements,
         train_dataloader=dataloader,
         optimizer=optimizer,


### PR DESCRIPTION
Currently our convention is when a dataset returns `torch.nan, y`, this means that there is no ground truth. when wrapped in a dataloader, the trainer detects this nan and gets None as ground truth. However, when batch size > 1, this fails. This PR fixes it.

I also remove the situation where x is a tuple or a list in get_samples_offline - that should never be the case?


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
