### PR TITLE
fix: correct bregman_prox docstring from 'right' to 'left' Bregman prox

### DIFF
--- a/deepinv/optim/potential.py
+++ b/deepinv/optim/potential.py
@@ -136,7 +136,7 @@ class Potential(nn.Module):
         **kwargs,
     ):
         r"""
-        Calculates the (right) Bregman proximity operator of h` at :math:`x`, with Bregman potential `bregman_potential`.
+        Calculates the (left) Bregman proximity operator of h` at :math:`x`, with Bregman potential `bregman_potential`.
 
         .. math::
 


### PR DESCRIPTION
## Summary

The `bregman_prox` docstring describes the operator as computing the **right** Bregman proximity operator, but the mathematical formula:

```
argmin_u  γ/2 · h(u) + D_φ(u, x)
```

places the variable being optimized (`u`) as the **first** argument of the Bregman divergence `D_φ(u, x)`, which corresponds to the **left** Bregman prox.

This PR corrects the docstring from 'right' to 'left'.

Fixes #1112