### PR TITLE
Push new black 2026 stable style

### DIFF
--- a/deepinv/datasets/base.py
+++ b/deepinv/datasets/base.py
@@ -13,7 +13,6 @@ from PIL.Image import Image as PIL_Image
 from deepinv.utils.tensorlist import TensorList
 from natsort import natsorted
 
-
 CORE_TYPES = (
     Tensor,
     TensorList,

--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -5,7 +5,6 @@ import torch.nn as nn
 from torch import Tensor
 from .base import Denoiser
 
-
 # Coeffs is, depending on the dimension:
 # 2D: [Tensor, list[Tensor], list[Tensor]]
 # 3D: [Tensor, dict[str, Tensor], dict[str, Tensor]]

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -17,7 +17,6 @@ from deepinv.optim.distance import (
 from deepinv.optim.potential import Potential
 from deepinv.physics.functional import dct_2d, idct_2d
 
-
 if TYPE_CHECKING:
     from deepinv.physics import Physics, StackedPhysics
 

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -1258,7 +1258,7 @@ def adjoint_function(A, input_size, device="cpu", dtype=torch.float):
 
     """
     x = torch.ones(input_size, device=device, dtype=dtype)
-    (_, vjpfunc) = torch.func.vjp(A, x)
+    _, vjpfunc = torch.func.vjp(A, x)
     batches = x.size()[0]
 
     # NOTE: In certain cases A(x) can't be automatically differentiated

--- a/deepinv/physics/generator/zernike.py
+++ b/deepinv/physics/generator/zernike.py
@@ -1,7 +1,6 @@
 import torch
 import math
 
-
 # Dictionary for Standard aberrations
 # See: https://en.wikipedia.org/wiki/Zernike_polynomials#Zernike_polynomials
 _NAMES = {

--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -22,7 +22,6 @@ import typing
 # NOTE: It's used as a fixture.
 from conftest import non_blocking_plots  # noqa: F401
 
-
 NO_LEARNING = ["A_dagger", "A_adjoint", "prox_l2", "y"]
 
 

--- a/examples/external-libraries/demo_hf_dataset.py
+++ b/examples/external-libraries/demo_hf_dataset.py
@@ -20,7 +20,6 @@ from torchvision import transforms
 
 import deepinv as dinv
 
-
 # %%
 # Stream data from Internet
 # ----------------------------------------------------------------------------------------

--- a/examples/optimization/demo_custom_prior.py
+++ b/examples/optimization/demo_custom_prior.py
@@ -19,7 +19,6 @@ from deepinv.training import test
 from torchvision import transforms
 from deepinv.utils import load_dataset
 
-
 # %%
 # Setup paths for data loading and results.
 # --------------------------------------------

--- a/examples/physics/demo_blur_tour.py
+++ b/examples/physics/demo_blur_tour.py
@@ -14,7 +14,6 @@ import deepinv as dinv
 from deepinv.utils.plotting import plot
 from deepinv.utils import load_example
 
-
 # %% Load test images
 # ----------------
 #

--- a/examples/physics/demo_lidar.py
+++ b/examples/physics/demo_lidar.py
@@ -10,7 +10,6 @@ import deepinv as dinv
 import torch
 import matplotlib.pyplot as plt
 
-
 # %%
 # Create forward model
 # -----------------------------------------------

--- a/examples/physics/demo_mri_tour.py
+++ b/examples/physics/demo_mri_tour.py
@@ -464,13 +464,11 @@ dataset = dinv.datasets.CMRxReconSliceDataset(
 
 x, y, params = next(iter(DataLoader(dataset)))
 
-print(
-    f"""
+print(f"""
     Ground truth: {x.shape} (B, C, T, H, W)
     Measurements: {y.shape}
     Acc. mask: {params["mask"].shape}
-"""
-)
+""")
 
 # %%
 # Dynamic MRI data is directly compatible with existing functionality.

--- a/examples/physics/demo_physics_tour.py
+++ b/examples/physics/demo_physics_tour.py
@@ -14,7 +14,6 @@ import deepinv as dinv
 from deepinv.utils.plotting import plot
 from deepinv.utils import load_example
 
-
 # %%
 # Load image from the internet
 # ----------------------------

--- a/examples/physics/demo_spatial_unwrapping.py
+++ b/examples/physics/demo_spatial_unwrapping.py
@@ -26,7 +26,6 @@ import matplotlib.pyplot as plt
 from deepinv.optim import ADMM
 from deepinv.utils import load_example
 
-
 # %%
 # Load image and preprocess
 # -------------------------------------------------------

--- a/examples/plug-and-play/demo_RED_GSPnP_SR.py
+++ b/examples/plug-and-play/demo_RED_GSPnP_SR.py
@@ -18,7 +18,6 @@ from torchvision import transforms
 from deepinv.utils.parameters import get_GSPnP_params
 from deepinv.utils import load_dataset, load_degradation
 
-
 # %%
 # Setup paths for data loading and results.
 # --------------------------------------------------------

--- a/examples/sampling/demo_diffusion_sde.py
+++ b/examples/sampling/demo_diffusion_sde.py
@@ -136,7 +136,6 @@ import os
 import shutil
 from pathlib import Path
 
-
 try:
     final_dir = (
         Path(os.getcwd()).parent.parent / "docs" / "source" / "auto_examples" / "images"

--- a/examples/self-supervised-learning/demo_poisson2sparse.py
+++ b/examples/self-supervised-learning/demo_poisson2sparse.py
@@ -11,7 +11,6 @@ This method is based on the paper "Poisson2Sparse" :footcite:t:`ta2022poisson2sp
 import deepinv as dinv
 import torch
 
-
 # %%
 # Load a Poisson corrupted image
 # ------------------------------

--- a/examples/unfolded/demo_DEQ.py
+++ b/examples/unfolded/demo_DEQ.py
@@ -19,7 +19,6 @@ from deepinv.optim import PGD
 from torchvision import transforms
 from deepinv.utils import load_dataset, load_degradation
 
-
 # %%
 # Setup paths for data loading and results.
 # ----------------------------------------------------------------------------------------


### PR DESCRIPTION
Black has released its new stable style for 2026: https://black.readthedocs.io/en/stable/change_log.html. I am pushing this here to avoid cluttering other PRs with out-of-scope file changes.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` runs successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
