### PR TITLE
Implement / improve convolution functional ops

### DIFF
--- a/deepinv/physics/functional/convolution.py
+++ b/deepinv/physics/functional/convolution.py
@@ -186,7 +186,9 @@ def conv_transpose2d(
     return out
 
 
-def conv2d_fft(x: Tensor, filter: Tensor, real_fft: bool = True) -> torch.Tensor:
+def conv2d_fft(
+    x: Tensor, filter: Tensor, real_fft: bool = True, padding: str = "circular"
+) -> torch.Tensor:
     r"""
     A helper function performing the 2d convolution of images ``x`` and ``filter`` using FFT.
 
@@ -196,14 +198,16 @@ def conv2d_fft(x: Tensor, filter: Tensor, real_fft: bool = True) -> torch.Tensor
     `numpy <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_.
     Otherwise, each channel of each image is convolved with the corresponding kernel.
 
-    For convolution using FFT consider only ``'circular'`` padding (i.e., circular convolution).
+    .. note::
 
-    .. note:
-
-        The convolution here is a convolution, not a correlation as in conv2d.
+        The convolution here is a convolution, not a correlation as in :func:`torch.nn.functional.conv2d`.
 
     :param torch.Tensor x: Image of size ``(B, C, W, H)``.
     :param torch.Tensor filter: Filter of size ``(b, c, w, h)`` where ``b`` can be either ``1`` or ``B`` and ``c`` can be either ``1`` or ``C``.
+    :param bool real_fft: for real filters and images choose `True` (default) to accelerate computation.
+    :param str padding: can be ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'``, ``'constant'``.
+        If ``padding = 'valid'`` the output is smaller than the image (no padding),
+        otherwise the output has the same size as the image. Default is ``'circular'``.
     :return: torch.Tensor : the output of the convolution of the shape size as :math:`x`
     """
     assert x.dim() == filter.dim() == 4, "Input and filter must be 4D tensors"
@@ -220,24 +224,64 @@ def conv2d_fft(x: Tensor, filter: Tensor, real_fft: bool = True) -> torch.Tensor
     if b != B:
         assert b == 1, "Batch size of the kernel is not matched for broadcasting"
 
-    filter_f = filter_fft_2d(filter, img_size, real_fft)
-    x_f = fft.rfft2(x) if real_fft else fft.fft2(x)
+    ph, pw = h // 2, w // 2
+    ih, iw = (h - 1) % 2, (w - 1) % 2
 
-    return fft.irfft2(x_f * filter_f).real
+    def fft2(t, s=None):
+        return fft.rfft2(t, s=s) if real_fft else fft.fft2(t, s=s)
+
+    def ifft2(t, s):
+        return fft.irfft2(t, s=s).real if real_fft else fft.ifft2(t, s=s).real
+
+    if padding == "circular":
+        img_size = (H, W)
+        fx = fft2(x)
+        ff = fft2(filter, s=img_size)  # no pre-shift
+        y = ifft2(fx * ff, s=img_size)
+        # Align kernel center (equivalent to pre-shifting the filter)
+        return torch.roll(y, shifts=(-ph, -pw), dims=(-2, -1))
+
+    elif padding == "valid":
+        # Full linear conv via zero-padding in FFT, then crop to valid
+        sH, sW = H + h - 1, W + w - 1
+        img_size = (sH, sW)
+        fx = fft2(x, s=img_size)
+        ff = fft2(filter, s=img_size)
+        full = ifft2(fx * ff, s=img_size)
+        return full[:, :, h - 1 : H, w - 1 : W]
+
+    elif padding in ("constant", "reflect", "replicate"):
+        # Pad in spatial domain, do circular FFT-conv on padded grid, center-crop back
+        pad = (pw, pw - iw, ph, ph - ih)  # (W_left, W_right, H_top, H_bottom)
+        x_pad = F.pad(x, pad, mode=padding, value=0)
+        Hp, Wp = x_pad.shape[-2:]
+        img_size = (Hp, Wp)
+        fx = fft2(x_pad)
+        ff = fft2(filter, s=img_size)
+        y_pad = ifft2(fx * ff, s=img_size)
+        y_pad = torch.roll(y_pad, shifts=(-ph, -pw), dims=(-2, -1))
+        return y_pad[:, :, ph : -ph + ih, pw : -pw + iw]
+
+    else:
+        raise ValueError(
+            f"padding = '{padding}' not implemented. Please use one of 'valid', 'circular', 'replicate', 'reflect' or 'constant'."
+        )
 
 
 def conv_transpose2d_fft(
-    y: Tensor, filter: Tensor, real_fft: bool = True
+    y: Tensor, filter: Tensor, real_fft: bool = True, padding: str = "circular"
 ) -> torch.Tensor:
     r"""
-    A helper function performing the 2d transposed convolution 2d of ``x`` and ``filter`` using FFT. The adjoint of this operation is :func:`deepinv.physics.functional.conv2d_fft`.
+    A helper function performing the 2d transposed convolution 2d of ``x`` and ``filter`` using FFT.
+    The adjoint of this operation is :func:`deepinv.physics.functional.conv2d_fft`.
 
     :param torch.Tensor y: Image of size ``(B, C, W, H)``.
     :param torch.Tensor filter: Filter of size ``(b, c, w, h)`` ) where ``b`` can be either ``1`` or ``B`` and ``c`` can be either ``1`` or ``C``.
 
     If ``b = 1`` or ``c = 1``, then this function supports broadcasting as the same as `numpy <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_. Otherwise, each channel of each image is convolved with the corresponding kernel.
 
-    For convolution using FFT consider only ``'circular'`` padding (i.e., circular convolution).
+    :param bool real_fft: for real filters and images choose `True` (default) to accelerate computation.
+    :param str padding: can be ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'``, ``'constant'``. If ``padding = 'valid'`` the output is larger than the image (padding), otherwise the output has the same size as the image. Default is ``'circular'``.
 
     :return: torch.Tensor : the output of the convolution, which has the same shape as :math:`y`
     """
@@ -255,12 +299,95 @@ def conv_transpose2d_fft(
     if b != B:
         assert b == 1
 
-    filter_f = filter_fft_2d(filter, img_size, real_fft)
-    y_f = fft.rfft2(y) if real_fft else fft.fft2(y)
+    ph, pw = h // 2, w // 2
+    ih, iw = (h - 1) % 2, (w - 1) % 2
 
-    return fft.irfft2(y_f * torch.conj(filter_f), s=(H, W)).real
+    def fft2(t, s=None):
+        return fft.rfft2(t, s=s) if real_fft else fft.fft2(t, s=s)
+
+    def ifft2(t, s):
+        return fft.irfft2(t, s=s).real if real_fft else fft.ifft2(t, s=s).real
+
+    if padding == "circular":
+        img_size = (H, W)
+        # Adjoint of conv2d_fft circular: roll input by +center before multiplication
+        y_roll = torch.roll(y, shifts=(ph, pw), dims=(-2, -1))
+        fy = fft2(y_roll, s=img_size)
+        ff = fft2(filter, s=img_size)
+        return ifft2(fy * torch.conj(ff), s=img_size)
+
+    elif padding == "valid":
+        # Adjoint of: full linear conv then center-crop [h-1:H, w-1:W]
+        sH, sW = H + h - 1, W + w - 1
+        img_size = (sH, sW)
+        y_full = torch.zeros((B, C, sH, sW), device=y.device, dtype=y.dtype)
+        y_full[:, :, h - 1 : h - 1 + H, w - 1 : w - 1 + W] = y
+        fy = fft2(y_full, s=img_size)
+        ff = fft2(filter, s=img_size)
+        return ifft2(fy * torch.conj(ff), s=img_size)
+
+    elif padding in ("constant", "reflect", "replicate"):
+        if ph == 0 or pw == 0:
+            raise ValueError(
+                "Both dimensions of the filter must be strictly greater than 2 for this padding mode."
+            )
+        # Forward was: pad (P) -> conv (C) -> roll (R) -> crop (S)
+        # Adjoint should be: (S*) -> roll (R*) -> conv (C*) -> pad (P*))
+        Hp = H + ph + (ph - ih)
+        Wp = W + pw + (pw - iw)
+        img_size = (Hp, Wp)
+
+        # S*: embed y into center of padded grid
+        y_big = torch.zeros((B, C, Hp, Wp), device=y.device, dtype=y.dtype)
+        y_big[:, :, ph : -ph + ih, pw : -pw + iw] = y
+        # R*: roll by +center
+        y_big = torch.roll(y_big, shifts=(ph, pw), dims=(-2, -1))
+
+        # C*: circular transpose conv on padded grid
+        fy = fft2(y_big, s=img_size)
+        ff = fft2(filter, s=img_size)
+        z_big = ifft2(fy * torch.conj(ff), s=img_size)
+
+        # P*: adjoint of padding -> fold to original HxW
+        if padding == "constant":
+            out = z_big[:, :, ph : -ph + ih, pw : -pw + iw]
+        elif padding == "reflect":
+            out = z_big[:, :, ph : -ph + ih, pw : -pw + iw].clone()
+            for sy in (-1, 0, 1):
+                for sx in (-1, 0, 1):
+                    if sy == 0 and sx == 0:
+                        continue
+                    ty, ysrc = _tgt_src_for_axis_reflect(sy, ph, ih)
+                    tx, xsrc = _tgt_src_for_axis_reflect(sx, pw, iw)
+                    flip_dims = tuple(dim for s, dim in zip((sy, sx), (2, 3)) if s != 0)
+                    chunk = z_big[:, :, ysrc, xsrc]
+                    if flip_dims:
+                        chunk = chunk.flip(dims=flip_dims)
+                    out[:, :, ty, tx].add_(chunk)
+        else:  # replicate
+            out = z_big[:, :, ph : -ph + ih, pw : -pw + iw].clone()
+            for sy in (-1, 0, 1):
+                for sx in (-1, 0, 1):
+                    if sy == 0 and sx == 0:
+                        continue
+                    ty, ysrc, yred = _tgt_src_for_axis_replicate(sy, ph, ih)
+                    tx, xsrc, xred = _tgt_src_for_axis_replicate(sx, pw, iw)
+                    reduce_dims = tuple(
+                        dim for red, dim in zip((yred, xred), (2, 3)) if red
+                    )
+                    chunk = z_big[:, :, ysrc, xsrc]
+                    if reduce_dims:
+                        chunk = chunk.sum(dim=reduce_dims)
+                    out[:, :, ty, tx].add_(chunk)
+        return out
+
+    else:
+        raise ValueError(
+            f"padding = '{padding}' not implemented. Please use one of 'valid', 'circular', 'replicate', 'reflect' or 'constant'."
+        )
 
 
+# This function is no longer used but kept for reference
 def filter_fft_2d(filter, img_size, real_fft=True):
     ph = int((filter.shape[-2] - 1) / 2)
     pw = int((filter.shape[-1] - 1) / 2)
@@ -452,7 +579,287 @@ def conv_transpose3d(
     return out
 
 
+def conv3d_fft(
+    x: Tensor, filter: Tensor, real_fft: bool = True, padding: str = "circular"
+) -> torch.Tensor:
+    r"""
+    A helper function performing the 3d convolution of ``x`` and `filter` using FFT.
+
+    The adjoint of this operation is :func:`deepinv.physics.functional.conv_transpose3d_fft`.
+
+    If ``b = 1`` or ``c = 1``, this function applies the same filter for each channel and each image.
+    Otherwise, each channel of each image is convolved with the corresponding kernel.
+
+    :param torch.Tensor y: Image of size ``(B, C, D, H, W)``.
+    :param torch.Tensor filter: Filter of size ``(b, c, d, h, w)`` where ``b`` can be either ``1`` or ``B`` and ``c`` can be either ``1`` or ``C``.
+    :param bool real_fft: for real filters and images choose True (default) to accelerate computation
+    :param str padding: can be ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'``, ``'constant'``.
+        If ``padding = 'valid'`` the output is smaller than the image (no padding), otherwise the output has the same size as the image. Default is ``'circular'``.
+
+    .. note::
+
+        The filter center is located at ``(d//2, h//2, w//2)``.
+
+    .. tip::
+
+        This function and :func:`deepinv.physics.functional.conv3d` are equivalent. However, this function is more efficient for large filters.
+
+    :return: torch.Tensor : the output of the convolution, which has the same shape as :math:``x`` if ``padding = 'circular'``, ``(B, C, D-d+1, W-w+1, H-h+1)`` otherwise.
+    """
+
+    assert x.dim() == filter.dim() == 5, "Input and filter must be 5D tensors"
+
+    B, C, D, H, W = x.size()
+    img_size = x.shape[-3:]
+    b, c, d, h, w = filter.size()
+
+    if c != C:
+        assert c == 1
+        filter = filter.expand(-1, C, -1, -1, -1)
+
+    if b != B:
+        assert b == 1
+        filter = filter.expand(B, -1, -1, -1, -1)
+
+    # if real_fft:
+    #     f_f = fft.rfftn(filter, s=img_size, dim=(-3, -2, -1))
+    #     x_f = fft.rfftn(x, dim=(-3, -2, -1))
+    #     res = fft.irfftn(x_f * f_f, s=img_size, dim=(-3, -2, -1))
+    # else:
+    #     f_f = fft.fftn(filter, s=img_size, dim=(-3, -2, -1))
+    #     x_f = fft.fftn(x, dim=(-3, -2, -1))
+    #     res = fft.ifftn(x_f * f_f, s=img_size, dim=(-3, -2, -1))
+
+    # if padding == "valid":
+    #     return res[:, :, d - 1 :, h - 1 :, w - 1 :]
+    # elif padding == "circular":
+    #     shifts = (-(d // 2), -(h // 2), -(w // 2))
+    #     return torch.roll(res, shifts=shifts, dims=(-3, -2, -1))
+    # else:
+    #     raise ValueError("padding = '" + padding + "' not implemented")
+
+    pd, ph, pw = d // 2, h // 2, w // 2
+    id, ih, iw = (d - 1) % 2, (h - 1) % 2, (w - 1) % 2
+
+    def fftn3(t, s=None):
+        return (
+            fft.rfftn(t, s=s, dim=(-3, -2, -1))
+            if real_fft
+            else fft.fftn(t, s=s, dim=(-3, -2, -1))
+        )
+
+    def ifftn3(t, s=None):
+        return (
+            fft.irfftn(t, s=s, dim=(-3, -2, -1))
+            if real_fft
+            else fft.ifftn(t, s=s, dim=(-3, -2, -1))
+        )
+
+    if padding == "circular":
+        img_size = (D, H, W)
+        fx = fftn3(x, s=img_size)
+        ff = fftn3(filter, s=img_size)
+        y = ifftn3(fx * ff, s=img_size)
+        # Align kernel center
+        return torch.roll(y, shifts=(-pd, -ph, -pw), dims=(-3, -2, -1))
+
+    elif padding == "valid":
+        # Full linear conv then crop to valid
+        sD, sH, sW = D + d - 1, H + h - 1, W + w - 1
+        img_size = (sD, sH, sW)
+        fx = fftn3(x, s=img_size)
+        ff = fftn3(filter, s=img_size)
+        full = ifftn3(fx * ff, s=img_size)
+        return full[:, :, d - 1 : D, h - 1 : H, w - 1 : W]
+
+    elif padding in ("constant", "reflect", "replicate"):
+        # Pad in spatial domain, circular FFT-conv on padded grid, center-crop back
+        pad = (pw, pw - iw, ph, ph - ih, pd, pd - id)  # (Wl, Wr, Ht, Hb, Df, Db)
+        x_pad = F.pad(x, pad, mode=padding, value=0)
+        Dp, Hp, Wp = x_pad.shape[-3:]
+        img_size = (Dp, Hp, Wp)
+        fx = fftn3(x_pad, s=img_size)
+        ff = fftn3(filter, s=img_size)
+        y_pad = ifftn3(fx * ff, s=img_size)
+        y_pad = torch.roll(y_pad, shifts=(-pd, -ph, -pw), dims=(-3, -2, -1))
+        return y_pad[:, :, pd : -pd + id, ph : -ph + ih, pw : -pw + iw]
+
+    else:
+        raise ValueError(
+            f"padding = '{padding}' not implemented. Please use one of 'valid', 'circular', 'replicate', 'reflect' or 'constant'."
+        )
+
+
+def conv_transpose3d_fft(
+    y: Tensor, filter: Tensor, real_fft: bool = True, padding: str = "circular"
+) -> torch.Tensor:
+    r"""
+    A helper function performing the 3d transposed convolution of ``y`` and ``filter`` using FFT.
+
+    The adjoint of this operation is :func:`deepinv.physics.functional.conv3d_fft`.
+
+    If ``b = 1`` or ``c = 1``, then this function applies the same filter for each channel.
+    Otherwise, each channel of each image is convolved with the corresponding kernel.
+
+
+    :param torch.Tensor y: Image of size ``(B, C, D, H, W)``.
+    :param torch.Tensor filter: Filter of size ``(b, c, d, h, w)`` where ``b`` can be either ``1`` or ``B`` and ``c`` can be either ``1`` or ``C``.
+    :param bool real_fft: for real filters and images choose True (default) to accelerate computation
+    :param str padding: can be ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'``, ``'constant'``.
+        If ``padding = 'valid'`` the output is larger than the image (padding), otherwise the output has the same size as the image. Default is ``'circular'``.
+
+    .. tip::
+
+        This function and :func:`deepinv.physics.functional.conv_transposed3d` are equivalent. However, this function is more efficient for large filters.
+
+    :return: torch.Tensor : the output of the transposed convolution, which has the same shape as :math:``y`` if ``padding = 'circular'``, ``(B, C, D+d-1, W+w-1, H+h-1)`` otherwise.
+    """
+
+    assert y.dim() == filter.dim() == 5, "Input and filter must be 5D tensors"
+
+    # Get dimensions of the input and the filter
+    B, C, D, H, W = y.size()
+    b, c, d, h, w = filter.size()
+    if padding == "valid":
+        img_size = (D + d - 1, H + h - 1, W + w - 1)
+    elif padding == "circular":
+        img_size = (D, H, W)
+        shifts = (d // 2, h // 2, w // 2)
+        y = torch.roll(y, shifts=shifts, dims=(-3, -2, -1))
+    else:
+        raise ValueError("padding = '" + padding + "' not implemented")
+
+    if c != C:
+        assert c == 1
+        filter = filter.expand(-1, C, -1, -1, -1)
+
+    if b != B:
+        assert b == 1
+        filter = filter.expand(B, -1, -1, -1, -1)
+
+    # if real_fft:
+    #     f_f = fft.rfftn(filter, s=img_size, dim=(-3, -2, -1))
+    #     y_f = fft.rfftn(y, s=img_size, dim=(-3, -2, -1))
+    #     res = fft.irfftn(y_f * torch.conj(f_f), s=img_size, dim=(-3, -2, -1))
+    # else:
+    #     f_f = fft.fftn(filter, s=img_size, dim=(-3, -2, -1))
+    #     y_f = fft.fftn(y, s=img_size, dim=(-3, -2, -1))
+    #     res = fft.ifftn(y_f * torch.conj(f_f), s=img_size, dim=(-3, -2, -1))
+
+    # if padding == "valid":
+    #     return torch.roll(res, shifts=(d - 1, h - 1, w - 1), dims=(-3, -2, -1))
+    # else:
+    #     return res
+
+    pd, ph, pw = d // 2, h // 2, w // 2
+    id, ih, iw = (d - 1) % 2, (h - 1) % 2, (w - 1) % 2
+
+    def fftn3(t, s=None):
+        return (
+            fft.rfftn(t, s=s, dim=(-3, -2, -1))
+            if real_fft
+            else fft.fftn(t, s=s, dim=(-3, -2, -1))
+        )
+
+    def ifftn3(t, s):
+        return (
+            fft.irfftn(t, s=s, dim=(-3, -2, -1))
+            if real_fft
+            else fft.ifftn(t, s=s, dim=(-3, -2, -1))
+        )
+
+    if padding == "circular":
+        img_size = (D, H, W)
+        # Adjoint of circular: roll input by +center, multiply by conj FFT of filter
+        y_roll = torch.roll(y, shifts=(pd, ph, pw), dims=(-3, -2, -1))
+        fy = fftn3(y_roll, s=img_size)
+        ff = fftn3(filter, s=img_size)
+        return ifftn3(fy * torch.conj(ff), s=img_size)
+
+    elif padding == "valid":
+        # Adjoint of linear conv + valid crop: embed y into center of full grid
+        sD, sH, sW = D + d - 1, H + h - 1, W + w - 1
+        img_size = (sD, sH, sW)
+        y_full = torch.zeros((B, C, sD, sH, sW), device=y.device, dtype=y.dtype)
+        y_full[:, :, d - 1 : d - 1 + D, h - 1 : h - 1 + H, w - 1 : w - 1 + W] = y
+        fy = fftn3(y_full, s=img_size)
+        ff = fftn3(filter, s=img_size)
+        return ifftn3(fy * torch.conj(ff), s=img_size)
+
+    elif padding in ("constant", "reflect", "replicate"):
+        if pd == 0 or ph == 0 or pw == 0:
+            raise ValueError(
+                "All three dimensions of the filter must be strictly greater than 2 for this padding mode."
+            )
+
+        # Forward: pad (P) -> conv (C) -> roll (R) -> crop (S)
+        # Adjoint:  S* -> R* -> C* -> P*
+        Dp = D + pd + (pd - id)
+        Hp = H + ph + (ph - ih)
+        Wp = W + pw + (pw - iw)
+        img_size = (Dp, Hp, Wp)
+
+        # S*: embed y into center of padded grid
+        y_big = torch.zeros((B, C, Dp, Hp, Wp), device=y.device, dtype=y.dtype)
+        y_big[:, :, pd : -pd + id, ph : -ph + ih, pw : -pw + iw] = y
+        # R*: roll by +center
+        y_big = torch.roll(y_big, shifts=(pd, ph, pw), dims=(-3, -2, -1))
+
+        # C*: circular transpose conv on padded grid
+        fy = fftn3(y_big, s=img_size)
+        ff = fftn3(filter, s=img_size)
+        z_big = ifftn3(fy * torch.conj(ff), s=img_size)
+
+        # P*: adjoint of padding -> fold to original D x H x W
+        if padding == "constant":
+            out = z_big[:, :, pd : -pd + id, ph : -ph + ih, pw : -pw + iw]
+        elif padding == "reflect":
+            out = z_big[:, :, pd : -pd + id, ph : -ph + ih, pw : -pw + iw].clone()
+            for sz in (-1, 0, 1):
+                for sy in (-1, 0, 1):
+                    for sx in (-1, 0, 1):
+                        if sz == 0 and sy == 0 and sx == 0:
+                            continue
+                        tz, zsrc = _tgt_src_for_axis_reflect(sz, pd, id)
+                        ty, ysrc = _tgt_src_for_axis_reflect(sy, ph, ih)
+                        tx, xsrc = _tgt_src_for_axis_reflect(sx, pw, iw)
+                        flip_dims = tuple(
+                            dim for s, dim in zip((sz, sy, sx), (2, 3, 4)) if s != 0
+                        )
+                        chunk = z_big[:, :, zsrc, ysrc, xsrc]
+                        if flip_dims:
+                            chunk = chunk.flip(dims=flip_dims)
+                        out[:, :, tz, ty, tx].add_(chunk)
+        else:  # replicate
+            out = z_big[:, :, pd : -pd + id, ph : -ph + ih, pw : -pw + iw].clone()
+            for sz in (-1, 0, 1):
+                for sy in (-1, 0, 1):
+                    for sx in (-1, 0, 1):
+                        if sz == 0 and sy == 0 and sx == 0:
+                            continue
+                        tz, zsrc, zred = _tgt_src_for_axis_replicate(sz, pd, id)
+                        ty, ysrc, yred = _tgt_src_for_axis_replicate(sy, ph, ih)
+                        tx, xsrc, xred = _tgt_src_for_axis_replicate(sx, pw, iw)
+                        reduce_dims = tuple(
+                            dim
+                            for red, dim in zip((zred, yred, xred), (2, 3, 4))
+                            if red
+                        )
+                        chunk = z_big[:, :, zsrc, ysrc, xsrc]
+                        if reduce_dims:
+                            chunk = chunk.sum(dim=reduce_dims)
+                        out[:, :, tz, ty, tx].add_(chunk)
+        return out
+
+    else:
+        raise ValueError(
+            f"padding = '{padding}' not implemented. Please use one of 'valid', 'circular', 'replicate', 'reflect' or 'constant'."
+        )
+
+
+# Some helper functions for computing the slice indices for padding modes in convolution operations
 # Map the shift {-1,0,+1} to (target slice on out, source slice on x) per axis
+# --------------------------------------------------------------------------------------------------
 def _tgt_src_for_axis_circular(s, p, i):
     # target slice on out,  source slice on x
     if s == 0:
@@ -481,117 +888,3 @@ def _tgt_src_for_axis_replicate(s, p, i):
         return 0, slice(0, p), True
     else:
         return -1, slice(-p + i, None), True
-
-
-def conv3d_fft(
-    x: Tensor, filter: Tensor, real_fft: bool = True, padding: str = "valid"
-) -> torch.Tensor:
-    r"""
-    A helper function performing the 3d convolution of ``x`` and `filter` using FFT.
-
-    The adjoint of this operation is :func:`deepinv.physics.functional.conv_transpose3d_fft`.
-
-    If ``b = 1`` or ``c = 1``, this function applies the same filter for each channel and each image.
-    Otherwise, each channel of each image is convolved with the corresponding kernel.
-
-    Padding conditions include ``'circular'`` and ``'valid'``.
-
-    :param torch.Tensor y: Image of size ``(B, C, D, H, W)``.
-    :param torch.Tensor filter: Filter of size ``(b, c, d, h, w)`` where ``b`` can be either ``1`` or ``B`` and ``c`` can be either ``1`` or ``C``.
-    :param bool real_fft: for real filters and images choose True (default) to accelerate computation
-    :param str padding: can be ``'valid'`` (default) or ``'circular'``
-
-    .. note::
-        The filter center is located at ``(d//2, h//2, w//2)``.
-
-    :return: torch.Tensor : the output of the convolution, which has the same shape as :math:``x`` if ``padding = 'circular'``, ``(B, C, D-d+1, W-w+1, H-h+1)`` if ``padding = 'valid'``
-    """
-
-    assert x.dim() == filter.dim() == 5, "Input and filter must be 5D tensors"
-
-    B, C, D, H, W = x.size()
-    img_size = x.shape[-3:]
-    b, c, d, h, w = filter.size()
-
-    if c != C:
-        assert c == 1
-        filter = filter.expand(-1, C, -1, -1, -1)
-
-    if b != B:
-        assert b == 1
-        filter = filter.expand(B, -1, -1, -1, -1)
-
-    if real_fft:
-        f_f = fft.rfftn(filter, s=img_size, dim=(-3, -2, -1))
-        x_f = fft.rfftn(x, dim=(-3, -2, -1))
-        res = fft.irfftn(x_f * f_f, s=img_size, dim=(-3, -2, -1))
-    else:
-        f_f = fft.fftn(filter, s=img_size, dim=(-3, -2, -1))
-        x_f = fft.fftn(x, dim=(-3, -2, -1))
-        res = fft.ifftn(x_f * f_f, s=img_size, dim=(-3, -2, -1))
-
-    if padding == "valid":
-        return res[:, :, d - 1 :, h - 1 :, w - 1 :]
-    elif padding == "circular":
-        shifts = (-(d // 2), -(h // 2), -(w // 2))
-        return torch.roll(res, shifts=shifts, dims=(-3, -2, -1))
-    else:
-        raise ValueError("padding = '" + padding + "' not implemented")
-
-
-def conv_transpose3d_fft(
-    y: Tensor, filter: Tensor, real_fft: bool = True, padding: str = "valid"
-) -> torch.Tensor:
-    r"""
-    A helper function performing the 3d transposed convolution of ``y`` and ``filter`` using FFT.
-
-    The adjoint of this operation is :func:`deepinv.physics.functional.conv3d_fft`.
-
-    If ``b = 1`` or ``c = 1``, then this function applies the same filter for each channel.
-    Otherwise, each channel of each image is convolved with the corresponding kernel.
-
-    Padding conditions include ``'circular'`` and ``'valid'``.
-
-    :param torch.Tensor y: Image of size ``(B, C, D, H, W)``.
-    :param torch.Tensor filter: Filter of size ``(b, c, d, h, w)`` where ``b`` can be either ``1`` or ``B`` and ``c`` can be either ``1`` or ``C``.
-    :param bool real_fft: for real filters and images choose True (default) to accelerate computation
-    :param str padding: can be ``'valid'`` (default) or ``'circular'``
-
-    :return: torch.Tensor : the output of the convolution, which has the same shape as :math:`y`
-    """
-
-    assert y.dim() == filter.dim() == 5, "Input and filter must be 5D tensors"
-
-    # Get dimensions of the input and the filter
-    B, C, D, H, W = y.size()
-    b, c, d, h, w = filter.size()
-    if padding == "valid":
-        img_size = (D + d - 1, H + h - 1, W + w - 1)
-    elif padding == "circular":
-        img_size = (D, H, W)
-        shifts = (d // 2, h // 2, w // 2)
-        y = torch.roll(y, shifts=shifts, dims=(-3, -2, -1))
-    else:
-        raise ValueError("padding = '" + padding + "' not implemented")
-
-    if c != C:
-        assert c == 1
-        filter = filter.expand(-1, C, -1, -1, -1)
-
-    if b != B:
-        assert b == 1
-        filter = filter.expand(B, -1, -1, -1, -1)
-
-    if real_fft:
-        f_f = fft.rfftn(filter, s=img_size, dim=(-3, -2, -1))
-        y_f = fft.rfftn(y, s=img_size, dim=(-3, -2, -1))
-        res = fft.irfftn(y_f * torch.conj(f_f), s=img_size, dim=(-3, -2, -1))
-    else:
-        f_f = fft.fftn(filter, s=img_size, dim=(-3, -2, -1))
-        y_f = fft.fftn(y, s=img_size, dim=(-3, -2, -1))
-        res = fft.ifftn(y_f * torch.conj(f_f), s=img_size, dim=(-3, -2, -1))
-
-    if padding == "valid":
-        return torch.roll(res, shifts=(d - 1, h - 1, w - 1), dims=(-3, -2, -1))
-    else:
-        return res

--- a/deepinv/physics/functional/convolution.py
+++ b/deepinv/physics/functional/convolution.py
@@ -4,6 +4,7 @@ from torch import Tensor
 import torch.fft as fft
 import warnings
 
+
 def conv2d(
     x: Tensor, filter: Tensor, padding: str = "valid", correlation=False
 ) -> torch.Tensor:
@@ -54,11 +55,14 @@ def conv2d(
         ih = (h - 1) % 2
         pw = w // 2
         iw = (w - 1) % 2
-        
+
         if ph == 0 and pw == 0:
-            warnings.warn(f"Use are using padding = '{padding}' with a 1x1 kernel. This is equivalent to no padding. "
-                          f"Consider using padding = 'valid' instead.", UserWarning)
-            
+            warnings.warn(
+                f"Use are using padding = '{padding}' with a 1x1 kernel. This is equivalent to no padding. "
+                f"Consider using padding = 'valid' instead.",
+                UserWarning,
+            )
+
         pad = (pw, pw - iw, ph, ph - ih)  # because functional.pad is w,h instead of h,w
 
         x = F.pad(x, pad, mode=padding, value=0)
@@ -110,8 +114,11 @@ def conv_transpose2d(
     iw = (w - 1) % 2
 
     if padding != "valid" and (ph == 0 and pw == 0):
-        warnings.warn(f"Use are using padding = '{padding}' with a 1x1 kernel. This is equivalent to no padding. "
-                      f"Consider using padding = 'valid' instead.", UserWarning)
+        warnings.warn(
+            f"Use are using padding = '{padding}' with a 1x1 kernel. This is equivalent to no padding. "
+            f"Consider using padding = 'valid' instead.",
+            UserWarning,
+        )
 
     if c != C:
         assert (
@@ -229,8 +236,12 @@ def conv2d_fft(
     ih, iw = (h - 1) % 2, (w - 1) % 2
 
     if padding != "valid" and (ph == 0 and pw == 0):
-        warnings.warn(f"Use are using padding = '{padding}' with a 1x1 kernel. This is equivalent to no padding. "
-                      f"Consider using padding = 'valid' instead.", UserWarning)
+        warnings.warn(
+            f"Use are using padding = '{padding}' with a 1x1 kernel. This is equivalent to no padding. "
+            f"Consider using padding = 'valid' instead.",
+            UserWarning,
+        )
+
     def fft2(t, s=None):
         return fft.rfft2(t, s=s) if real_fft else fft.fft2(t, s=s)
 
@@ -275,6 +286,7 @@ def conv2d_fft(
             f"padding = '{padding}' not implemented. Please use one of 'valid', 'circular', 'replicate', 'reflect' or 'constant'."
         )
 
+
 def conv_transpose2d_fft(
     y: Tensor, filter: Tensor, real_fft: bool = True, padding: str = "circular"
 ) -> torch.Tensor:
@@ -306,12 +318,15 @@ def conv_transpose2d_fft(
         assert b == 1
 
     ph, pw = h // 2, w // 2
-    
+
     if padding != "valid":
         if ph == 0 and pw == 0:
-            warnings.warn(f"Use are using padding = '{padding}' with a 1x1 kernel. This is equivalent to no padding. "
-                          f"Consider using padding = 'valid' instead.", UserWarning)
-            
+            warnings.warn(
+                f"Use are using padding = '{padding}' with a 1x1 kernel. This is equivalent to no padding. "
+                f"Consider using padding = 'valid' instead.",
+                UserWarning,
+            )
+
     ih, iw = (h - 1) % 2, (w - 1) % 2
 
     def fft2(t, s=None):
@@ -355,13 +370,15 @@ def conv_transpose2d_fft(
         # P*: adjoint of padding -> fold to original H x W
         if padding == "constant":
             out = z_big[
-                :, :,
+                :,
+                :,
                 _center_crop_slice_1d(ph, ih),
                 _center_crop_slice_1d(pw, iw),
             ]
         elif padding == "reflect":
             out = z_big[
-                :, :,
+                :,
+                :,
                 _center_crop_slice_1d(ph, ih),
                 _center_crop_slice_1d(pw, iw),
             ].clone()
@@ -378,7 +395,8 @@ def conv_transpose2d_fft(
                     out[:, :, ty, tx].add_(chunk)
         else:  # replicate
             out = z_big[
-                :, :,
+                :,
+                :,
                 _center_crop_slice_1d(ph, ih),
                 _center_crop_slice_1d(pw, iw),
             ].clone()
@@ -401,6 +419,7 @@ def conv_transpose2d_fft(
         raise ValueError(
             f"padding = '{padding}' not implemented. Please use one of 'valid', 'circular', 'replicate', 'reflect' or 'constant'."
         )
+
 
 def filter_fft_2d(filter, img_size, real_fft=True):
     ph = int((filter.shape[-2] - 1) / 2)
@@ -469,15 +488,18 @@ def conv3d(
         x = F.pad(x, pad, mode=padding, value=0)
 
         if pd == 0 and pw == 0 and ph == 0:
-            warnings.warn(f"Use are using padding = '{padding}' with a 1x1x1 kernel. This is equivalent to no padding. "
-                          f"Consider using padding = 'valid' instead.", UserWarning)
-            
+            warnings.warn(
+                f"Use are using padding = '{padding}' with a 1x1x1 kernel. This is equivalent to no padding. "
+                f"Consider using padding = 'valid' instead.",
+                UserWarning,
+            )
+
         B, C, D, H, W = x.shape
 
     # Grouped convolution trick for per-batch filters and channels
     x = x.reshape(1, B * C, D, H, W)
     filter = filter.reshape(B * C, -1, d, h, w)
-    out = F.conv3d(x, filter, padding='valid', groups=B * C)
+    out = F.conv3d(x, filter, padding="valid", groups=B * C)
     # Make it in the good shape
     out = out.reshape(B, C, *out.shape[-3:])
     return out
@@ -501,17 +523,20 @@ def conv_transpose3d(
     assert y.dim() == filter.dim() == 5, "Input and filter must be 5D tensors"
     B, C, D, H, W = y.shape
     b, c, d, h, w = filter.shape
-    
+
     pd = d // 2
     ph = h // 2
     pw = w // 2
     id = (d - 1) % 2
     ih = (h - 1) % 2
     iw = (w - 1) % 2
-    
+
     if padding != "valid" and (pd == 0 and pw == 0 and ph == 0):
-        warnings.warn(f"Use are using padding = '{padding}' with a 1x1x1 kernel. This is equivalent to no padding. "
-                      f"Consider using padding = 'valid' instead.", UserWarning)
+        warnings.warn(
+            f"Use are using padding = '{padding}' with a 1x1x1 kernel. This is equivalent to no padding. "
+            f"Consider using padding = 'valid' instead.",
+            UserWarning,
+        )
 
     # Adjust filter shape if batch or channel is 1
     if b != B:
@@ -538,7 +563,13 @@ def conv_transpose3d(
         out = x
     elif padding == "circular":
         # Start from the central crop
-        out = x[:, :, _center_crop_slice_1d(pd, id), _center_crop_slice_1d(ph, ih), _center_crop_slice_1d(pw, iw)]
+        out = x[
+            :,
+            :,
+            _center_crop_slice_1d(pd, id),
+            _center_crop_slice_1d(ph, ih),
+            _center_crop_slice_1d(pw, iw),
+        ]
         # Triple loop over shifts for (z, y, x); skip the (0,0,0) case
         for sz in (-1, 0, 1):
             for sy in (-1, 0, 1):
@@ -550,10 +581,22 @@ def conv_transpose3d(
                     tx, sx_src = _tgt_src_for_axis_circular(sx, pw, iw)
                     out[:, :, tz, ty, tx].add_(x[:, :, sz_src, sy_src, sx_src])
     elif padding == "constant":
-        out = x[:,:, _center_crop_slice_1d(pd, id), _center_crop_slice_1d(ph, ih), _center_crop_slice_1d(pw, iw)]
+        out = x[
+            :,
+            :,
+            _center_crop_slice_1d(pd, id),
+            _center_crop_slice_1d(ph, ih),
+            _center_crop_slice_1d(pw, iw),
+        ]
     elif padding == "reflect":
         # Center crop
-        out = x[:, :, _center_crop_slice_1d(pd, id), _center_crop_slice_1d(ph, ih), _center_crop_slice_1d(pw, iw)]
+        out = x[
+            :,
+            :,
+            _center_crop_slice_1d(pd, id),
+            _center_crop_slice_1d(ph, ih),
+            _center_crop_slice_1d(pw, iw),
+        ]
         for sz in (-1, 0, 1):
             for sy in (-1, 0, 1):
                 for sx in (-1, 0, 1):
@@ -570,7 +613,13 @@ def conv_transpose3d(
                         chunk = chunk.flip(dims=flip_dims)
                     out[:, :, tz, ty, tx].add_(chunk)
     elif padding == "replicate":
-        out = x[:, :, _center_crop_slice_1d(pd, id), _center_crop_slice_1d(ph, ih), _center_crop_slice_1d(pw, iw)]
+        out = x[
+            :,
+            :,
+            _center_crop_slice_1d(pd, id),
+            _center_crop_slice_1d(ph, ih),
+            _center_crop_slice_1d(pw, iw),
+        ]
         for sz in (-1, 0, 1):
             for sy in (-1, 0, 1):
                 for sx in (-1, 0, 1):
@@ -580,9 +629,7 @@ def conv_transpose3d(
                     ty, ysrc, yred = _tgt_src_for_axis_replicate(sy, ph, ih)
                     tx, xsrc, xred = _tgt_src_for_axis_replicate(sx, pw, iw)
                     reduce_dims = tuple(
-                        dim
-                        for red, dim in zip((zred, yred, xred), (2, 3, 4))
-                        if red
+                        dim for red, dim in zip((zred, yred, xred), (2, 3, 4)) if red
                     )
                     chunk = x[:, :, zsrc, ysrc, xsrc]
                     if reduce_dims:
@@ -629,7 +676,9 @@ def conv3d_fft(
     b, c, d, h, w = filter.size()
 
     if c != C:
-        assert c == 1, "Number of channels of the kernel is not matched for broadcasting"
+        assert (
+            c == 1
+        ), "Number of channels of the kernel is not matched for broadcasting"
         filter = filter.expand(-1, C, -1, -1, -1)
 
     if b != B:
@@ -660,27 +709,51 @@ def conv3d_fft(
             else fft.ifftn(t, s=s, dim=(-3, -2, -1)).real
         )
 
-    if padding == "valid":
-        # Linear full convolution then crop to the valid window
+    if padding == "circular":
+        # Circular convolution with kernel center aligned via filter centering
+        img_size = (D, H, W)
+        filt_shifted = _center_filter_3d(filter, img_size)
+        fx = fft3(x, s=img_size)
+        ff = fft3(filt_shifted, s=img_size)
+        return ifft3(fx * ff, s=img_size)
+
+    elif padding == "valid":
+        # Full linear convolution then crop to valid window
         sD, sH, sW = D + d - 1, H + h - 1, W + w - 1
-        fx = fft3(x, s=(sD, sH, sW))
-        ff = fft3(filter, s=(sD, sH, sW))
-        full = ifft3(fx * ff, s=(sD, sH, sW))
+        img_size = (sD, sH, sW)
+        fx = fft3(x, s=img_size)
+        ff = fft3(filter, s=img_size)
+        full = ifft3(fx * ff, s=img_size)
         return full[:, :, d - 1 : D, h - 1 : H, w - 1 : W]
 
-    elif padding in ("constant", "reflect", "replicate", "circular"):
-        # Match conv3d: symmetric pre-padding, then valid conv on the padded grid
-        pad = (pw, pw - iw, ph, ph - ih, pd, pd - id)  # (W_left, W_right, H_top, H_bottom, D_front, D_back)
+    elif padding in ("constant", "reflect", "replicate"):
+        # Linear convolution on a padded grid via circular FFT-conv on that grid.
+        pad = (
+            pw,
+            pw - iw,
+            ph,
+            ph - ih,
+            pd,
+            pd - id,
+        )  # (W_left, W_right, H_top, H_bottom, D_front, D_back)
         x_pad = F.pad(x, pad, mode=padding, value=0)
         img_size = x_pad.shape[-3:]
 
-        # Full linear conv on padded grid via FFT, then take valid part
+        # Center filter on (0,0) in the padded grid
+        filt_shifted = _center_filter_3d(filter, img_size)
+
         fx = fft3(x_pad, s=img_size)
-        ff = fft3(filter, s=img_size)
+        ff = fft3(filt_shifted, s=img_size)
         y_pad = ifft3(fx * ff, s=img_size)
-        
+
         # Extract central region back to original size
-        return y_pad[:, :, _center_crop_slice_1d(pd, id), _center_crop_slice_1d(ph, ih), _center_crop_slice_1d(pw, iw)]
+        return y_pad[
+            :,
+            :,
+            _center_crop_slice_1d(pd, id),
+            _center_crop_slice_1d(ph, ih),
+            _center_crop_slice_1d(pw, iw),
+        ]
 
     else:
         raise ValueError(
@@ -720,7 +793,9 @@ def conv_transpose3d_fft(
     b, c, d, h, w = filter.size()
 
     if c != C:
-        assert c == 1, "Number of channels of the kernel is not matched for broadcasting"
+        assert (
+            c == 1
+        ), "Number of channels of the kernel is not matched for broadcasting"
         filter = filter.expand(-1, C, -1, -1, -1)
 
     if b != B:
@@ -729,11 +804,14 @@ def conv_transpose3d_fft(
 
     pd, ph, pw = d // 2, h // 2, w // 2
     id, ih, iw = (d - 1) % 2, (h - 1) % 2, (w - 1) % 2
-    
+
     if padding != "valid":
         if pd == 0 and pw == 0 and ph == 0:
-            warnings.warn(f"Use are using padding = '{padding}' with a 1x1x1 kernel. This is equivalent to no padding. "
-                          f"Consider using padding = 'valid' instead.", UserWarning)
+            warnings.warn(
+                f"Use are using padding = '{padding}' with a 1x1x1 kernel. This is equivalent to no padding. "
+                f"Consider using padding = 'valid' instead.",
+                UserWarning,
+            )
 
     def fft3(t, s=None):
         return (
@@ -744,7 +822,7 @@ def conv_transpose3d_fft(
 
     def ifft3(t, s):
         return (
-            fft.irfftn(t, s=s, dim=(-3, -2, -1)).real 
+            fft.irfftn(t, s=s, dim=(-3, -2, -1)).real
             if real_fft
             else fft.ifftn(t, s=s, dim=(-3, -2, -1)).real
         )
@@ -869,6 +947,7 @@ def _tgt_src_for_axis_replicate(s, p, i):
     else:
         return -1, slice(-p + i, None), True
 
+
 def _center_crop_slice_1d(p: int, i: int) -> slice:
     # When p == i == 0, return the whole axis; otherwise replicate p : -p + i
     # This prevent issues with 0:-0 slices
@@ -880,12 +959,13 @@ def _center_filter_2d(filter, img_size):
     A helper function to zero-padded to img_size and center the frequencies.
     """
     b, c, fh, fw = filter.shape
-    ih, iw = img_size[-2:] 
+    ih, iw = img_size[-2:]
     ph = int((fh - 1) / 2)
     pw = int((fw - 1) / 2)
     filter = F.pad(filter, (0, iw - fw, 0, ih - fh))
     filter = torch.roll(filter, shifts=(-ph, -pw), dims=(-2, -1))
     return filter
+
 
 def _center_filter_3d(filter, img_size):
     r"""

--- a/deepinv/tests/test_physics_functional.py
+++ b/deepinv/tests/test_physics_functional.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-import deepinv as dinv
 import deepinv.physics.functional as dF
 from functools import partial
 

--- a/deepinv/tests/test_physics_functional.py
+++ b/deepinv/tests/test_physics_functional.py
@@ -1,49 +1,137 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Thu Jul 11 14:48:05 2024
-
-@author: fsarron
-"""
 import pytest
 import torch
 import deepinv as dinv
+import deepinv.physics.functional as dF 
+from functools import partial
 
-
-def test_conv2d_adjointness(device):
+# Some global constants
+ALL_CONV_PADDING = ("valid", "circular", "constant", "replicate", "reflect")
+                   
+@pytest.mark.parametrize("B", [1, 2])
+@pytest.mark.parametrize("nchan_im,nchan_filt", [(1, 1), (3, 1), (3, 3)])
+@pytest.mark.parametrize("padding", ALL_CONV_PADDING)
+@pytest.mark.parametrize("real_fft", [True, False])
+@pytest.mark.parametrize("use_fft", [False, True])
+def test_conv2d_adjointness(device, B, nchan_im, nchan_filt, padding, real_fft, use_fft):
     torch.manual_seed(0)
 
-    nchannels = ((1, 1), (3, 1), (3, 3))
+    size_im = ([nchan_im, 5, 5], 
+               [nchan_im, 6, 6], 
+               [nchan_im, 5, 6], 
+               [nchan_im, 6, 5])
+    size_filt = (
+        [nchan_filt, 3, 3],
+        [nchan_filt, 4, 4],
+        [nchan_filt, 3, 4],
+        [nchan_filt, 4, 3],
+    )
 
-    for nchan_im, nchan_filt in nchannels:
-        size_im = (
-            [nchan_im, 5, 5],
-            [nchan_im, 6, 6],
-            [nchan_im, 5, 6],
-            [nchan_im, 6, 5],
+    if use_fft:
+        conv2d_fn = partial(dF.conv2d_fft, real_fft=real_fft)
+        conv_transpose2d_fn = partial(dF.conv_transpose2d_fft, real_fft=real_fft) 
+    else:
+        conv2d_fn = dF.conv2d
+        conv_transpose2d_fn = dF.conv_transpose2d
+    
+    for sim in size_im:
+        for sfil in size_filt:
+            for bf in (1, B):
+                x = torch.rand((B, *sim), device=device)
+                h = torch.rand((bf, *sfil), device=device)
+                h = h / h.sum(dim=(-1, -2), keepdim=True)  # normalize filter to avoid numerical issues
+
+                Ax = conv2d_fn(x, h, padding=padding)
+                y = torch.rand_like(Ax)
+                Aty = conv_transpose2d_fn(
+                    y, h, padding=padding
+                )
+
+                lhs = torch.sum(Ax * y)
+                rhs = torch.sum(Aty * x)
+                assert torch.abs(lhs - rhs) < 1e-4 * max(torch.abs(lhs), torch.abs(rhs)) # relative tolerance
+                    
+                    
+@pytest.mark.parametrize("B", [1, 2])
+@pytest.mark.parametrize("nchan_im,nchan_filt", [(1, 1), (3, 1), (3, 3)])
+@pytest.mark.parametrize("padding", ALL_CONV_PADDING)  
+@pytest.mark.parametrize("transposed", [True, False])
+def test_conv2d_spatial_and_fft_equivalence(device, B, nchan_im, nchan_filt, padding, transposed):
+    torch.manual_seed(0)
+
+    size_im = ([nchan_im, 5, 5], 
+               [nchan_im, 6, 6], 
+               [nchan_im, 5, 6], 
+               [nchan_im, 6, 5]
+               )
+    size_filt = (
+        [nchan_filt, 3, 3],
+        [nchan_filt, 4, 4],
+        [nchan_filt, 3, 4],
+        [nchan_filt, 4, 3],
+    )
+
+    if transposed:
+        spatial_fn = dF.conv_transpose2d
+        fft_fn = partial(dF.conv_transpose2d_fft, real_fft=True)  # Only test real_fft
+    else:
+        spatial_fn = dF.conv2d
+        fft_fn = partial(dF.conv2d_fft, real_fft=True)
+
+    for sim in size_im:
+        for sfil in size_filt:
+            for bf in (1, B):
+                x = torch.rand((B, *sim), device=device)
+                h = torch.rand((bf, *sfil), device=device)
+                h = h / h.sum(dim=(-1, -2), keepdim=True) # normalize filter to avoid numerical issues
+
+                spatial_output = spatial_fn(x, h, padding=padding)
+                fft_output = fft_fn(x, h, padding=padding)
+
+                assert spatial_output.shape == fft_output.shape
+                assert torch.allclose(spatial_output, fft_output, rtol=1e-4, atol=1e-4)
+                    
+@pytest.mark.parametrize("B", [1, 2])
+@pytest.mark.parametrize("nchan_im,nchan_filt", [(1, 1), (3, 1), (3, 3)])
+@pytest.mark.parametrize("padding", ALL_CONV_PADDING)  # safe set
+@pytest.mark.parametrize("real_fft", [True, False])
+@pytest.mark.parametrize("use_fft", [False])
+def test_conv3d_adjointness(device, B, nchan_im, nchan_filt, padding, real_fft, use_fft):
+    torch.manual_seed(0)
+
+    size_im = ([nchan_im, 5, 5, 5], 
+               [nchan_im, 6, 6, 6], 
+               [nchan_im, 5, 5, 6], 
+               [nchan_im, 5, 6, 5])
+    size_filt = (
+            [nchan_filt, 3, 3, 3],
+            [nchan_filt, 4, 4, 4],
+            [nchan_filt, 4, 3, 4],
+            [nchan_filt, 3, 4, 3],
         )
-        size_filt = (
-            [nchan_filt, 3, 3],
-            [nchan_filt, 4, 4],
-            [nchan_filt, 3, 4],
-            [nchan_filt, 4, 3],
-        )
 
-        paddings = ("valid", "constant", "circular", "reflect", "replicate")
+    if use_fft:
+        conv3d_fn = partial(dF.conv3d_fft, real_fft=real_fft)
+        conv_transpose3d_fn = partial(dF.conv_transpose3d_fft, real_fft=real_fft) 
+    else:
+        conv3d_fn = dF.conv3d
+        conv_transpose3d_fn = dF.conv_transpose3d
+    
+    for sim in size_im:
+        for sfil in size_filt:
+            for bf in (1, B):
+                x = torch.rand((B, *sim), device=device, dtype=torch.float64)
+                h = torch.rand((bf, *sfil), device=device, dtype=torch.float64)
+                h = h / h.sum(dim=(-1, -2, -3), keepdim=True)  # normalize filter to avoid numerical issues
 
-        for pad in paddings:
-            for sim in size_im:
-                for sfil in size_filt:
-                    x = torch.rand(sim)[None].to(device)
-                    h = torch.rand(sfil)[None].to(device)
-                    Ax = dinv.physics.functional.conv2d(x, h, padding=pad)
-                    y = torch.rand_like(Ax)
-                    Aty = dinv.physics.functional.conv_transpose2d(y, h, padding=pad)
+                Ax = conv3d_fn(x, h, padding=padding)
+                y = torch.rand_like(Ax)
+                Aty = conv_transpose3d_fn(
+                    y, h, padding=padding
+                )
 
-                    Axy = torch.sum(Ax * y)
-                    Atyx = torch.sum(Aty * x)
-
-                    assert torch.abs(Axy - Atyx) < 1e-3
+                lhs = torch.sum(Ax * y)
+                rhs = torch.sum(Aty * x)
+                assert torch.abs(lhs - rhs) < 1e-3 * max(torch.abs(lhs), torch.abs(rhs)) # relative tolerance
 
 
 def test_conv3d_norm(device):
@@ -79,8 +167,8 @@ def test_conv3d_norm(device):
 
                     zold = torch.zeros_like(x)
                     for it in range(max_iter):
-                        y = dinv.physics.functional.conv3d_fft(x, h, padding=pad)
-                        y = dinv.physics.functional.conv_transpose3d_fft(
+                        y = dF.conv3d_fft(x, h, padding=pad)
+                        y = dF.conv_transpose3d_fft(
                             y, h, padding=pad
                         )
                         z = (
@@ -97,70 +185,46 @@ def test_conv3d_norm(device):
                     assert torch.abs(zold.item() - torch.ones(1)) < 1e-2
 
 
-def test_conv3d_adjointness(device):
+
+@pytest.mark.parametrize("B", [1, 2])
+@pytest.mark.parametrize("nchan_im,nchan_filt", [(1, 1), (3, 1), (3, 3)])
+@pytest.mark.parametrize("padding", ALL_CONV_PADDING)
+@pytest.mark.parametrize("transposed", [False])  # test conv3d or conv_transpose3d
+def test_conv3d_spatial_and_fft_equivalence(device, B, nchan_im, nchan_filt, padding, transposed):
     torch.manual_seed(0)
 
-    nchannels = ((1, 1), (3, 1), (3, 3))
-
-    for nchan_im, nchan_filt in nchannels:
-        size_im = (
-            [nchan_im, 5, 5, 5],
-            [nchan_im, 6, 6, 6],
-            [nchan_im, 5, 5, 6],
-            [nchan_im, 5, 6, 5],
-        )
-        size_filt = (
-            [nchan_filt, 3, 3, 3],
-            [nchan_filt, 4, 4, 4],
-            [nchan_filt, 4, 3, 4],
-            [nchan_filt, 3, 4, 3],
-        )
-
-        paddings = ("valid", "circular")
-
-        for pad in paddings:
-            for sim in size_im:
-                for sfil in size_filt:
-                    # print(sim, sfil)
-                    x = torch.rand(sim)[None].to(device)
-                    h = torch.rand(sfil)[None].to(device)
-                    Ax = dinv.physics.functional.conv3d_fft(x, h, padding=pad)
-                    y = torch.rand_like(Ax)
-                    Aty = dinv.physics.functional.conv_transpose3d_fft(
-                        y, h, padding=pad
-                    )
-
-                    Axy = torch.sum(Ax * y)
-                    Atyx = torch.sum(Aty * x)
-
-                    assert torch.abs(Axy - Atyx) < 1e-3
-
-
-@pytest.mark.parametrize("kernel", ["cubic", "gaussian"])
-@pytest.mark.parametrize("scale", [2, 0.5])
-@pytest.mark.parametrize("antialiasing", [True, False])
-def test_imresize(kernel, scale, antialiasing):
-    sigma = 2
-    img_size = (1, 64, 64)
-    x = torch.randn(1, *img_size)
-    y = dinv.physics.functional.imresize_matlab(
-        x,
-        scale=scale,
-        kernel=kernel,
-        sigma=sigma,
-        padding_type="reflect",
-        antialiasing=antialiasing,
+    size_im = (
+        [nchan_im, 5, 5, 5],
+        [nchan_im, 6, 6, 6],
+        [nchan_im, 5, 5, 6],
+        [nchan_im, 5, 6, 5],
     )
-    assert y.shape == (
-        1,
-        img_size[0],
-        int(img_size[1] * scale),
-        int(img_size[2] * scale),
+    size_filt = (
+        [nchan_filt, 3, 3, 3],
+        [nchan_filt, 4, 4, 4],
+        [nchan_filt, 4, 3, 4],
+        [nchan_filt, 3, 4, 3],
     )
 
+    if transposed:
+        spatial_fn = dF.conv_transpose3d
+        fft_fn = partial(dF.conv_transpose3d_fft, real_fft=True)  # Only test real_fft
+    else:
+        spatial_fn = dF.conv3d
+        fft_fn = partial(dF.conv3d_fft, real_fft=True)
+        
+    for sim in size_im:
+        for sfil in size_filt:
+            for bf in (1, B):
+                x = torch.rand((B, *sim), device=device)
+                h = torch.rand((bf, *sfil), device=device)
+                h = h / h.sum(dim=(-1, -2, -3), keepdim=True)  # normalize filter to avoid numerical issues
 
-def test_imresize_div2k():
-    x = dinv.utils.load_example("div2k_valid_hr_0877.png") * 255.0
-    y = dinv.utils.load_example("div2k_valid_lr_bicubic_0877x4.png") * 255.0
-    y2 = dinv.physics.functional.imresize_matlab(x, scale=1 / 4).round()
-    assert dinv.metric.PSNR()(y2 / 255.0, y / 255.0) > 59
+                spatial_output = spatial_fn(x, h, padding=padding)
+                fft_output = fft_fn(x, h, padding=padding)
+
+                assert spatial_output.shape == fft_output.shape
+                assert torch.allclose(spatial_output, fft_output, rtol=1e-4, atol=1e-4)
+
+
+


### PR DESCRIPTION
This PR implements:
- `conv3d`, `conv_transpose3d` with all `padding` mode 
- Extend `conv3d_fft`, `conv_transpose3d_fft` to all `padding` mode 
- Extend `conv2d_fft`, `conv_transpose2d_fft` to all `padding` mode 
- Make sure that spatial convolution and FFT-based convolution give the same output (both 2D and 3D) for all padding (pytested)
- Better pytest. 
- Fix some error in docstring and better warnings / assertion 


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
