### PR TITLE
Gentler loader check

### DIFF
--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -419,7 +419,7 @@ class Trainer:
             and self.show_progress_bar
         ):
             warnings.warn(
-                "Update progress bar frequency of 1 may slow down training on GPU. Consider increasing this."
+                "Update progress bar frequency of 1 may slow down training on GPU. Consider setting freq_update_progress_bar > 1."
             )
 
         _ = self.load_model()


### PR DESCRIPTION
This softens the dataloader check inside trainer.

The problem before is if you use a custom dataloader, whose internal `dataset` does not return tensors (maybe returns list of patches for eaxmple, and the custom loader does the tensor loading), then that will raise an error in the trainer, even though the loader can be used perfectly fine. So now the check only happens if you use the normal torch utils data dataloader.

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [CHANGELOG.rst](../CHANGELOG.rst).
