### PR TITLE
CI hotfixes

### DIFF
--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -33,6 +33,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
+          pixi-bin-path: /local/jtachell/pixi/bin/pixi
 
       - name: Check import
         run: |
@@ -137,3 +138,7 @@ jobs:
               body,
             });
 
+      - name: Cleanup Pixi
+        if: always()
+        run: |
+          rm -rf /local/jtachell/pixi

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml --junitxml=junit.xml --testmon
+          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml --testmon
 
       - name: Save .testmondata # only when pushed to main, not for PRs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -64,16 +64,9 @@ jobs:
           key: testmon-cpu-main-${{ matrix.os }}-${{ github.run_id }}
 
       - name: Upload coverage to Codecov
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.environment == 'full'
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-
-      - name: Upload test results to Codecov
-        if: (!cancelled()) && runner.os == 'Linux'
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./junit.xml

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
     - main
+  push:
+    branches:
+    - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -33,6 +33,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
+          pixi-bin-path: /local/jtachell/pixi/bin/pixi
 
       - name: Check import
         run: |
@@ -77,3 +78,8 @@ jobs:
               issue_number: pr,
               body,
             });
+
+      - name: Cleanup Pixi
+        if: always()
+        run: |
+          rm -rf /local/jtachell/pixi


### PR DESCRIPTION
Some CI hot fixes after #1108 

- missing `test_cpu` when pushing to main
- pixi installing in `/home/` instead of `/local/` for gpu tests/docs

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
