### PR TITLE
Fix backtraking typo in optimizer docs

### DIFF
--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -1335,7 +1335,7 @@ class GD(BaseOptim):
     :param bool early_stop: whether to stop the algorithm as soon as the convergence criterion is met. Default: ``False``.
     :param deepinv.optim.BacktrackingConfig, bool backtracking: configuration for using a backtracking line-search strategy for automatic stepsize adaptation.
         If None (default), stepsize backtracking is disabled. Otherwise, ``backtracking`` must be an instance of :class:`deepinv.optim.BacktrackingConfig`, which defines the parameters for backtracking line-search.
-        By default, backtracking is disabled (i.e., ``backtracking=None``), and as soon as ``backtraking`` is not ``None``, the default ``BacktrackingConfig`` is used.
+        By default, backtracking is disabled (i.e., ``backtracking=None``), and as soon as ``backtracking`` is not ``None``, the default ``BacktrackingConfig`` is used.
     :param dict custom_metrics: dictionary of custom metric functions to be computed along the iterations. The keys of the dictionary are the names of the metrics, and the values are functions that take as input the current and previous iterates, and return a scalar value. Default: ``None``.
     :param Callable custom_init:  Custom initialization of the algorithm.
         The callable function ``custom_init(y, physics)`` takes as input the measurement :math:`y` and the physics ``physics`` and returns the initialization in the form of either:
@@ -1613,7 +1613,7 @@ class PGD(BaseOptim):
     :param bool early_stop: whether to stop the algorithm as soon as the convergence criterion is met. Default: ``False``.
     :param deepinv.optim.BacktrackingConfig, bool backtracking: configuration for using a backtracking line-search strategy for automatic stepsize adaptation.
         If None (default), stepsize backtracking is disabled. Otherwise, ``backtracking`` must be an instance of :class:`deepinv.optim.BacktrackingConfig`, which defines the parameters for backtracking line-search.
-        By default, backtracking is disabled (i.e., ``backtracking=None``), and as soon as ``backtraking`` is not ``None``, the default ``BacktrackingConfig`` is used.
+        By default, backtracking is disabled (i.e., ``backtracking=None``), and as soon as ``backtracking`` is not ``None``, the default ``BacktrackingConfig`` is used.
     :param dict custom_metrics: dictionary of custom metric functions to be computed along the iterations. The keys of the dictionary are the names of the metrics, and the values are functions that take as input the current and previous iterates, and return a scalar value. Default: ``None``.
     :param Callable custom_init:  Custom initialization of the algorithm.
         The callable function ``custom_init(y, physics)`` takes as input the measurement :math:`y` and the physics ``physics`` and returns the initialization in the form of either:

--- a/docs/source/user_guide/reconstruction/optimization.rst
+++ b/docs/source/user_guide/reconstruction/optimization.rst
@@ -371,7 +371,7 @@ which defines the parameters for backtracking line-search. The :class:`deepinv.o
         max_iter: int = 10
             # Maximum number of backtracking iterations
 
-By default, backtracking is disabled (i.e., ``backtracking=None``), and as soon as ``backtraking`` is not ``None``, the above ``BacktrackingConfig`` is used by default.
+By default, backtracking is disabled (i.e., ``backtracking=None``), and as soon as ``backtracking`` is not ``None``, the above ``BacktrackingConfig`` is used by default.
 
 .. note::
   To use backtracking, the optimized function (i.e., both the the data-fidelity and prior) must be explicit and provide a computable cost for the current iterate.


### PR DESCRIPTION
## Summary
- fix typo `backtraking` -> `backtracking` in optimizer docstrings
- fix same typo in optimization user guide

## Files changed
- `deepinv/optim/optimizers.py`
- `docs/source/user_guide/reconstruction/optimization.rst`

Closes #1052