### PR TITLE
fix lsdir glob pattern

### DIFF
--- a/deepinv/datasets/lsdir.py
+++ b/deepinv/datasets/lsdir.py
@@ -168,7 +168,7 @@ class LsdirHR(ImageFolder):
             super().__init__(self.root, x_path="val1/HR/val/*.png", transform=transform)
         else:  # mode is train for sure, because of earlier check
             super().__init__(
-                self.root, x_path="shard-[0-1][0-9]/**/*.png", transform=transform
+                self.root, x_path="00[0-8][0-9]000/*.png", transform=transform
             )
 
     def verify_split_dataset_integrity(self) -> bool:


### PR DESCRIPTION
Fix #979 by correcting the glob structure.


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
