### PR TITLE
Imaging benchmarks 

### DIFF
--- a/deepinv/benchmark/urban100_gaussian_denoising.py
+++ b/deepinv/benchmark/urban100_gaussian_denoising.py
@@ -18,8 +18,8 @@ class Benchmark:
         The noise standard deviation is set to 25/255 for images normalized between 0 and 1.
     """
 
+    @staticmethod
     def run(
-        self,
         model: dinv.models.Denoiser,
         *,
         device: torch.device | str = torch.device("cpu"),


### PR DESCRIPTION
The library has all of the building blocks necessary to compute benchmarks on different imaging modalities. Yet, there is no standardized way to do that at the moment and we do not showcase it in the docs. The goal of this PR is to remedy that.

**Plan**

- Create a module `deepinv.benchmark` for the benchmark-related code
- Add standard benchmarks (Gaussian denoising, Super-Resolution)
- Create a GitHub action to compute the benchmarks on a GPU
- Add the benchmarks to the docs

**Inspirations**

- timm leaderboard https://huggingface.co/spaces/timm/leaderboard

**TODO**

- [x] Create a simple benchmark PoC for Gaussian denoising or super-resolution
- [x] Test multiple denoisers
- [ ] Write the GitHub action
