### PR TITLE
docs: add Jin et al. 2017 reference for UNet design

### DIFF
--- a/deepinv/models/unet.py
+++ b/deepinv/models/unet.py
@@ -14,8 +14,8 @@ class UNet(Denoiser):
     r"""
     U-Net convolutional denoiser.
 
-    This network is a fully convolutional denoiser based on the U-Net architecture. The number of stages in the network is
-    controlled by ``scales``. The width of each stage is controlled by ``channels_per_scale``,
+    This network is a fully convolutional denoiser based on the U-Net architecture from :footcite:t:`jin2017deep`.
+    The number of stages in the network is controlled by ``scales``. The width of each stage is controlled by ``channels_per_scale``,
     which gives the number of feature maps at each stage, from shallow to deeper stages.
     The number of trainable parameters increases with both ``scales`` and the values in ``channels_per_scale``.
 
@@ -23,6 +23,13 @@ class UNet(Denoiser):
     ``channels_per_scale=[64, 128, 256, 512]``. If only ``scales`` is specified, ``channels_per_scale=[64 * (2**k) for k in range(scales)]``.
     When both are specified, ``scales`` must match the length of ``channels_per_scale``.
 
+    .. note::
+        This UNet implementation follows the design from :footcite:t:`jin2017deep`, which differs from the original
+        medical segmentation UNet :footcite:t:`ronneberger2015u` in several ways:
+        
+        - Use of zero padding instead of valid padding
+        - Introduction of a global residual connection
+        - Designed for inverse problems in imaging rather than medical segmentation
 
     .. warning::
         When using the bias-free batch norm via ``batch_norm="biasfree"``, NaNs may be encountered

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1253,3 +1253,12 @@ journal = {ACM Trans. Graph.}
  year={1998},
  pages={839-846},
 }
+
+@inproceedings{ronneberger2015u,
+  title={U-net: Convolutional networks for biomedical image segmentation},
+  author={Ronneberger, Olaf and Fischer, Philipp and Brox, Thomas},
+  booktitle={International Conference on Medical image computing and computer-assisted intervention},
+  pages={234--241},
+  year={2015},
+  organization={Springer}
+}


### PR DESCRIPTION
This PR adds the reference to the original UNet design for inverse problems imaging.

**Changes:**
- Add citation to Jin et al. 2017 in UNet docstring
- Add note explaining differences from Ronneberger et al. 2015
- Add Ronneberger et al. 2015 to refs.bib

Closes #1031