### PR TITLE
FIX CI - Update transformers dependency version to 5.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ denoisers = [
     "astra-toolbox>=2.2.0,!=2.3.0; platform_system=='Linux'",
     "spyrit>=3.0.0; platform_system=='Linux'",
     "diffusers>=0.37.0",
-    "transformers>=4.46.0"
+    "transformers>=4.46.0",
     "numba>=0.60.0",
 ]
 


### PR DESCRIPTION
update `transformers` version to fix CI


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
