### PR TITLE
fix: warn when model-adapting losses affect other losses in Trainer

### DIFF
--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -423,6 +423,23 @@ class Trainer:
         if not isinstance(self.losses, (list, tuple)):
             self.losses = [self.losses]
 
+        if len(self.losses) > 1:
+            from deepinv.loss.loss import Loss
+
+            adapting = [
+                type(l).__name__
+                for l in self.losses
+                if getattr(type(l), "adapt_model", Loss.adapt_model)
+                is not Loss.adapt_model
+            ]
+            if adapting:
+                warnings.warn(
+                    f"Multiple losses are used and {', '.join(adapting)} adapt(s) the model. "
+                    f"All losses will receive x_net from the adapted model, not the original. "
+                    f"Make sure this is intended.",
+                    stacklevel=2,
+                )
+
         for l in self.losses:
             self.model = l.adapt_model(self.model)
 


### PR DESCRIPTION
## Summary

When multiple losses are used and one adapts the model (e.g. `SplittingLoss`), all other losses silently receive `x_net` from the adapted model rather than the original. This can produce unexpected results (e.g. `MCLoss` getting `f(y1)` instead of `f(y)`). This PR adds a warning during `setup_train` when this situation is detected, using duck typing to check if any loss overrides `adapt_model` from the base `Loss` class.

Fixes #875

## Changes

- Added detection of model-adapting losses using comparison against `Loss.adapt_model`
- Emit a warning listing which losses adapt the model when multiple losses are used

## Testing

- Single loss: no warning
- Multiple losses, none adapting: no warning
- Multiple losses with `SplittingLoss` + `MCLoss`: warning emitted naming `SplittingLoss`

---

> Contributed via [definable.ai](https://definable.ai) — @Anandesh-Sharma