### PR TITLE
fix: handle NaN in SpectralAngleMapper when pixels are zero

### DIFF
--- a/deepinv/loss/metric/distortion.py
+++ b/deepinv/loss/metric/distortion.py
@@ -587,7 +587,7 @@ class SpectralAngleMapper(Metric):
     def metric(self, x_net: Tensor, x: Tensor, *args, **kwargs) -> Tensor:
         from torchmetrics.functional.image import spectral_angle_mapper
 
-        return spectral_angle_mapper(x_net, x, reduction="none").mean(
+        return spectral_angle_mapper(x_net, x, reduction="none").nanmean(
             dim=tuple(range(1, x.ndim - 1)), keepdim=False
         )
 


### PR DESCRIPTION
## Summary

When any pixel in the input image is zero, `torchmetrics.functional.image.spectral_angle_mapper` produces NaN values for those spatial positions. Using `.mean()` for reduction then propagates the NaN to the final output. This PR replaces `.mean()` with `.nanmean()` so that NaN values from zero pixels are ignored during reduction.

Fixes #1047

## Changes

- Changed `.mean()` to `.nanmean()` in `SpectralAngleMapper.metric()` for the spatial reduction step

## Testing

- Verified with the reproducer from the issue:
  ```python
  a, b = torch.ones(2, 1, 3, 8, 8)
  a[:, :, 5, 3] = 0
  dinv.metric.SpectralAngleMapper()(a, b)
  # Before: tensor([nan])
  # After: tensor([0.])
  ```

---

> Contributed via [definable.ai](https://definable.ai) — @Anandesh-Sharma