### PR TITLE
fix: use physics.adjointness_test in downsampling adjointness test

### DIFF
--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1462,13 +1462,7 @@ def test_downsampling_adjointness(padding, device):
                     sim, filter=h, padding=padding, device=device
                 )
 
-                Ax = physics.A(x)
-                y = torch.rand_like(Ax)
-                Aty = physics.A_adjoint(y)
-                Axy = torch.sum(Ax * y)
-                Atyx = torch.sum(Aty * x)
-
-                assert torch.abs(Axy - Atyx) < 1e-3
+                assert physics.adjointness_test(x).abs() < 1e-3
 
 
 def test_prox_l2_downsampling(device):


### PR DESCRIPTION
## Summary

The `test_downsampling_adjointness` test manually computed `<Ax, y>` and `<x, A^Ty>` to verify adjointness, while all other adjointness tests use the built-in `physics.adjointness_test()` method. This PR replaces the manual computation for consistency.

Fixes #652

## Changes

- Replaced manual adjointness check in `test_downsampling_adjointness` with `physics.adjointness_test(x).abs() < 1e-3`
- Removed unnecessary intermediate variables (`Ax`, `y`, `Aty`, `Axy`, `Atyx`)

## Testing

- The test logic is equivalent — `adjointness_test` internally computes the same `<Ax,y> - <x,A^Ty>` check
- All other downsampling tests remain unchanged

---

> Contributed via [definable.ai](https://definable.ai) — @Anandesh-Sharma