### PR TITLE
Remove sqrt bug in plot_ortho3D

### DIFF
--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -1214,9 +1214,7 @@ def plot_ortho3D(
         for r, img in enumerate(row_imgs):
 
             ax_XY = axs[r, i]
-            ax_XY.imshow(
-                img[img.shape[0] // 2], cmap=cmap, interpolation=interpolation
-            )
+            ax_XY.imshow(img[img.shape[0] // 2], cmap=cmap, interpolation=interpolation)
             # ax_XY.set_aspect(1.)
             from mpl_toolkits.axes_grid1 import make_axes_locatable
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -33,6 +33,7 @@ Fixed
 - Add :class:`deepinv.physics.ComposedPhysics`, :class:`deepinv.physics.ComposedLinearPhysics` to online documentation (:gh:`1000` by `Romain Vo`_)
 - Have test ground truths returned in HDF5Dataset when present (:gh:`764` by `Jérémy Scanvic`_)
 - Dispose of invalid physics parameters in HDF5Dataset loading (:gh:`764` by `Jérémy Scanvic`_)
+- :func:`deepinv.utils.plot_ortho3D` doesn't perform sqrt on images (:gh:`1068` by `Andrew Wang`_)
 
 v0.3.7
 ------

--- a/examples/physics/demo_microscopy_3d.py
+++ b/examples/physics/demo_microscopy_3d.py
@@ -144,7 +144,7 @@ blurs = diffraction_generator.step(
     batch_size=3, coeff=torch.zeros(3, n_zernike, device=device)
 )
 dinv.utils.plot_ortho3D(
-    [f ** 0.5 for f in blurs["filter"][:, None]],
+    [f**0.5 for f in blurs["filter"][:, None]],
     suptitle="Airy pattern",
 )
 


### PR DESCRIPTION
`plot_ortho3D` currently performs sqrt (two sqrts!) before plotting, presumably to make PSFs look nicer in the [microscopy example](https://deepinv.github.io/deepinv/auto_examples/physics/demo_microscopy_3d.html). However this is not general behaviour and makes everything else look funny. This PR removes it.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` runs successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
