### PR TITLE
fix(docs): remove nested equation environments in iterative reconstruction guide

### DIFF
--- a/docs/source/user_guide/reconstruction/iterative.rst
+++ b/docs/source/user_guide/reconstruction/iterative.rst
@@ -7,10 +7,8 @@ Many image reconstruction algorithms can be shown to be solving
 minimization problems of the form
 
 .. math::
-    \begin{equation*}
-    \label{eq:min_prob}
+
     \underset{x}{\arg\min} \quad \datafid{x}{y} +  \lambda \reg{x},
-    \end{equation*}
 
 where :math:`\datafidname:\xset\times\yset \mapsto \mathbb{R}_{+}` is a data-fidelity term, :math:`\regname:\xset\mapsto \mathbb{R}_{+}`
 is a prior term, and :math:`\lambda` is a positive scalar. The data-fidelity term measures the discrepancy between the
@@ -47,12 +45,10 @@ solving the inverse problem :math:`y = \noise{\forw{x}}` reads
 
 .. math::
 
-    \begin{equation*}
     \begin{aligned}
     u_{k} &=  x_k - \gamma \nabla \datafid{x_k}{y} \\
     x_{k+1} &= \denoiser{u_k}{\sigma},
     \end{aligned}
-    \end{equation*}
 
 
 where :math:`f(x)=\frac{1}{2}\|y-\forw{x}\|^2` is a standard data-fidelity term,


### PR DESCRIPTION
The iterative reconstruction user guide page shows "Erroneous nesting of equation structures" instead of equations. The math blocks wrapped content in `\begin{equation*}...\end{equation*}` inside Sphinx's `.. math::` directive, which already provides a math environment. MathJax rejects the double nesting.

Removed the redundant `equation*` wrappers from both math blocks. The `aligned` environment in the second block is kept since it works inside the implicit math context.

Fixes #1106