### PR TITLE
fix DPIR device

### DIFF
--- a/deepinv/optim/dpir.py
+++ b/deepinv/optim/dpir.py
@@ -9,7 +9,7 @@ from deepinv.optim import BaseOptim
 import torch
 
 
-def get_DPIR_params(noise_level_img):
+def get_DPIR_params(noise_level_img, device="cpu"):
     r"""
     Default parameters for the DPIR Plug-and-Play algorithm.
 
@@ -24,6 +24,7 @@ def get_DPIR_params(noise_level_img):
         torch.log10(torch.tensor(s2, dtype=torch.float32)),
         steps=max_iter,
         dtype=torch.float32,
+        device=device,
     )
 
     stepsize = (sigma_denoiser / max(0.01, noise_level_img)) ** 2
@@ -66,7 +67,7 @@ class DPIR(BaseOptim):
                 else denoiser
             )
         )
-        sigma_denoiser, stepsize, max_iter = get_DPIR_params(sigma)
+        sigma_denoiser, stepsize, max_iter = get_DPIR_params(sigma, device=device)
         params_algo = {"stepsize": stepsize, "g_param": sigma_denoiser}
         super(DPIR, self).__init__(
             create_iterator("HQS", prior=prior, F_fn=None, g_first=False),


### PR DESCRIPTION
The DPIR algorithm doesn't work when `device='cuda'` is provided, as `sigma_denoiser, stepsize` are always on `cpu`

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
