### PR TITLE
fix(docs): correct bregman_prox description from right to left

### DIFF
--- a/deepinv/optim/potential.py
+++ b/deepinv/optim/potential.py
@@ -136,7 +136,7 @@ class Potential(nn.Module):
         **kwargs,
     ):
         r"""
-        Calculates the (right) Bregman proximity operator of h` at :math:`x`, with Bregman potential `bregman_potential`.
+        Calculates the (left) Bregman proximity operator of `h` at :math:`x`, with Bregman potential `bregman_potential`.
 
         .. math::
 


### PR DESCRIPTION
## Problem
The `bregman_prox` method docstring incorrectly states it computes the **right** Bregman proximity operator.

## Solution
Changed the description to correctly say **left** Bregman proximity operator.

The method computes `argmin_u γ·h(u) + D_φ(u, x)`, where the first argument of the Bregman divergence `D_φ(u, x)` varies — this is the **left** Bregman prox by convention. The right Bregman prox would have `D_φ(x, u)` instead.

The implementation confirms this: the gradient step computes `∇h(u) + ∇φ(u) - ∇φ(x)`, consistent with minimizing over the first argument of the divergence.

## Files Changed
- `deepinv/optim/potential.py`: Fixed docstring (right → left)

Closes #1112