### PR TITLE
Allow str in rotate interp mode

### DIFF
--- a/deepinv/tests/test_transform.py
+++ b/deepinv/tests/test_transform.py
@@ -15,6 +15,7 @@ Caveat: certain orderings of complicated arithmetic cannot be achieved with the 
 TRANSFORMS = [
     "shift",
     "rotate",
+    "rotate-bilinear",
     "scale",
     "reflect",
     "shift+scale",
@@ -105,6 +106,8 @@ def choose_transform(transform_name, device, rng):
         return dinv.transform.Shift(rng=rng)
     elif transform_name == "rotate":
         return dinv.transform.Rotate(rng=rng)
+    elif transform_name == "rotate-bilinear":
+        return dinv.transform.Rotate(rng=rng, interpolation_mode="bilinear")
     elif transform_name == "rotate3":
         return dinv.transform.Rotate(n_trans=3, rng=rng)
     elif transform_name == "reflect":

--- a/deepinv/transform/rotate.py
+++ b/deepinv/transform/rotate.py
@@ -43,13 +43,14 @@ class Rotate(Transform):
         self.limits = limits
         self.multiples = multiples
         self.positive = positive
-        if interpolation_mode is None and multiples % 90 != 0:
+        if interpolation_mode is None:
             interpolation_mode = InterpolationMode.NEAREST
-            warn(
-                "The default interpolation mode will be changed to bilinear "
-                "interpolation in the near future. Please specify the interpolation "
-                "mode explicitly if you plan to keep using nearest interpolation."
-            )
+            if multiples % 90 != 0:
+                warn(
+                    "The default interpolation mode will be changed to bilinear "
+                    "interpolation in the near future. Please specify the interpolation "
+                    "mode explicitly if you plan to keep using nearest interpolation."
+                )
         self.interpolation_mode = (
             InterpolationMode(interpolation_mode)
             if isinstance(interpolation_mode, str)


### PR DESCRIPTION
Tiny PR to allow str in rotate interp mode for a friendlier interface (i.e. without having to import torchvision just to use bicubic).

Also, when multiples are multiples of 90 degrees (we already test that this is perfect), we don't need to warn about any interpolation.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
