### PR TITLE
Fix test transform on GPU

### DIFF
--- a/deepinv/tests/test_transform.py
+++ b/deepinv/tests/test_transform.py
@@ -218,6 +218,8 @@ def test_transform_identity(
         "similarity",
         "affine",
         "pantiltrotate",
+        "VARIANTshift+scale*rotate",
+        "VARIANTshift*scale|rotate",
     ):
         # more reliable with a cpu rng here
         rng = torch.Generator().manual_seed(0)


### PR DESCRIPTION
As simple as giving the failing transforms the CPU rng instead as that had better luck in the test

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
