### PR TITLE
fix: use per-sample statistics for standardize normalization in Metric

### DIFF
--- a/deepinv/loss/metric/metric.py
+++ b/deepinv/loss/metric/metric.py
@@ -246,7 +246,13 @@ class Metric(Module):
                 raise ValueError(
                     "Both x and x_net must not be None in order to use standardize."
                 )
-            x_net = (x_net - x_net.mean()) / x_net.std() * x.std() + x.mean()
+            reduce_dims = tuple(range(1, x_net.ndim))
+            x_net = (
+                (x_net - x_net.mean(dim=reduce_dims, keepdim=True))
+                / x_net.std(dim=reduce_dims, keepdim=True)
+                * x.std(dim=reduce_dims, keepdim=True)
+                + x.mean(dim=reduce_dims, keepdim=True)
+            )
 
         x_net = self.normalizer(x_net)
         x = self.normalizer(x) if x is not None else None


### PR DESCRIPTION
## Summary

The `standardize` normalization mode in `Metric` computed mean and std over the entire batch tensor, making metric results dependent on batch composition and non-deterministic with shuffled dataloaders. This PR changes it to compute per-sample statistics (over all dims except batch), matching the documented behavior.

Fixes #908

## Changes

- Changed `x_net.mean()` / `x_net.std()` (global) to `x_net.mean(dim=reduce_dims, keepdim=True)` / `x_net.std(dim=reduce_dims, keepdim=True)` (per-sample) in `Metric.forward`
- Same change applied to `x.mean()` / `x.std()`

## Testing

- For batch_size=1, behavior is identical (global mean == per-sample mean)
- For batch_size>1, each sample is now independently standardized to match its corresponding ground truth's statistics, which is deterministic regardless of batch composition

---

> Contributed via [definable.ai](https://definable.ai) — @Anandesh-Sharma