### PR TITLE
fix auto-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,6 @@ jobs:
     name: Auto version, test & publish
     runs-on: ubuntu-latest
 
-    env:
-      # Configure a constant location for the uv cache
-      UV_CACHE_DIR: /tmp/.uv-cache
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -37,22 +33,11 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'  # minimum supported version
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Restore uv cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.uv-cache
-          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-            uv-${{ runner.os }}
+          cache: 'pip'  # caching pip dependencies
 
       - name: Install tools
         run: |
-          uv pip install --upgrade tomlkit
+          pip install --upgrade tomlkit
 
       - name: Update changelog
         id: changelog
@@ -90,6 +75,3 @@ jobs:
           body_path: changelog.txt
           name: Release v${{ steps.bump.outputs.version }}
           files: dist/*
-
-      - name: Minimize uv cache
-        run: uv cache prune --ci

--- a/.github/workflows/upload_pypi.yml
+++ b/.github/workflows/upload_pypi.yml
@@ -1,4 +1,4 @@
-name: Deploy to pipy 
+name: Deploy to pipy
 
 on:
   pull_request:
@@ -11,8 +11,6 @@ jobs:
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.head.ref == 'release-branch'
     runs-on: ubuntu-latest
-    env:
-      UV_CACHE_DIR: /tmp/.uv-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -22,21 +20,9 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Restore uv cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.uv-cache
-          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-            uv-${{ runner.os }}
-
       - name: Install tools
         run: |
-          uv pip install --upgrade build twine
+          pip install --upgrade build twine
 
       - name: Build the package
         run: python -m build
@@ -46,22 +32,17 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
         run: |
-          uv run twine check dist/*
-          uv run twine upload --verbose --repository testpypi dist/*
+          python -m twine check dist/*
+          python -m twine upload --verbose --repository testpypi dist/*
 
       - name: Install from TestPyPI and test
         run: |
-          uv pip install --index-url https://test.pypi.org/simple/ deepinv --extra-index-url https://pypi.org/simple
-          uv run python -c "import deepinv"
-          
+          pip install --index-url https://test.pypi.org/simple/ deepinv --extra-index-url https://pypi.org/simple
+          python -c "import deepinv"
+
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          uv run twine upload dist/*
-
-      - name: Minimize uv cache
-        run: uv cache prune --ci
-        
-      
+          python -m twine upload dist/*


### PR DESCRIPTION
I'm reverting the changes applied to the auto pypi release workflow (updated to `uv`) since they broke the workflows and the workflows were already very fast (so no need for `uv` here).

The files should match those present before #943 

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
