### PR TITLE
feat: add documentation badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
    :alt: deepinv logo
    :align: center
 
-|pip install| |stars| |discord| |colab| |youtube| |paper|
+|pip install| |stars| |discord| |colab| |youtube| |paper| |docs|
 
 |Test Status| |GPU Test Status|  |Docs Status| |GPU Docs Status| |Python Version| |Black| |codecov|
 
@@ -146,3 +146,5 @@ Star history
    :target: https://doi.org/10.21105/joss.08923
 .. |stars| image:: https://img.shields.io/github/stars/deepinv/deepinv?style=flat&label=%E2%AD%90%20Star%20us%20on%20GitHub
    :target: https://github.com/deepinv/deepinv
+.. |docs| image:: https://img.shields.io/badge/docs-deepinv.github.io-blue?logo=readthedocs
+   :target: https://deepinv.github.io/deepinv/


### PR DESCRIPTION
## Summary

Adds a documentation badge linking to deepinv.github.io on the README homepage, making it easier for new users to find the docs directly from GitHub.

Fixes #676

## Changes

- Added `|docs|` badge to the badge row in `README.rst`
- Added badge definition linking to `https://deepinv.github.io/deepinv/`

## Testing

- Verified RST syntax renders correctly

---

> Contributed via [definable.ai](https://definable.ai) — @Anandesh-Sharma