### PR TITLE
Add use_fft param in Blur

### DIFF
--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -360,7 +360,7 @@ class Blur(LinearPhysics):
 
     .. note::
 
-        This class performs a true convolution, not a cross-correlation as the standard convolution functions in ``torch.nn.functional``. 
+        This class performs a true convolution, not a cross-correlation as the standard convolution functions in ``torch.nn.functional``.
         It is recommended to use ``use_fft=True`` for large filters, and ``use_fft=False`` for small filters, since FFT-based convolutions can be faster for large kernels but slower for small kernels.
 
     |sep|


### PR DESCRIPTION
Add `use_fft=False` to the `Blur` physics for selecting spatial conv or FFT conv (which is advantageous for large filters). 


Thank you for contributing to DeepInverse!

Please refer to our [contributing guidelines](https://deepinv.github.io/deepinv/contributing.html) for full instructions on how to contribute, including writing tests, documentation and code style.

Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/documentation.yml). Look for the workflow run corresponding to your pull request.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
