### PR TITLE
Fix #828

### DIFF
--- a/deepinv/__about__.py
+++ b/deepinv/__about__.py
@@ -5,7 +5,9 @@ __title__ = metadata["Name"]
 __summary__ = metadata["Summary"]
 __version__ = metadata["Version"]
 __author__ = metadata["Author"]
-__license__ = metadata["License"]
+__license__ = metadata.get(
+    "License", metadata.get("License-Expression", "BSD-3-Clause")
+)
 __url__ = metadata["Project-URL"]
 
 __all__ = [


### PR DESCRIPTION
Fixes #828 by using metadata License fallback when doing `from napari import Viewer` before `import deepinv`

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
