### PR TITLE
fix: deprecate non-adjoint reduction modes in StackedLinearPhysics

### DIFF
--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -1423,7 +1423,7 @@ class StackedLinearPhysics(StackedPhysics, LinearPhysics):
 
     :param list[deepinv.physics.Physics] physics_list: list of physics operators to stack.
     :param str reduction: how to combine tensorlist outputs of adjoint operators into single
-        adjoint output. Choose between ``sum``, ``mean`` or ``None``.
+        adjoint output. Only ``sum`` preserves adjointness. ``mean`` and ``None`` are deprecated.
     """
 
     def __init__(self, physics_list, reduction="sum", **kwargs):
@@ -1431,8 +1431,20 @@ class StackedLinearPhysics(StackedPhysics, LinearPhysics):
         if reduction == "sum":
             self.reduction = sum
         elif reduction == "mean":
+            warnings.warn(
+                'reduction="mean" breaks adjointness of StackedLinearPhysics and is deprecated. '
+                'Use reduction="sum" instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
             self.reduction = lambda x: sum(x) / len(x)
         elif reduction in ("none", None):
+            warnings.warn(
+                'reduction="none" breaks adjointness of StackedLinearPhysics and is deprecated. '
+                'Use reduction="sum" instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
             self.reduction = lambda x: x
         else:
             raise ValueError("reduction must be either sum, mean or none.")


### PR DESCRIPTION
## Summary

The `"mean"` and `"none"` reduction options in `StackedLinearPhysics` break the adjointness property of the operator. Only `"sum"` correctly implements the adjoint as documented. This PR adds deprecation warnings when the non-adjoint modes are used, preserving backward compatibility while guiding users to the correct option.

Fixes #1066

## Changes

- Added `DeprecationWarning` when `reduction="mean"` or `reduction="none"` is passed to `StackedLinearPhysics`
- Updated docstring to note that only `"sum"` preserves adjointness

## Testing

- `reduction="sum"` (default): no warning, adjointness preserved
- `reduction="mean"`: `DeprecationWarning` emitted, existing behavior preserved for backward compatibility
- `reduction="none"`: `DeprecationWarning` emitted, existing behavior preserved for backward compatibility

---

> Contributed via [definable.ai](https://definable.ai) — @Anandesh-Sharma