### PR TITLE
Suppress printing to stdout when downloading model from the hub

### DIFF
--- a/deepinv/optim/linear/bicgstab.py
+++ b/deepinv/optim/linear/bicgstab.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from .utils import dot
-from deepinv.utils import TensorList, zeros_like
+from deepinv.utils.tensorlist import TensorList, zeros_like
 import torch
 from torch import Tensor
 from typing import Callable

--- a/deepinv/optim/linear/least_squares.py
+++ b/deepinv/optim/linear/least_squares.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from deepinv.utils import zeros_like
+from deepinv.utils.tensorlist import zeros_like
 import torch
 from torch import Tensor
 from torch.autograd.function import once_differentiable

--- a/deepinv/optim/linear/lsqr.py
+++ b/deepinv/optim/linear/lsqr.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import torch
 from torch import Tensor
 from typing import Callable
-from deepinv.utils import TensorList, zeros_like
+from deepinv.utils.tensorlist import TensorList, zeros_like
 from deepinv.utils.compat import zip_strict
 
 

--- a/deepinv/optim/linear/minres.py
+++ b/deepinv/optim/linear/minres.py
@@ -1,6 +1,6 @@
 import torch
 from torch import Tensor
-from deepinv.utils import TensorList
+from deepinv.utils.tensorlist import TensorList
 from .utils import dot
 
 

--- a/deepinv/optim/linear/utils.py
+++ b/deepinv/optim/linear/utils.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from deepinv.utils import TensorList
+from deepinv.utils.tensorlist import TensorList
 from deepinv.utils.compat import zip_strict
 
 

--- a/deepinv/physics/__init__.py
+++ b/deepinv/physics/__init__.py
@@ -7,6 +7,7 @@ from .blur import (
     SpaceVaryingBlur,
     Upsampling,
     DownsamplingMatlab,
+    TiledSpaceVaryingBlur,
 )
 from .scattering import Scattering
 from .range import Decolorize

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -5,8 +5,11 @@ import torchvision
 import torch
 import torch.fft as fft
 from torch import Tensor
+import torch.nn.functional as F
 from deepinv.physics.forward import LinearPhysics, DecomposablePhysics, adjoint_function
 import deepinv.physics.functional as dF
+from deepinv.utils.mixins import TiledMixin2d
+from deepinv.utils._internal import _as_pair, _add_tuple
 
 
 class Downsampling(LinearPhysics):
@@ -414,7 +417,6 @@ class Upsampling(Downsampling):
         device: torch.device | str = "cpu",
         **kwargs,
     ):
-
         assert (
             padding != "valid"
         ), "Padding 'valid' is not supported for Upsampling operator."
@@ -858,6 +860,335 @@ class SpaceVaryingBlur(LinearPhysics):
             self.padding = padding
 
         super().update_parameters(filters=filters, multipliers=multipliers, **kwargs)
