### PR TITLE
Make CI fail on deprecation warnings in tests

### DIFF
--- a/deepinv/tests/conftest.py
+++ b/deepinv/tests/conftest.py
@@ -101,3 +101,8 @@ def pytest_collection_modifyitems(config, items):
             # All other tests are grouped under "main" and run one at a time
             # but in parallel of the slow tests.
             item.add_marker(pytest.mark.xdist_group("main"))
+
+
+# Make deprecation warnings raise errors in tests
+def pytest_configure(config):
+    config.addinivalue_line("filterwarnings", "error::DeprecationWarning")


### PR DESCRIPTION
Our own code should not trigger deprecation warnings yet it does - I suggest to remedy that