### PR TITLE
Fix broken download Set14

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changed
 Fixed
 ^^^^^
 - Blur physics objects now put new filters to physics device regardless of input filter device (:gh:`844` by `Vicky De Ridder`_)
+- Set14HR dataset now downloads from a different source (and has slightly different folderstructure), since old link broke. (:gh:`845` by `Vicky De Ridder`_)
 
 v0.3.5
 ------

--- a/deepinv/datasets/set14.py
+++ b/deepinv/datasets/set14.py
@@ -100,7 +100,6 @@ class Set14HR(ImageFolder):
                 )
 
         # Initialize ImageFolder
-
         super().__init__(self.img_dir, transform=transform)
 
     def check_dataset_exists(self) -> bool:


### PR DESCRIPTION
To fix #729 
I can make it such that we reproduce exactly what was there before in terms of structure. Not sure if the checksum needs to be changed anyway.

Now, it would download as 
- `Set14/Set14_HR` --> all HR versions of the images
- `Set14/Set14_LR_x2` --> all images downsampled by factor 2
...

So the folder naming will need some cleaning + in the original behavior (from my understanding) had each HR image inside each folder (basically duplicates?).

Additionally, file names in this downloading are not integers, but image names (e.g. `baboon.png`).

TBD if we 
(i) Make the format indeed like this (with some minor change so we do not repeat `Set14` twice (once top level, one per resolution folder). 
(ii) Try to change the extracted folder structure such that we have an exact replica (requires most code).
(iii) Host the version we want on HuggingFace as suggested by @Andrewwango 

From my understanding, the purpose anyway is to simply have access to the HR versions. This could thus be greatly simplified by only downloading `Set14_HR.tar.gz`. 
I think thus it is the easiest approach to only download the HR images. Thoughts?

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