+
+
+class TiledSpaceVaryingBlur(TiledMixin2d, LinearPhysics):
+    r"""
+    Space varying blur via tiled-convolution.
+
+    This forward operator performs the space-varying blur using local convolutions on overlapping patches (tiles) of the image.
+    The resulting images is then reconstructed using a smooth blending of the overlapping patches (`blending_mode`).
+
+    Given an input image :math:`x`, this linear operator performs
+
+    .. math::
+
+        y = \sum_{k=1}^K h_k \star (m_k \odot x)
+
+    where :math:`\star` is a convolution, :math:`\odot` is a Hadamard product, :math:`m_k` are binary masks defining the tiles and :math:`h_k` are filters.
+    When the size of the image minus `stride` is not perfectly divisible by the `patch_size`, the image is padded with zeros to fit an integer number of patches and the extra padding is removed afterwards automatically.
+
+    The number of patches (tiles) :math:`K` is determined by the `patch_size` and `stride` parameters: it is the product of the number of patches along each spatial dimension.
+    A helper class method `num_filters(img_size, patch_size, stride)` is provided to compute the number of filters needed for a given image size, patch size and stride.
+
+    .. note::
+
+        For simplicity, we also provide the generator class :class:`deepinv.physics.generator.TiledBlurGenerator` to generate the filters, for example during training.
+
+
+    .. note::
+
+        This class supports both FFT-based convolutions and direct convolutions, see :func:`deepinv.physics.functional.conv2d_fft` and :func:`deepinv.physics.functional.conv2d`.
+        FFT-based convolutions are typically faster for large filters. This can be selected via the `use_fft` parameter (default: `True`).
+
+    .. note::
+
+        This class supports broadcast between of batch and channel dimensions of the filters and the input image.
+        See :func:`deepinv.physics.functional.conv2d` for more details.
+
+
+    :param torch.Tensor filters: Filters :math:`h_k`. Tensor of size `(B, C, K, h, w)` where
+        `B` is the batch size, `C` the number of channels, `K` the number of filters, `h` and `w` the filter height and width which should be smaller or equal than the image :math:`x` height and width respectively.
+        If `None`, filters must be provided during the forward pass.
+    :param str blending_mode: Blending mode for overlapping patches. Options are `'bump'` (default) and `'linear'`.
+    :param int, tuple[int, int] patch_size: Size of the patches (tiles). If `int`, the same size is used for both spatial dimensions.
+
+    |sep|
+
+    .. note::
+
+        This class only supports `'valid'` padding. If you need other padding options, please raise an issue.
+
+    |sep|
+
+    :Examples:
+
+    >>> import torch
+    >>> from deepinv.physics import TiledSpaceVaryingBlur
+    >>> from deepinv.physics.generator import MotionBlurGenerator, TiledBlurGenerator
+    >>> import deepinv as dinv
+    >>> img_size = (256, 256)
+    >>> patch_size = (64, 64)
+    >>> stride = (32, 32)
+    >>> x = dinv.utils.load_example(
+    ...        "butterfly.png", img_size=img_size, resize_mode="resize"
+    ...    )
+    >>> psf_generator = MotionBlurGenerator(psf_size=(31, 31))
+    >>> generator = TiledBlurGenerator(
+    ...     psf_generator=psf_generator,
+    ...     patch_size=patch_size,
+    ...     stride=stride,
+    ... )
+    >>> filters = generator.step(batch_size=1, img_size=img_size)["filters"]
+    >>> physics = TiledSpaceVaryingBlur(patch_size=patch_size, stride=stride)
+    >>> y = physics(x, filters=filters)
+    >>> print(x.shape, y.shape)
+    torch.Size([1, 3, 256, 256]) torch.Size([1, 3, 226, 226])
+    >>> dinv.utils.plot([x, y], titles=["Original", "Blurred"])   # doctest: +SKIP
+    """
+
+    def __init__(
+        self,
+        filters: Tensor = None,
+        patch_size: int | tuple[int, int] = None,
+        stride: int | tuple[int, int] = None,
+        blending_mode: str = "bump",
+        use_fft: bool = True,
+        device: torch.device | str = "cpu",
+        dtype: str | torch.dtype = torch.float32,
+        **kwargs,
+    ):
+        super().__init__(
+            patch_size=patch_size, stride=stride, pad_if_needed=True, **kwargs
+        )
+        # Always use pad_if_needed=True to ensure that the image is padded to fit an integer number of patches, and the extra padding is removed automatically after processing.
+
+        try:
+            from einops import rearrange
+        except ImportError:
+            raise ImportError(
+                "einops is required for TiledSpaceVaryingBlur. Please install it via 'pip install einops'."
+            )
+
+        self.rearrange = rearrange
+        self._dynamic_img_size = None  # To track image size changes
+        self._dynamic_psf_size = (
+            filters.shape[-2:] if filters is not None else None
+        )  # To track psf size changes
+
+        self.use_fft = use_fft
+        self.conv2d_fn = dF.conv2d if not use_fft else dF.conv2d_fft
+        self.conv2d_adjoint_fn = (
+            dF.conv_transpose2d if not use_fft else dF.conv_transpose2d_fft
+        )
+        self.blending_mode = blending_mode
+
+        self.register_buffer("filters", filters)
+        self.register_buffer("multipliers", None)
+        self.to(device=device, dtype=dtype)
+
+    def A(self, x: Tensor, filters: Tensor = None, **kwargs) -> torch.Tensor:
+        r"""
+        Applies the space varying blur operator to the input image.
+
+        :param torch.Tensor x: input image.
+        :param torch.Tensor filters: Filters :math:`h_k`.
+
+        :return: torch.Tensor: Space varying blurred image.
+        """
+        img_size = x.shape[-2:]
+        self.update_parameters(filters, img_size=img_size, device=x.device, **kwargs)
+
+        w = self.multipliers  # (B, C, K, H, W)
+        h = self.filters  # (B, C, K, h, w)
+
+        # Extract patches: (B, C, K1, K2, P1, P2)
+        patches = self.image_to_patches(x)
+
+        n_rows, n_cols = patches.size(2), patches.size(3)
+        if n_rows * n_cols != h.size(2):
+            raise ValueError(
+                f"The total number of patches must be equal to the number of PSFs, "
+                f"got {n_rows * n_cols} and {h.size(2)}"
+            )
+
+        # Flatten K1 and K2 to: (B, C, K, P1, P2)
+        patches = patches.flatten(2, 3)
+        patches = patches * w
+
+        # Pad each patch for local convolution: so that local convolution produce image of same size
+        h_size = h.shape[-2:]
+        pad = self._get_pad(h_size)
+        patches = self._pad(patches, pad)
+
+        # Apply convolution per patch
+        B, C = patches.shape[:2]
+        h = dF.convolution._prepare_filter_for_grouped(h, B=B, C=C)
+
+        result = self.conv2d_fn(
+            self.rearrange(patches, "b c k h w -> (b k) c h w").contiguous(),
+            self.rearrange(h, "b c k h w -> (b k) c h w").contiguous(),
+            padding="valid",
+        )
+        result = self.rearrange(
+            result, "(b k) c h w -> b c k h w", b=patches.size(0), k=h.size(2)
+        )
+
+        B, C, K, H, W = result.size()
+        result = self.patches_to_image(
+            result.view(B, C, n_rows, n_cols, H, W),
+            img_size=img_size,
+        )
+        # Remove pad
+        result = self._crop(result, pad)
+        return result
+
+    def A_adjoint(
+        self,
+        y: Tensor,
+        filters: Tensor = None,
+        **kwargs,
+    ) -> Tensor:
+        r"""
+        Applies the adjoint operator.
+
+        :param torch.Tensor y: blurry image :math:`y`. Tensor of size `(B, C, H', W')`.
+        :param torch.Tensor filters: Filters :math:`h_k`. Tensor of size `(b, c, K, h, w)`.
+
+        :return: torch.Tensor: Adjoint result.
+        """
+        if filters is None:
+            filters = self.filters
+
+        # Infer original image size from y and filters, since the padding is 'valid'
+        h_size = filters.shape[-2:]
+        original_img_size = _add_tuple(y.shape[-2:], _add_tuple(h_size, (-1, -1)))
+
+        self.update_parameters(
+            filters=filters,
+            img_size=original_img_size,
+            device=y.device,
+            dtype=y.dtype,
+            **kwargs,
+        )
+
+        w = self.multipliers  # (B, C, K, H, W)
+        h = self.filters  # (B, C, K, h, w)
+
+        # Pad input
+        pad = self._get_pad(h_size)
+        y = self._pad(y, pad)
+
+        # Extract patches
+        patches = self.image_to_patches(y)
+
+        n_rows, n_cols = patches.size(2), patches.size(3)
+        if n_rows * n_cols != h.size(2):
+            raise ValueError(
+                f"The total number of patches must be equal to the number of PSFs, "
+                f"got {n_rows * n_cols} and {h.size(2)}"
+            )
+
+        # Apply transpose convolution per patch
+        patches = patches.flatten(2, 3)
+        B, C = patches.shape[:2]
+        h = dF.convolution._prepare_filter_for_grouped(h, B=B, C=C)
+
+        result = self.conv2d_adjoint_fn(
+            self.rearrange(patches, "b c k h w -> (b k) c h w").contiguous(),
+            self.rearrange(h, "b c k h w -> (b k) c h w").contiguous(),
+            padding="valid",
+        )
+
+        result = self.rearrange(result, "(b k) c h w -> b c k h w", b=B, k=h.size(2))
+
+        # Remove pad and apply weights
+        result = self._crop(result, pad)
+        result = result * w
+
+        # Reconstruct image using overlapping patches
+        B, C, _, H, W = result.size()
+        return self.patches_to_image(
+            result.view(B, C, n_rows, n_cols, H, W),
+            img_size=original_img_size,
+        )
+
+    def update_parameters(
+        self,
+        filters: Tensor = None,
+        img_size: int | tuple[int, int] = None,
+        device: torch.device = None,
+        dtype: torch.dtype = torch.float32,
+        **kwargs,
+    ):
+        if filters is not None and isinstance(filters, Tensor):
+            self.register_buffer("filters", filters.to(device))
+            self._dynamic_psf_size = filters.shape[-2:]
+
+        # Only generate multipliers if the image size changed
+        if getattr(self, "multipliers", None) is None or (
+            img_size is not None and img_size != self._dynamic_img_size
+        ):
+            multipliers = dF.generate_tiled_multipliers(
+                self.get_compatible_img_size(img_size),
+                self.patch_size,
+                self.stride,
+                mode=self.blending_mode,
+                device=device,
+                dtype=dtype,
+            )
+            self.register_buffer("multipliers", multipliers)
+            self._dynamic_img_size = img_size
+
+        super().update_parameters(**kwargs)
+
+    @staticmethod
+    def num_filters(
+        img_size: tuple[int, int], patch_size: tuple[int, int], stride: tuple[int, int]
+    ) -> tuple[int, int]:
+        r"""
+        Computes the number of filters (tiles) required for a given image size, patch size and stride.
+        Can be used to determine the required number of filters when instantiating the class.
+
+        :param tuple[int, int] img_size: Image size `(H, W)`.
+        :param tuple[int, int] patch_size: Patch size `(h, w)`.
+        :param tuple[int, int] stride: Stride size `(sh, sw)`.
+        :return: Number of filters (tiles) required in each spatial dimension.
+        """
+        img_size = _as_pair(img_size)
+        patch_size = _as_pair(patch_size)
+        stride = _as_pair(stride)
+
+        # Using the same logic as in TiledMixin2d, but a static method here to help users compute the number of filters needed beforehand
+        num = [(i - p) // s + 1 for i, p, s in zip(img_size, patch_size, stride)]
+        pad = [
+            (p + n * s - i) % s for p, n, s, i in zip(patch_size, num, stride, img_size)
+        ]
+        compatible_size = _add_tuple(img_size, pad)
+        n_h = (compatible_size[0] - patch_size[0]) // stride[0] + 1
+        n_w = (compatible_size[1] - patch_size[1]) // stride[1] + 1
+
+        return n_h, n_w
+
+    @staticmethod
+    def _get_pad(filter_size: tuple[int, int]) -> tuple[int, int]:
+        r"""
+        Computes padding from the filters size: (left, right, top, bottom).
+        """
+        h, w = filter_size
+
+        left = w // 2
+        right = w - left - 1
+        top = h // 2
+        bottom = h - top - 1
+        return (left, right, top, bottom)
+
+    @staticmethod
+    def _pad(x: Tensor, pad: tuple[int, int, int, int]) -> Tensor:
+        r"""
+        Pads the input tensor `x` with padding `pad`, in the order (left, right, top, bottom).
+        """
+        return F.pad(x, pad=pad, mode="constant", value=0)
+
+    @staticmethod
+    def _crop(x: Tensor, pad: tuple[int, int, int, int]) -> Tensor:
+        r"""
+        Removes padding from the input tensor `x` with padding `pad`, in the order (left, right, top, bottom).
+        """
+        left, right, top, bottom = pad
+        h_slice = slice(top, -bottom if bottom > 0 else None)  # top, bottom
+        w_slice = slice(left, -right if right > 0 else None)  # left, right
+        return x[..., h_slice, w_slice]
 
 
 def gaussian_blur(

--- a/deepinv/physics/functional/__init__.py
+++ b/deepinv/physics/functional/__init__.py
@@ -12,6 +12,9 @@ from .convolution import (
 )
 
 from .product_convolution import product_convolution2d, product_convolution2d_adjoint
+from .tiled_product_convolution import (
+    generate_tiled_multipliers,
+)
 
 from .multiplier import (
     multiplier,

--- a/deepinv/physics/functional/tiled_product_convolution.py
+++ b/deepinv/physics/functional/tiled_product_convolution.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Literal
+from torch import Tensor
+import torch
+from deepinv.utils._internal import _as_pair, _add_tuple
+
+
+def _unity_partition_function_1d(
+    image_size: int,
+    patch_size: int,
+    overlap: int,
+    mode: Literal["bump", "linear"] = "bump",
+    device="cpu",
+    dtype=torch.float32,
+) -> Tensor:
+    r"""Create a 1D unity partition function for smooth patch blending.
+
+    Creates masks that sum to 1 across all patches, enabling smooth blending
+    in overlap regions. The function is 1 on [-a, a] and decreases to 0 on
+    -(a+b) and (a+b), where a = patch_size/2 - overlap and b = overlap.
+
+    :param int image_size: Size of the image dimension.
+    :param int patch_size: Size of each patch.
+    :param int overlap: Overlap between adjacent patches.
+    :param str mode: Blending mode - 'bump' (smooth) or 'linear'.
+    :return: Tensor of shape (n_patches, max_size) with partition masks.
+    """
+    n_patch = (image_size - patch_size) // (patch_size - overlap) + 1
+    max_size = patch_size + (n_patch - 1) * (patch_size - overlap)
+    t = torch.linspace(
+        -max_size // 2, max_size // 2, max_size, device=device, dtype=dtype
+    )
+
+    if mode.lower() == "bump":
+        from deepinv.physics.generator.blur import bump_function
+
+        mask = bump_function(t, patch_size / 2 - overlap, overlap).roll(
+            shifts=-max_size // 2 + patch_size // 2
+        )
+    elif mode.lower() == "linear":
+        a = patch_size / 2 - overlap
+        b = overlap
+        mask = ((a + b) / b - t.abs().clip(0, a + b) / b).abs().clip(0, 1)
+        mask = mask.roll(shifts=-max_size // 2 + patch_size // 2)
+    else:
+        raise ValueError(f"Unknown mode: {mode}. Use 'bump' or 'linear'.")
+
+    # Create masks for each patch
+    masks = torch.stack(
+        [mask.roll(shifts=(patch_size - overlap) * i) for i in range(n_patch)], dim=0
+    )
+
+    # Handle boundary patches
+    masks[0, :overlap] = 1.0
+    masks[-1, -overlap:] = 1.0
+
+    # Normalize to sum to 1
+    masks = masks / (masks.sum(dim=0, keepdims=True) + 1e-8)
+    return masks
+
+
+def _crop_unity_partition_2d(
+    masks: Tensor,
+    patch_size: tuple[int, int],
+    stride: tuple[int, int],
+) -> Tensor:
+    r"""
+    Crop unity partition masks to patch regions.
+
+    Extracts the relevant portion of each partition mask corresponding to
+    its patch location.
+    """
+
+    n_rows, n_cols = masks.size(0), masks.size(1)
+
+    # Create grid indices for vectorized extraction
+    row_idx = torch.arange(n_rows, device=masks.device)
+    col_idx = torch.arange(n_cols, device=masks.device)
+    h_starts = row_idx * stride[0]
+    w_starts = col_idx * stride[1]
+
+    # Extract cropped masks using unfold for efficiency
+    # Reshape masks from (K_h, K_w, H, W) to process each patch location
+    cropped_masks = torch.zeros(
+        n_rows,
+        n_cols,
+        patch_size[0],
+        patch_size[1],
+        device=masks.device,
+        dtype=masks.dtype,
+    )
+    for i in range(n_rows):
+        for j in range(n_cols):
+            h_start, w_start = int(h_starts[i]), int(w_starts[j])
+            cropped_masks[i, j] = masks[
+                i,
+                j,
+                h_start : h_start + patch_size[0],
+                w_start : w_start + patch_size[1],
+            ]
+
+    return cropped_masks
+
+
+def generate_tiled_multipliers(
+    img_size: int | tuple[int, int],
+    patch_size: int | tuple[int, int],
+    stride: int | tuple[int, int],
+    mode: Literal["bump", "linear"] = "bump",
+    device="cpu",
+    dtype=torch.float32,
+) -> Tensor:
+    r"""
+    Generate tiled multipliers for patch blending.
+
+    It is used in tiled product convolution, see :class:`deepinv.physics.TiledSpaceVaryingBlur` to smoothly blend overlapping patches.
+
+    :param img_size: Size of the image (height, width) or single `int` for square images.
+    :param patch_size: Size of each patch (height, width) or single `int` for square patches.
+    :param stride: Stride between adjacent patches (height, width). If a single `int` is provided, it is used for both dimensions.
+    :param mode: Blending mode - `'bump'` (smooth) or `'linear'`.
+    :return: Tensor of shape `(1, 1, K, H, W)` with multipliers for each patch.
+    """
+    img_size = _as_pair(img_size)
+    patch_size = _as_pair(patch_size)
+    stride = _as_pair(stride)
+    overlap = _add_tuple(patch_size, stride, -1)
+
+    masks_x = _unity_partition_function_1d(
+        img_size[0], patch_size[0], overlap[0], mode, device=device, dtype=dtype
+    )
+    masks_y = _unity_partition_function_1d(
+        img_size[1], patch_size[1], overlap[1], mode, device=device, dtype=dtype
+    )
+
+    # Combine 1D masks into 2D via outer product
+    masks = torch.tensordot(masks_x, masks_y, dims=0)
+    masks = masks.permute(0, 2, 1, 3)
+
+    # Normalize to sum to 1
+    masks = masks / (masks.sum(dim=(0, 1), keepdims=True) + 1e-8)
+
+    w = _crop_unity_partition_2d(masks, patch_size, stride)
+    return w.flatten(0, 1).unsqueeze(0).unsqueeze(0)

--- a/deepinv/physics/generator/__init__.py
+++ b/deepinv/physics/generator/__init__.py
@@ -7,6 +7,7 @@ from .blur import (
     DiffractionBlurGenerator3D,
     ConfocalBlurGenerator3D,
     bump_function,
+    TiledBlurGenerator,
 )
 from .mri import (
     BaseMaskGenerator,

--- a/deepinv/physics/generator/blur.py
+++ b/deepinv/physics/generator/blur.py
@@ -3,10 +3,12 @@ import torch
 import numpy as np
 from math import ceil, floor
 from deepinv.physics.generator import PhysicsGenerator
-from deepinv.physics.functional import histogramdd, conv2d
+from deepinv.physics.functional.hist import histogramdd
+from deepinv.physics.functional.convolution import conv2d
 from deepinv.physics.functional.interp import ThinPlateSpline
 from deepinv.utils.decorators import _deprecated_alias
 from deepinv.transform.rotate import rotate_via_shear
+from deepinv.utils.mixins import TiledMixin2d
 from .zernike import Zernike
 
 
@@ -1104,3 +1106,68 @@ class ConfocalBlurGenerator3D(PSFGenerator):
         List of Zernike polynomials used in the decomposition, with the corresponding aberration if available.
         """
         return self.generator_ill.zernike_polynomials
+
+
+class TiledBlurGenerator(TiledMixin2d, PSFGenerator):
+    r"""
+    Generates parameters of the :class:`deepinv.physics.TiledSpaceVaryingBlur` operator.
+    The image is divided into overlapping patches, each local patch is convolved with a different PSF.
+
+    This generates a dict with key `'filter'`, which is tensor of shape `(B, C, K, psf_size, psf_size)`
+    where `K` is the number of patches in which the image is divided.
+    It is computed based on the `patch_size`, `stride` and the given `img_size` during the `step()` function call.
+
+    :param deepinv.physics.generator.PSFGenerator psf_generator: A PSF generator, such as :class:`motion blur <deepinv.physics.generator.MotionBlurGenerator>` or :class:`diffraction blur generator <deepinv.physics.generator.DiffractionBlurGenerator>`.
+
+    :param int | tuple[int, int] patch_size: size of the patches (height, width) in which the image is divided.
+    :param int | tuple[int, int] stride: stride between adjacent patches (height, width). Defaults to `patch_size`.
+    """
+
+    def __init__(
+        self,
+        psf_generator: PSFGenerator,
+        patch_size: int | tuple[int, int],
+        stride: int | tuple[int, int] = None,
+        rng: torch.Generator = None,
+        device: str | torch.device = "cpu",
+        **kwargs,
+    ):
+        super().__init__(
+            patch_size=patch_size, stride=stride, rng=rng, device=device, **kwargs
+        )
+        self.psf_generator = psf_generator
+        self.psf_size = psf_generator.psf_size
+
+    def step(
+        self,
+        batch_size: int = 1,
+        img_size: int | tuple[int, int] = None,
+        seed: int | None = None,
+        **kwargs,
+    ) -> dict:
+        r"""
+        Generates a random set of filters for the tiled space-varying blur.
+
+        :param int batch_size: batch size of the PSF parameters to generate. Should be equal to the batch size of the images to be blurred.
+        :param int | tuple[int, int] img_size: size of the image to be blurred (height, width).
+        :param int | None seed: the seed for the random number generator.
+
+        :returns: a dictionary containing filters, with key:
+
+            - `filters`: a tensor of shape `(B, C, K, psf_size, psf_size)`, where `K` is the number of patches in which the image is divided.
+
+        """
+
+        num_patches = self.get_num_patches(img_size=img_size)
+        num_patches = num_patches[0] * num_patches[1]
+
+        params = self.psf_generator.step(
+            batch_size=batch_size * num_patches, seed=seed, **kwargs
+        )
+        psf = (
+            params["filter"]
+            .view(batch_size, num_patches, -1, *self.psf_size)
+            .transpose(1, 2)
+        )  # B x C x num_patches x psf_size x psf_size
+
+        return dict(filters=psf)

--- a/deepinv/physics/generator/downsampling.py
+++ b/deepinv/physics/generator/downsampling.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import torch
 from deepinv.physics.generator import PhysicsGenerator
-from deepinv.physics.blur import gaussian_blur, bilinear_filter, bicubic_filter
 from deepinv.utils.compat import zip_strict
 
 
@@ -58,6 +57,8 @@ class DownsamplingGenerator(PhysicsGenerator):
         r"""
         Returns the filter associated to a given filter name and factor.
         """
+        from deepinv.physics.blur import gaussian_blur, bilinear_filter, bicubic_filter
+
         if filter_name == "gaussian":
             filter = torch.nn.Parameter(
                 gaussian_blur(sigma=(factor, factor)), requires_grad=False

--- a/deepinv/physics/generator/inpainting.py
+++ b/deepinv/physics/generator/inpainting.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from warnings import warn
 import torch
 from deepinv.physics.generator.base import PhysicsGenerator
-from deepinv.physics.functional import random_choice
+from deepinv.physics.functional.rand import random_choice
 from deepinv.utils.decorators import _deprecated_alias
 
 if TYPE_CHECKING:

--- a/deepinv/physics/generator/mri.py
+++ b/deepinv/physics/generator/mri.py
@@ -5,7 +5,7 @@ import warnings
 import torch
 
 from deepinv.physics.generator import PhysicsGenerator
-from deepinv.physics.functional import random_choice
+from deepinv.physics.functional.rand import random_choice
 
 
 def ceildiv(a: float, b: float) -> float:

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -5,8 +5,6 @@ import copy
 from math import sqrt
 import pytest
 import warnings
-import random
-
 import torch
 
 import numpy as np
@@ -42,6 +40,7 @@ OPERATORS = [
     "space_deblur_reflect",
     "space_deblur_replicate",
     "space_deblur_constant",
+    "tiled_space_deblur_valid",
     "hyperspectral_unmixing",
     "3Ddeblur_valid",
     "3Ddeblur_circular",
@@ -387,6 +386,25 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
             device=device,
         )
         params = ["filters", "multipliers"]
+    elif name == "tiled_space_deblur_valid":
+        img_size = (3, 20, 13) if imsize is None else imsize
+        h = dinv.physics.blur.bilinear_filter(factor=2).to(device)
+        h = h.unsqueeze(2)  # shape (1,1,1,Hf,Wf)
+        num_filters = dinv.physics.TiledSpaceVaryingBlur.num_filters(
+            img_size=img_size[-2:],
+            patch_size=(8, 5),
+            stride=(4, 3),
+        )
+        h = h.repeat(1, 3, num_filters[0] * num_filters[1], 1, 1)  # shape (1,3,K,Hf,Wf)
+        p = dinv.physics.TiledSpaceVaryingBlur(
+            filters=h,
+            patch_size=(8, 5),
+            stride=(4, 3),
+            device=device,
+        )
+
+        params = ["filters", "multipliers"]
+
     elif name == "hyperspectral_unmixing":
         img_size = (15, 32, 32) if imsize is None else imsize  # x (E, H, W)
         p = dinv.physics.HyperSpectralUnmixing(E=15, C=64, device=device)
@@ -2447,19 +2465,54 @@ def test_scattering_mie(device, wavenumber, contrast, wave_type):
     ).abs().mean() < 1e-1, "theoretical and empirical total fields do not match"
 
 
-@pytest.mark.parametrize("seed", [0])
-def test_squared_or_non_squared_norms(seed, device):
-    random.seed(seed)
-    name = random.choice(OPERATORS)
+def test_squared_or_non_squared_norms(device):
+    name = "fftdeblur"
     physics, imsize, _, dtype = find_operator(name, device)
-
-    rng = torch.Generator(device).manual_seed(seed)
+    rng = torch.Generator(device)
     x = torch.randn(imsize, device=device, dtype=dtype, generator=rng).unsqueeze(0)
-    sqnorm1 = physics.compute_sqnorm(x, max_iter=1, tol=1e-9)
-    norm = physics.compute_norm(x, max_iter=1, tol=1e-9, squared=False)
+    sqnorm1 = physics.compute_sqnorm(x, max_iter=1000, tol=1e-9)
+    norm = physics.compute_norm(x, max_iter=1000, tol=1e-9, squared=False)
 
     with pytest.warns(DeprecationWarning, match="compute_sqnorm"):
-        sqnorm2 = physics.compute_norm(x, max_iter=1, tol=1e-9, squared=True)
+        sqnorm2 = physics.compute_norm(x, max_iter=1000, tol=1e-9, squared=True)
 
-    assert torch.allclose(sqnorm1, sqnorm2, rtol=1e-5), "squared norms do not match"
-    assert torch.allclose(sqnorm1, norm**2, rtol=1e-5), "norms do not match"
+    assert torch.allclose(sqnorm1, sqnorm2, rtol=1e-4), "squared norms do not match"
+    assert torch.allclose(sqnorm1, norm**2, rtol=1e-4), "norms do not match"
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("n_channels", [1, 3])
+@pytest.mark.parametrize("img_size", [(32, 32), (33, 33), (32, 33)])
+@pytest.mark.parametrize("patch_size", [8, 9, (8, 9)])
+@pytest.mark.parametrize("stride", [4, 5, (4, 5)])
+@pytest.mark.parametrize("psf_size", [(5, 5), (6, 6), (5, 6)])
+@pytest.mark.parametrize("use_fft", [False, True])
+def test_tiled_product_physics_adjointness(
+    batch_size, n_channels, img_size, patch_size, psf_size, stride, use_fft, device
+):
+    from deepinv.physics.blur import TiledSpaceVaryingBlur
+
+    x = torch.randn(batch_size, n_channels, *img_size).to(device)
+
+    n_filters = TiledSpaceVaryingBlur.num_filters(
+        img_size=img_size, patch_size=patch_size, stride=stride
+    )
+    h = torch.rand(1, n_channels, n_filters[0] * n_filters[1], *psf_size).to(device)
+
+    physics = TiledSpaceVaryingBlur(
+        filters=h,
+        patch_size=patch_size,
+        stride=stride,
+        use_fft=use_fft,
+        device=device,
+    )
+
+    Ax = physics.A(x)
+    y = torch.randn_like(Ax)
+    Aty = physics.A_adjoint(y)
+
+    lhs = torch.sum(Ax * y)
+    rhs = torch.sum(Aty * x)
+    assert torch.abs(lhs - rhs) < 1e-3 * max(
+        torch.abs(lhs), torch.abs(rhs)
+    )  # relative tolerance

--- a/deepinv/utils/__init__.py
+++ b/deepinv/utils/__init__.py
@@ -45,7 +45,7 @@ from .phantoms import RandomPhantomDataset, SheppLoganDataset
 from .patch_extractor import patch_extractor
 from .parameters import get_GSPnP_params
 from .signals import normalize_signal, complex_abs
-from .mixins import TimeMixin, MRIMixin
+from .mixins import TimeMixin, MRIMixin, TiledMixin2d
 from .compat import zip_strict
 from .io import (
     load_dicom,

--- a/deepinv/utils/_internal.py
+++ b/deepinv/utils/_internal.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+
+def _add_tuple(a: tuple, b: tuple, constant: float = 1) -> tuple:
+    """Add two tuples element-wise with optional scaling of second tuple.
+    It computes: output[i] = a[i] + b[i] * constant
+    """
+    if len(a) != len(b):
+        raise ValueError("Input tuples must have the same length")
+    return tuple(a[i] + constant * b[i] for i in range(len(a)))
+
+
+def _as_pair(value: int | float | tuple | list) -> tuple[int, int]:
+    """Ensure value is a 2-tuple."""
+    if isinstance(value, (int, float)):
+        return (value, value)
+    elif isinstance(value, (tuple, list)):
+        if len(value) >= 2:
+            return tuple(value[-2:])
+        else:
+            raise ValueError("Tuple/list must have at least 2 elements.")
+    else:
+        raise TypeError(
+            f"Expected int, float, or tuple/list, got {type(value).__name__}"
+        )

--- a/deepinv/utils/mixins.py
+++ b/deepinv/utils/mixins.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from typing import Callable
 import numpy as np
 import torch
 from torch import Tensor, zeros_like
 from torch.nn import Module
 from torchvision.transforms import CenterCrop, Resize
+import torch.nn.functional as F
 from deepinv.utils.decorators import _deprecated_argument
+from ._internal import _as_pair, _add_tuple
 
 
 class TimeMixin:
@@ -276,3 +280,232 @@ class MRIMixin:
             ss = ss.sum(dim=2)
 
         return ss.sqrt()
+
+
+class TiledMixin2d:
+    r"""
+    Mixin base class for 2D tiled patch extraction and reconstruction.
+    Provides methods to extract overlapping patches from images and reconstruct images from patches.
+
+    It also handles padding if necessary to ensure all patches have the same size.
+    The patch extraction and reconstruction are implemented using PyTorch's unfold and fold operations for efficiency.
+
+    :param int | tuple[int, int] patch_size: Size of each patch (height, width) or single `int` for square patches.
+    :param int | tuple[int, int] stride: Stride between adjacent patches (height, width). If a single `int` is provided, it is used for both dimensions. Defaults to half the patch size.
+    :param bool pad_if_needed: If `True`, the image will be padded if necessary to ensure all patches have the same size. Defaults to `True`.
+
+    |sep|
+
+    The following example demonstrates how to use the `TiledMixin2d` to extract patches from an image and reconstruct the image from those patches.
+
+    :Examples:
+
+        >>> import torch
+        >>> from deepinv.utils.mixins import TiledMixin2d
+        >>> # Create an image of shape (B, C, H, W)
+        >>> B, C, H, W = 1, 1, 5, 5
+        >>> image = torch.arange(B * C * H * W, dtype=torch.float32).reshape(B, C, H, W)
+        >>> print(image)
+        tensor([[[[ 0.,  1.,  2.,  3.,  4.],
+                  [ 5.,  6.,  7.,  8.,  9.],
+                  [10., 11., 12., 13., 14.],
+                  [15., 16., 17., 18., 19.],
+                  [20., 21., 22., 23., 24.]]]])
+
+        >>> # Initialize the TiledMixin2d with patch size and stride
+        >>> patch_size = (3, 3)
+        >>> stride = (2, 2)
+        >>> tiled_mixin = TiledMixin2d(patch_size=patch_size, stride=stride)
+
+        >>> # Extract patches from the image
+        >>> patches = tiled_mixin.image_to_patches(image)
+        >>> print("Extracted Patches Shape:", patches.shape)
+        Extracted Patches Shape: torch.Size([1, 1, 2, 2, 3, 3])
+        >>> print(patches[..., 0, 0, :, :]) # Print the first patch for verification
+        tensor([[[[ 0.,  1.,  2.],
+                  [ 5.,  6.,  7.],
+                  [10., 11., 12.]]]])
+
+        >>> # Reconstruct the image from the patches
+        >>> reconstructed_image = tiled_mixin.patches_to_image(patches, img_size=(H, W))
+        >>> print("Reconstructed Image Shape:", reconstructed_image.shape)
+        Reconstructed Image Shape: torch.Size([1, 1, 5, 5])
+        >>> print(reconstructed_image)
+        tensor([[[[ 0.,  1.,  4.,  3.,  4.],
+                  [ 5.,  6., 14.,  8.,  9.],
+                  [20., 22., 48., 26., 28.],
+                  [15., 16., 34., 18., 19.],
+                  [20., 21., 44., 23., 24.]]]])
+        >>> # Note that by default, the reconstructed image is not necessarily equal to the original image due to overlapping regions being summed. Setting `reduce_overlap="mean"` in `patches_to_image` will average the overlapping regions instead of summing, which can give a closer reconstruction to the original image.
+        >>> reconstructed_image_mean = tiled_mixin.patches_to_image(patches, img_size=(H, W), reduce_overlap="mean")
+        >>> print(reconstructed_image_mean)
+        tensor([[[[ 0.,  1.,  2.,  3.,  4.],
+                  [ 5.,  6.,  7.,  8.,  9.],
+                  [10., 11., 12., 13., 14.],
+                  [15., 16., 17., 18., 19.],
+                  [20., 21., 22., 23., 24.]]]])
+    """
+
+    def __init__(
+        self,
+        patch_size: int | tuple[int, ...],
+        stride: int | tuple[int, ...] = None,
+        pad_if_needed: bool = True,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.patch_size = _as_pair(patch_size)
+        self.stride = (
+            _as_pair(stride)
+            if stride is not None
+            else tuple(p // 2 for p in self.patch_size)
+        )
+
+        if self.stride[0] > self.patch_size[0] or self.stride[1] > self.patch_size[1]:
+            raise ValueError(
+                f"Stride {self.stride} must be smaller or equal than patch_size {self.patch_size}."
+            )
+
+        self.pad_if_needed = pad_if_needed
+
+    def image_to_patches(self, image: Tensor) -> Tensor:
+        r"""
+        Split an image into overlapping patches.
+
+        The image will be padded if necessary to ensure all patches have the same size.
+
+        :param torch.Tensor image: Input image tensor of shape `(B, C, H, W)`.
+        :return: Patches tensor of shape `(B, C, n_rows, n_cols, patch_h, patch_w)`.
+        """
+        patch_size = self.patch_size
+        stride = self.stride
+
+        img_size = image.shape[-2:]
+
+        # Pad image if necessary for even patch extraction
+        if self.pad_if_needed:
+            pad_h, pad_w = self.get_needed_pad(img_size)
+            if pad_h > 0 or pad_w > 0:
+                image = F.pad(image, (0, pad_w, 0, pad_h), mode="constant", value=0)
+
+        # Extract patches using unfold
+        patches = image.unfold(2, patch_size[0], stride[0]).unfold(
+            3, patch_size[1], stride[1]
+        )
+        return patches.contiguous()
+
+    def patches_to_image(
+        self,
+        patches: Tensor,
+        img_size: tuple[int, int] | None = None,
+        reduce_overlap: str = "sum",
+    ) -> Tensor:
+        r"""
+        Reconstruct an image from overlapping patches.
+
+        This is the inverse operation of `image_to_patches`. Note that overlapping
+        regions are summed. So the reconstructed image is not necessarily equal to the original image.
+
+        :param torch.Tensor patches: Patches tensor of shape `(B, C, n_rows, n_cols, patch_h, patch_w)`.
+        :param img_size: Target output size (height, width). If provided, output is cropped to this size from the top-left corner.
+        :param reduce_overlap: How to handle overlapping regions. Options are `"sum"` or `"mean"`.
+
+        :return: Reconstructed image tensor of shape `(B, C, H, W)`.
+        """
+        if not reduce_overlap in ["sum", "mean"]:
+            raise ValueError(
+                f"Invalid reduce_overlap option: {reduce_overlap}. Must be 'sum' or 'mean'."
+            )
+
+        stride = self.stride
+
+        B, C, num_patches_h, num_patches_w, h, w = patches.size()
+
+        output_size = (
+            h + (num_patches_h - 1) * stride[0],
+            w + (num_patches_w - 1) * stride[1],
+        )
+
+        # Reshape: (B, C, n_h, n_w, h, w) -> (B, n_h*n_w, C, h, w) -> (B, C*h*w, n_h*n_w)
+        num_patches = num_patches_h * num_patches_w
+        patches = (
+            patches.permute(0, 2, 3, 1, 4, 5).contiguous().view(B, num_patches, C, h, w)
+        )
+        patches = patches.view(B, num_patches, C * h * w).permute(0, 2, 1)
+
+        # Fold patches back into image
+        output = F.fold(
+            patches,
+            output_size=output_size,
+            kernel_size=(h, w),
+            stride=stride,
+        )
+
+        if reduce_overlap == "mean":
+            # Create a mask of ones with the same shape as patches to count overlaps
+            mask = torch.ones_like(patches)
+            overlap_count = F.fold(
+                mask,
+                output_size=output_size,
+                kernel_size=(h, w),
+                stride=stride,
+            ).clamp_min_(1)
+            # Average overlapping regions
+            output = output / overlap_count
+
+        # Crop to target size if specified
+        if img_size is not None:
+            img_size = _as_pair(img_size)
+            output = output[:, :, : img_size[0], : img_size[1]]
+
+        return output.contiguous()
+
+    def get_needed_pad(self, img_size: tuple[int, int]) -> tuple[int, int]:
+        """
+        Get required padding.
+
+        :param img_size: Original image size (height, width).
+        :return: Tuple of (compatible_size, padding).
+        """
+        # Compute number of maximum patches that can fit without padding
+        # Note that this number of patches can be not sufficient to cover the whole image, which is why we need padding
+        n_h = abs(img_size[0] - self.patch_size[0]) // self.stride[0] + 1
+        n_w = abs(img_size[1] - self.patch_size[1]) // self.stride[1] + 1
+
+        # Compute required padding to fit an integer number of patches
+        pad_h = (self.patch_size[0] + n_h * self.stride[0] - img_size[0]) % self.stride[
+            0
+        ]
+        pad_w = (self.patch_size[1] + n_w * self.stride[1] - img_size[1]) % self.stride[
+            1
+        ]
+
+        return pad_h, pad_w
+
+    def get_compatible_img_size(self, img_size: tuple[int, int]) -> tuple[int, int]:
+        """
+        Get compatible image size for patch extraction.
+
+        :param img_size: Original image size (height, width).
+        :return: Compatible image size (height, width).
+        """
+        return _add_tuple(img_size, self.get_needed_pad(img_size))
+
+    def get_num_patches(self, img_size: tuple[int, int]) -> tuple[int, int]:
+        """
+        Get number of patches along height and width.
+            - If `pad_if_needed` is `True`, this will return the number of patches that can be extracted after padding the image to a compatible size.
+            - If `pad_if_needed` is `False`, this will return the number of patches that can be extracted without padding, which may not cover the whole image.
+
+        :param img_size: Image size (height, width).
+        :return: Number of patches (n_h, n_w).
+        """
+        if self.pad_if_needed:
+            compatible_size = self.get_compatible_img_size(img_size)
+        else:
+            compatible_size = img_size
+
+        n_h = (compatible_size[0] - self.patch_size[0]) // self.stride[0] + 1
+        n_w = (compatible_size[1] - self.patch_size[1]) // self.stride[1] + 1
+        return n_h, n_w

--- a/docs/source/api/deepinv.physics.rst
+++ b/docs/source/api/deepinv.physics.rst
@@ -41,6 +41,7 @@ Operators
    deepinv.physics.Blur
    deepinv.physics.BlurFFT
    deepinv.physics.SpaceVaryingBlur
+   deepinv.physics.TiledSpaceVaryingBlur
    deepinv.physics.Downsampling
    deepinv.physics.Upsampling
    deepinv.physics.DownsamplingMatlab
@@ -90,6 +91,7 @@ Generators
    deepinv.physics.generator.DiffractionBlurGenerator
    deepinv.physics.generator.DiffractionBlurGenerator3D
    deepinv.physics.generator.ProductConvolutionBlurGenerator
+   deepinv.physics.generator.TiledBlurGenerator
    deepinv.physics.generator.ConfocalBlurGenerator3D
    deepinv.physics.generator.Zernike
    deepinv.physics.generator.BaseMaskGenerator

--- a/docs/source/api/deepinv.utils.rst
+++ b/docs/source/api/deepinv.utils.rst
@@ -71,6 +71,7 @@ Mixins
 
         deepinv.utils.MRIMixin
         deepinv.utils.TimeMixin
+        deepinv.utils.TiledMixin2d
 
 Image Loading
 -------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,7 @@ New Features
 - Add distributed computing framework with :class:`deepinv.distributed.DistributedContext`, :class:`deepinv.distributed.DistributedStackedPhysics`, :class:`deepinv.distributed.DistributedProcessing`, :class:`deepinv.distributed.DistributedDataFidelity` and :func:`deepinv.distributed.distribute` factory function. Supports multi-GPU/multi-process execution with physics-based and spatial tiling distribution strategies (:gh:`790`` by `Benoît Malézieux`_)
 - Add :class:`deepinv.loss.metric.CosineSimilarity` to the metrics (:gh:`944` by `Avithal Lautman`_)
 - New option to initialize 3D networks (DRUNet, DnCNN, DScCP) from pretrained 2D weights (:gh:`958` by `Romain Vo`_)
+- Add :class:`deepinv.physics.TiledSpaceVaryingBlur` physics and :class:`deepinv.physics.generator.TiledBlurGenerator` (:gh:`1033` by `Minh Hai Nguyen`_ and `Paul Escande`_)
 
 Changed
 ^^^^^^^
@@ -577,3 +578,4 @@ Changed
 .. _Thomas Boulanger: https://github.com/LeRatonLaveurSolitaire
 .. _Tiberiu Sabau: https://github.com/tibisabau
 .. _Benoît Malézieux: https://github.com/bmalezieux
+.. _Paul Escande: https://pescande.perso.math.cnrs.fr/

--- a/docs/source/user_guide/other/utils.rst
+++ b/docs/source/user_guide/other/utils.rst
@@ -183,3 +183,6 @@ such as temporal or MRI functionality.
 
    * - :class:`deepinv.utils.TimeMixin`
      - Methods for expanding and flattening time dimension for dynamic/video data.
+
+   * - :class:`deepinv.utils.TiledMixin2d`
+     - Methods for extracting and merging tiles for 2D images.

--- a/docs/source/user_guide/physics/physics.rst
+++ b/docs/source/user_guide/physics/physics.rst
@@ -44,6 +44,7 @@ This is particular useful when dealing with blind inverse problems or parameter 
        | :class:`deepinv.physics.Blur`
        | :class:`deepinv.physics.BlurFFT`
        | :class:`deepinv.physics.SpaceVaryingBlur`
+       | :class:`deepinv.physics.TiledSpaceVaryingBlur`
        | :class:`deepinv.physics.Downsampling`
        | :class:`deepinv.physics.Upsampling`
        | :class:`deepinv.physics.DownsamplingMatlab`
@@ -52,6 +53,7 @@ This is particular useful when dealing with blind inverse problems or parameter 
        | :class:`DownsamplingGenerator <deepinv.physics.generator.DownsamplingGenerator>`
        | :class:`DiffractionBlurGenerator <deepinv.physics.generator.DiffractionBlurGenerator>`
        | :class:`ProductConvolutionBlurGenerator <deepinv.physics.generator.ProductConvolutionBlurGenerator>`
+       | :class:`TiledBlurGenerator <deepinv.physics.generator.TiledBlurGenerator>`
        | :class:`ConfocalBlurGenerator3D <deepinv.physics.generator.ConfocalBlurGenerator3D>`
        | :class:`gaussian_blur <deepinv.physics.blur.gaussian_blur>`, :class:`sinc_filter <deepinv.physics.blur.sinc_filter>`
        | :class:`bilinear_filter <deepinv.physics.blur.bilinear_filter>`, :class:`bicubic_filter <deepinv.physics.blur.bicubic_filter>`


### PR DESCRIPTION
Add an env variable `DEEPINV_DOWNLOAD_VERBOSE` that suppresses all printing when using `load_state_dict_from_url`

Thank you for contributing to DeepInverse!

Please refer to our [contributing guidelines](https://deepinv.github.io/deepinv/contributing.html) for full instructions on how to contribute, including writing tests, documentation and code style.

Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/documentation.yml). Look for the workflow run corresponding to your pull request.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
