### PR TITLE
Preventive fix: Tensor non-tuple indexing deprecated

### DIFF
--- a/deepinv/utils/tensorlist.py
+++ b/deepinv/utils/tensorlist.py
@@ -338,7 +338,7 @@ def dirac(shape, device="cpu"):
     out = torch.zeros(shape, device=device)
     center = tuple([s // 2 for s in shape[-2:]])
     slices = [slice(None)] * (len(shape) - 2) + list(center)
-    out[slices] = 1
+    out[tuple(slices)] = 1
     return out
 
 


### PR DESCRIPTION
In the testing logs right now there is already a warning:

"UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result"

This PR is a preventive fix for PyTorch 2.9


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
