### PR TITLE
fix: raise error on failed HTTP response in download_archive

### DIFF
--- a/deepinv/datasets/utils.py
+++ b/deepinv/datasets/utils.py
@@ -63,6 +63,7 @@ def download_archive(url: str, save_path: str | Path, extract: bool = False) -> 
     # `stream=True` to avoid loading in memory an entire file, instead get a chunk
     # useful when downloading huge file
     response = requests.get(url, stream=True)
+    response.raise_for_status()
     file_size = int(response.headers.get("Content-Length", 0))
     # use tqdm progress bar to follow progress on downloading archive
     with tqdm.wrapattr(response.raw, "read", total=file_size) as r_raw:


### PR DESCRIPTION
## Summary

When `download_archive` is called with a URL that returns a non-2xx status (e.g. 404 for a nonexistent image name), it silently saves the error response body to disk. This leads to cryptic errors later (e.g. `UnpicklingError` from `torch.load`). This PR adds `response.raise_for_status()` so a clear `HTTPError` is raised immediately.

Fixes #873

## Changes

- Added `response.raise_for_status()` after `requests.get()` in `download_archive` to fail fast on HTTP errors

## Testing

- Verified that valid URLs continue to work as before (status 200 passes through `raise_for_status` without effect)
- Verified that a 404 URL now raises `requests.exceptions.HTTPError` with a descriptive message instead of silently saving garbage data

---

> Contributed via [definable.ai](https://definable.ai) — @Anandesh-Sharma