### PR TITLE
rm einops from banned module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,4 +144,4 @@ select = ["UP006", "F401", "B905", "B006", "RUF008", "RUF012", "TID253", "UP004"
 
 [tool.ruff.lint.flake8-tidy-imports]
 # Modules that slow down startup and should be imported lazily
-banned-module-level-imports = ["timm", "torchmetrics", "matplotlib", "datasets", "FrEIA", "bm3d", "einops", "wandb", "pandas", "kornia", "ptwt", "pywt", "astra", "torchkbnufft"]
+banned-module-level-imports = ["timm", "torchmetrics", "matplotlib", "datasets", "FrEIA", "bm3d", "wandb", "pandas", "kornia", "ptwt", "pywt", "astra", "torchkbnufft"]


### PR DESCRIPTION
`einops` is now a dependency of `deepinv` but it's banned from the ruff check so tests are not passing.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
