### PR TITLE
Fix astra test failing on GPU

### DIFF
--- a/deepinv/tests/test_external_libraries.py
+++ b/deepinv/tests/test_external_libraries.py
@@ -143,7 +143,7 @@ class TestTomographyWithAstra:
             loss.backward()
             assert pred.grad is not None
 
-            threshold = 1e-3 if geometry_type != 'conebeam' else 5e-2
+            threshold = 1e-3 if geometry_type != "conebeam" else 5e-2
             if normalize:
                 assert abs(physics.compute_norm(x, squared=False) - 1.0) < threshold
 


### PR DESCRIPTION
The norm computation during normalization of the TomographyWithAstra operator fails to converge for the conebeam geometry. I am increasing the relative threshold on the normalization test to 5e-2  for this case.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
