### PR TITLE
fix: add generator support to TensorList rand_like and randn_like

### DIFF
--- a/deepinv/utils/tensorlist.py
+++ b/deepinv/utils/tensorlist.py
@@ -295,26 +295,34 @@ class TensorList:
         return sum([xi.numel() for xi in self.x])
 
 
-def randn_like(x):
+def randn_like(x, generator=None):
     r"""
     Returns a :class:`deepinv.utils.TensorList` or :class:`torch.Tensor`
     with the same type as x, filled with standard gaussian numbers.
+
+    :param generator: optional :class:`torch.Generator` for reproducible sampling.
     """
     if isinstance(x, torch.Tensor):
-        return torch.randn_like(x)
+        return torch.empty_like(x).normal_(generator=generator)
     else:
-        return TensorList([torch.randn_like(xi) for xi in x])
+        return TensorList(
+            [torch.empty_like(xi).normal_(generator=generator) for xi in x]
+        )
 
 
-def rand_like(x):
+def rand_like(x, generator=None):
     r"""
     Returns a :class:`deepinv.utils.TensorList` or :class:`torch.Tensor`
     with the same type as x, filled with random uniform numbers in [0,1].
+
+    :param generator: optional :class:`torch.Generator` for reproducible sampling.
     """
     if isinstance(x, torch.Tensor):
-        return torch.rand_like(x)
+        return torch.empty_like(x).uniform_(generator=generator)
     else:
-        return TensorList([torch.rand_like(xi) for xi in x])
+        return TensorList(
+            [torch.empty_like(xi).uniform_(generator=generator) for xi in x]
+        )
 
 
 def zeros_like(x):


### PR DESCRIPTION
## Summary

The standalone `rand_like` and `randn_like` functions in `deepinv/utils/tensorlist.py` did not accept a random number generator, making them non-reproducible. This PR adds an optional `generator` parameter using the same `torch.empty_like` + in-place sampling pattern used in `deepinv.physics.noise`.

Fixes #626

## Changes

- Added `generator=None` parameter to `rand_like` and `randn_like` in `tensorlist.py`
- Changed implementation from `torch.rand_like`/`torch.randn_like` to `torch.empty_like().uniform_(generator=)` / `torch.empty_like().normal_(generator=)` to support the generator
- Backward compatible: existing calls without `generator` work identically

## Testing

- Without `generator`: produces random samples as before (default `None` passes through)
- With `generator`: produces reproducible samples seeded by the generator
- Works for both `torch.Tensor` and `TensorList` inputs

---

> Contributed via [definable.ai](https://definable.ai) — @Anandesh-Sharma