### PR TITLE
Add `use_fft` to space varying blur

### DIFF
--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -755,6 +755,7 @@ class SpaceVaryingBlur(LinearPhysics):
     :param str padding: options = ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'``.
         If ``padding = 'valid'`` the blurred output is smaller than the image (no padding),
         otherwise the blurred output has the same size as the image.
+    :param bool use_fft: whether to use FFT-based convolutions. If ``True``, it uses FFT-based convolutions which can be faster for large kernels.
     :param torch.device, str device: Device on which the physics' buffers will be created. If a buffer is updated via ``physics.update_parameters()``, if not None, it will be automatically casted to the device of the replaced buffer, else, use the device of the provided value. To change the device of all buffers, please use ``physics.to(device)``.
 
     |sep|
@@ -785,6 +786,7 @@ class SpaceVaryingBlur(LinearPhysics):
         filters: Tensor = None,
         multipliers: Tensor = None,
         padding: str = "valid",
+        use_fft: bool = False,
         device: torch.device | str = "cpu",
         **kwargs,
     ):
@@ -793,7 +795,7 @@ class SpaceVaryingBlur(LinearPhysics):
         self.register_buffer("filters", filters)
         self.register_buffer("multipliers", multipliers)
         self.padding = padding
-
+        self.use_fft = use_fft
         self.to(device)
 
     def A(
@@ -813,7 +815,9 @@ class SpaceVaryingBlur(LinearPhysics):
         :param str device: cpu or cuda
         """
         self.update_parameters(filters, multipliers, padding, **kwargs)
-        return dF.product_convolution2d(x, self.multipliers, self.filters, self.padding)
+        return dF.product_convolution2d(
+            x, self.multipliers, self.filters, self.padding, use_fft=self.use_fft
+        )
 
     def A_adjoint(
         self,
@@ -839,7 +843,7 @@ class SpaceVaryingBlur(LinearPhysics):
             filters=filters, multipliers=multipliers, padding=padding, **kwargs
         )
         return dF.product_convolution2d_adjoint(
-            y, self.multipliers, self.filters, self.padding
+            y, self.multipliers, self.filters, self.padding, use_fft=self.use_fft
         )
 
     def update_parameters(

--- a/deepinv/physics/functional/product_convolution.py
+++ b/deepinv/physics/functional/product_convolution.py
@@ -3,12 +3,12 @@ from deepinv.physics.functional.multiplier import (
     multiplier,
     multiplier_adjoint,
 )
-from deepinv.physics.functional.convolution import conv2d, conv_transpose2d
+import deepinv.physics.functional as dF
 import torch
 
 
 def product_convolution2d(
-    x: Tensor, w: Tensor, h: Tensor, padding: str = "valid"
+    x: Tensor, w: Tensor, h: Tensor, padding: str = "valid", use_fft: bool = False
 ) -> torch.Tensor:
     r"""
 
@@ -26,12 +26,13 @@ def product_convolution2d(
     :param torch.Tensor w: Tensor of size :math:`(b, c, K, H, W)`. :math:`b \in \{1, B\}` and :math:`c \in \{1, C\}`
     :param torch.Tensor h: Tensor of size :math:`(b, c, K, h, w)`. :math:`b \in \{1, B\}` and :math:`c \in \{1, C\}`, :math:`h\leq H` and :math:`w\leq W`.
     :param padding: ( options = ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'`` or ``'constant'``). If `padding = `'valid'` the blurred output is smaller than the image (no padding), otherwise the blurred output has the same size as the image.
-
+    :param bool use_fft: whether to use FFT-based convolutions. If ``True``, it uses FFT-based convolutions which can be faster for large kernels.
     :return: :class:`torch.Tensor` the blurry image.
     """
 
     K = w.size(2)
     result = 0.0
+    conv2d = dF.conv2d_fft if use_fft else dF.conv2d
     for k in range(K):
         result += conv2d(
             multiplier(x, w[:, :, k, ...]), h[:, :, k, ...], padding=padding
@@ -41,7 +42,7 @@ def product_convolution2d(
 
 
 def product_convolution2d_adjoint(
-    y: Tensor, w: Tensor, h: Tensor, padding: str = "valid"
+    y: Tensor, w: Tensor, h: Tensor, padding: str = "valid", use_fft: bool = False
 ) -> torch.Tensor:
     r"""
 
@@ -53,10 +54,12 @@ def product_convolution2d_adjoint(
     :param padding: options = ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'``.
         If `padding = 'valid'` the blurred output is smaller than the image (no padding),
         otherwise the blurred output has the same size as the image.
+    :param bool use_fft: whether to use FFT-based convolutions. If ``True``, it uses FFT-based convolutions which can be faster for large kernels.
     """
 
     K = w.size(2)
     result = 0.0
+    conv_transpose2d = dF.conv_transpose2d_fft if use_fft else dF.conv_transpose2d
     for k in range(K):
         result += multiplier_adjoint(
             conv_transpose2d(y, h[:, :, k, ...], padding=padding), w[:, :, k, ...]


### PR DESCRIPTION
Thank you for contributing to DeepInverse!

Please refer to our [contributing guidelines](https://deepinv.github.io/deepinv/contributing.html) for full instructions on how to contribute, including writing tests, documentation and code style.

Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/documentation.yml). Look for the workflow run corresponding to your pull request.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
