### PR TITLE
Fix docstring formatting in bsds500.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixed
 - Fix scaling issue in DiffusionSDE (:gh:`772` by `Minh Hai Nguyen`_)
 - All splitting losses fixed to work with changing image sizes and with multicoil MRI (:gh:`778` by `Andrew Wang`_)
 - Trainer treats batch of nans as no ground truth (:gh:`793` by `Andrew Wang`_)
+- Fix docstring formatting in BDSDS500 dataset (:gh:`816` by `Brayan Monroy`_)
 
 
 v0.3.4

--- a/deepinv/datasets/bsds500.py
+++ b/deepinv/datasets/bsds500.py
@@ -17,7 +17,7 @@ class BSDS500(ImageDataset):
         transform=None,
         rotate=False,
     ):
-        r"""Dataset for `BSDS500 <https://github.com/BIDS/BSDS500>`_.
+        """Dataset for `BSDS500 <https://github.com/BIDS/BSDS500>`_.
 
         BSDS500 dataset for image restoration benchmarks. BSDS stands for The Berkeley Segmentation Dataset and Benchmark from :footcite:t:`martin2001database`.
         Originally, BSDS500 was used for image segmentation. However, this dataset only loads the ground truth images.

--- a/deepinv/datasets/bsds500.py
+++ b/deepinv/datasets/bsds500.py
@@ -10,37 +10,37 @@ from natsort import natsorted
 class BSDS500(ImageDataset):
     """Dataset for `BSDS500 <https://github.com/BIDS/BSDS500>`_.
 
-        BSDS500 dataset for image restoration benchmarks. BSDS stands for The Berkeley Segmentation Dataset and Benchmark from :footcite:t:`martin2001database`.
-        Originally, BSDS500 was used for image segmentation. However, this dataset only loads the ground truth images.
-        The dataset consists of RGB color images of size 481 x 321 or 321 x 481 and is divided into three splits:
+    BSDS500 dataset for image restoration benchmarks. BSDS stands for The Berkeley Segmentation Dataset and Benchmark from :footcite:t:`martin2001database`.
+    Originally, BSDS500 was used for image segmentation. However, this dataset only loads the ground truth images.
+    The dataset consists of RGB color images of size 481 x 321 or 321 x 481 and is divided into three splits:
 
-        - "train": contains 200 training images
-        - "val": contains 100 validation images
-        - "test": contains 200 test images
+    - "train": contains 200 training images
+    - "val": contains 100 validation images
+    - "test": contains 200 test images
 
-        Despite the name, the "val" split is often used for testing (e.g., it is a superset of CBSD68), while the "train" and "test" splits are used for training.
+    Despite the name, the "val" split is often used for testing (e.g., it is a superset of CBSD68), while the "train" and "test" splits are used for training.
 
-        This dataset uses the file structure from the github repository `https://github.com/BIDS/BSDS500 <https://github.com/BIDS/BSDS500>`_
-        from the institute which published the dataset.
+    This dataset uses the file structure from the github repository `https://github.com/BIDS/BSDS500 <https://github.com/BIDS/BSDS500>`_
+    from the institute which published the dataset.
 
-        **Raw data file structure:** ::
+    **Raw data file structure:** ::
 
-                self.root --- BSDS500-master --- (all files from the github repo)
+            self.root --- BSDS500-master --- (all files from the github repo)
 
 
-        :param str root: Root directory of dataset. Directory path from where we load and save the dataset.
-        :param bool download: If ``True``, downloads the dataset from the internet and puts it in root directory.
-            If dataset is already downloaded, it is not downloaded again. Default at False.
-        :param bool train: If ``True``, the standard training dataset (containing the splits "train" and "test") will be loaded. If ``False``,
-            the standard test set (containing the "val" split) is loaded (which is a superset of CBSD68). Default at True
-        :param list of str splits: Alternatively to the `train` parameter, the precise splits used can be defined. E.g., pass `["train", "val"]`
-            to load the "train" and "val" splits. None for using the splits defined by the `train` parameter. Default None.
-        :param Callable transform: (optional) A function/transform that takes in a PIL image
-            and returns a transformed version. E.g, ``torchvision.transforms.RandomCrop``.
-        :param bool rotate: If set to ``True`` images are rotated to have all the same orientation. This can be important to use a torch dataloader.
-            Default at False.
-        """
-    
+    :param str root: Root directory of dataset. Directory path from where we load and save the dataset.
+    :param bool download: If ``True``, downloads the dataset from the internet and puts it in root directory.
+        If dataset is already downloaded, it is not downloaded again. Default at False.
+    :param bool train: If ``True``, the standard training dataset (containing the splits "train" and "test") will be loaded. If ``False``,
+        the standard test set (containing the "val" split) is loaded (which is a superset of CBSD68). Default at True
+    :param list of str splits: Alternatively to the `train` parameter, the precise splits used can be defined. E.g., pass `["train", "val"]`
+        to load the "train" and "val" splits. None for using the splits defined by the `train` parameter. Default None.
+    :param Callable transform: (optional) A function/transform that takes in a PIL image
+        and returns a transformed version. E.g, ``torchvision.transforms.RandomCrop``.
+    :param bool rotate: If set to ``True`` images are rotated to have all the same orientation. This can be important to use a torch dataloader.
+        Default at False.
+    """
+
     def __init__(
         self,
         root,

--- a/deepinv/datasets/bsds500.py
+++ b/deepinv/datasets/bsds500.py
@@ -8,16 +8,7 @@ from natsort import natsorted
 
 
 class BSDS500(ImageDataset):
-    def __init__(
-        self,
-        root,
-        download=False,
-        train=True,
-        splits=None,
-        transform=None,
-        rotate=False,
-    ):
-        """Dataset for `BSDS500 <https://github.com/BIDS/BSDS500>`_.
+    """Dataset for `BSDS500 <https://github.com/BIDS/BSDS500>`_.
 
         BSDS500 dataset for image restoration benchmarks. BSDS stands for The Berkeley Segmentation Dataset and Benchmark from :footcite:t:`martin2001database`.
         Originally, BSDS500 was used for image segmentation. However, this dataset only loads the ground truth images.
@@ -49,6 +40,16 @@ class BSDS500(ImageDataset):
         :param bool rotate: If set to ``True`` images are rotated to have all the same orientation. This can be important to use a torch dataloader.
             Default at False.
         """
+    
+    def __init__(
+        self,
+        root,
+        download=False,
+        train=True,
+        splits=None,
+        transform=None,
+        rotate=False,
+    ):
         checksum = "7bfe17302a219367694200a61ce8256c"
         if splits is None:
             if train:


### PR DESCRIPTION
Corrected the docstring formatting for the BSDS500 dataset.


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
