### PR TITLE
Support non-cubical 3D phantoms in TomographyWithAstra

### DIFF
--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -51,14 +51,14 @@ class XrayTransform:
         """The shape of the input volume."""
         import astra
 
-        return astra.geom_size(self.object_geometry)
+        return tuple(np.roll(astra.geom_size(self.object_geometry), shift=2))
 
     @property
     def range_shape(self) -> tuple:
         """The shape of the output projection."""
         import astra
 
-        return astra.geom_size(self.projection_geometry)
+        return tuple(np.roll(astra.geom_size(self.projection_geometry), shift=2))
 
     @property
     def object_cell_volume(self) -> float:
@@ -257,6 +257,8 @@ def _create_astra_link(data: torch.Tensor) -> object:
     :return: GPULink, instance of a utility class which holds the pointer of the underlying CUDA array, its shape and the the stride of the data.
     """
     import astra
+
+    data = torch.movedim(data, (0, 1, 2), (1, 2, 0))
 
     assert (
         data.device.type == "cuda"

--- a/deepinv/physics/functional/astra.py
+++ b/deepinv/physics/functional/astra.py
@@ -51,14 +51,14 @@ class XrayTransform:
         """The shape of the input volume."""
         import astra
 
-        return tuple(np.roll(astra.geom_size(self.object_geometry), shift=2))
+        return astra.geom_size(self.object_geometry)
 
     @property
     def range_shape(self) -> tuple:
         """The shape of the output projection."""
         import astra
 
-        return tuple(np.roll(astra.geom_size(self.projection_geometry), shift=2))
+        return astra.geom_size(self.projection_geometry)
 
     @property
     def object_cell_volume(self) -> float:
@@ -257,8 +257,6 @@ def _create_astra_link(data: torch.Tensor) -> object:
     :return: GPULink, instance of a utility class which holds the pointer of the underlying CUDA array, its shape and the the stride of the data.
     """
     import astra
-
-    data = torch.movedim(data, (0, 1, 2), (1, 2, 0))
 
     assert (
         data.device.type == "cuda"

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -656,8 +656,11 @@ class TomographyWithAstra(LinearPhysics):
         return sinogram_scaled
 
     def A(self, x: torch.Tensor, **kwargs) -> torch.Tensor:
-        """Forward projection.
-
+        """Forward projection. In 2D, the output is a sinogram of shape [B,C,A,N],
+        with A the number of angular positions, and N the number of detector cells.
+        In 3D, the output is a stack of sinograms of shape [B,C,V,A,N], with A the
+        number of angular positions, and (V,N) the shape of the 2D detector grid,
+        where V is the number of rows of the detector and N the number of columns.
         :param torch.Tensor x: input of shape [B,C,...,H,W]
         :return: projection of shape [B,C,...,A,N]
         """
@@ -693,7 +696,11 @@ class TomographyWithAstra(LinearPhysics):
             return super(TomographyWithAstra, self).A_dagger(y, **kwargs)
 
     def A_adjoint(self, y: torch.Tensor, **kwargs) -> torch.Tensor:
-        """Approximation of the adjoint.
+        """Approximation of the adjoint. In 2D, expected input is a sinogram of
+        shape [B,C,A,N], with A the number of angular positions, and N the number
+        of detector cells. In 3D, expected input is a stack of sinograms of shape [B,C,V,A,N],
+        with A the number of angular positions, and (V,N) the shape of the 2D detector grid,
+        where V is the number of rows of the detector and N the number of columns.
 
         :param torch.Tensor y: input of shape [B,C,...,A,N]
         :return: scaled back-projection of shape [B,C,...,H,W]

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -524,16 +524,8 @@ class TomographyWithAstra(LinearPhysics):
         if isinstance(angles, int):
             angles = torch.linspace(*angular_range, steps=angles + 1)[:-1]
 
-        if self.is_2d:
-            n_rows, n_cols = img_size
-            n_slices = 1
-        else:
-            n_slices, n_rows, n_cols = img_size
-
         self.object_geometry = create_object_geometry(
-            n_rows=n_rows,
-            n_cols=n_cols,
-            n_slices=n_slices,
+            *img_size,
             bounding_box=bounding_box,
             pixel_spacing=pixel_spacing,
             is_2d=self.is_2d,

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -656,8 +656,8 @@ class TomographyWithAstra(LinearPhysics):
         return sinogram_scaled
 
     def A(self, x: torch.Tensor, **kwargs) -> torch.Tensor:
-        """Forward projection. 
-        
+        """Forward projection.
+
         In 2D, the output is a sinogram of shape [B,C,A,N],
         with A the number of angular positions, and N the number of detector cells.
         In 3D, the output is a stack of sinograms of shape [B,C,V,A,N], with A the
@@ -698,8 +698,8 @@ class TomographyWithAstra(LinearPhysics):
             return super(TomographyWithAstra, self).A_dagger(y, **kwargs)
 
     def A_adjoint(self, y: torch.Tensor, **kwargs) -> torch.Tensor:
-        """Approximation of the adjoint. 
-        
+        """Approximation of the adjoint.
+
         In 2D, expected input is a sinogram of
         shape [B,C,A,N], with A the number of angular positions, and N the number
         of detector cells. In 3D, expected input is a stack of sinograms of shape [B,C,V,A,N],

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -656,7 +656,9 @@ class TomographyWithAstra(LinearPhysics):
         return sinogram_scaled
 
     def A(self, x: torch.Tensor, **kwargs) -> torch.Tensor:
-        """Forward projection. In 2D, the output is a sinogram of shape [B,C,A,N],
+        """Forward projection. 
+        
+        In 2D, the output is a sinogram of shape [B,C,A,N],
         with A the number of angular positions, and N the number of detector cells.
         In 3D, the output is a stack of sinograms of shape [B,C,V,A,N], with A the
         number of angular positions, and (V,N) the shape of the 2D detector grid,
@@ -696,7 +698,9 @@ class TomographyWithAstra(LinearPhysics):
             return super(TomographyWithAstra, self).A_dagger(y, **kwargs)
 
     def A_adjoint(self, y: torch.Tensor, **kwargs) -> torch.Tensor:
-        """Approximation of the adjoint. In 2D, expected input is a sinogram of
+        """Approximation of the adjoint. 
+        
+        In 2D, expected input is a sinogram of
         shape [B,C,A,N], with A the number of angular positions, and N the number
         of detector cells. In 3D, expected input is a stack of sinograms of shape [B,C,V,A,N],
         with A the number of angular positions, and (V,N) the shape of the 2D detector grid,

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -605,7 +605,7 @@ class TomographyWithAstra(LinearPhysics):
         is_3d = len(sinogram.shape) == 5
 
         if self.geometry_type == "conebeam" and is_3d:
-            # dimensions (V,N) are (col,row) of the 2D detector
+            # dimensions (V,N) are (row,col) of the 2D detector
             # A is the number of angles
             B, C, V, A, N = sinogram.shape
 

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -524,8 +524,16 @@ class TomographyWithAstra(LinearPhysics):
         if isinstance(angles, int):
             angles = torch.linspace(*angular_range, steps=angles + 1)[:-1]
 
+        if self.is_2d:
+            n_rows, n_cols = img_size
+            n_slices = 1
+        else:
+            n_slices, n_rows, n_cols = img_size
+
         self.object_geometry = create_object_geometry(
-            *img_size,
+            n_rows=n_rows,
+            n_cols=n_cols,
+            n_slices=n_slices,
             bounding_box=bounding_box,
             pixel_spacing=pixel_spacing,
             is_2d=self.is_2d,

--- a/deepinv/tests/test_external_libraries.py
+++ b/deepinv/tests/test_external_libraries.py
@@ -28,9 +28,10 @@ class TestTomographyWithAstra:
             (False, "conebeam"),
         ],
     )
+    @pytest.mark.parametrize("cubic", [True, False])
     @pytest.mark.parametrize("channels", [1, 3])
     def test_tomography_with_astra_logic(
-        self, is_2d, geometry_type, normalize, fbp, monkeypatch, channels
+        self, is_2d, geometry_type, normalize, fbp, monkeypatch, cubic, channels
     ):
         r"""
         Tests tomography operator with astra backend which does not have a numerically precise adjoint.
@@ -39,6 +40,7 @@ class TestTomographyWithAstra:
         :param str geometry_type: In 2D, expects ``parallel`` or ``fanbeam``. In 3D expects ``parallel`` or ``conebeam``.
         :param bool normalize: Initializes the operator with ``normalize=normalize``.
         :param bool fbp: Whether or not to approximate the pseudo-inverse with filtered back-projection.
+        :param bool cubic: Whether or not the input image is cubic (i.e. has the same size in all dimensions).
         :param int channels: Number of input channels. The tomography operator is applied per channel.
         """
 
@@ -68,7 +70,7 @@ class TestTomographyWithAstra:
 
         ## Test 2d transforms
         if is_2d:
-            img_size = (16, 16)
+            img_size = (16, 16) if cubic else (32, 16)
             n_detector_pixels = 2 * img_size[0]
             num_angles = 2 * img_size[0]
             physics = dinv.physics.TomographyWithAstra(
@@ -83,8 +85,8 @@ class TestTomographyWithAstra:
 
         else:
             ## Test 3d transforms
-            img_size = (16, 16, 16)
-            n_detector_pixels = (32, 32)
+            img_size = (16, 16, 16) if cubic else (32, 24, 16)
+            n_detector_pixels = (32, 32) if cubic else (64, 48)
             num_angles = 2 * img_size[0]
             physics = dinv.physics.TomographyWithAstra(
                 img_size=img_size,
@@ -162,14 +164,30 @@ class TestTomographyWithAstra:
 
         ## --- Test geometry properties ---
         if is_2d:
-            assert physics.measurement_shape == (32, 32)
-            assert physics.xray_transform.domain_shape == (1, 16, 16)
-            assert physics.xray_transform.range_shape == (1, 32, 32)
+            assert physics.measurement_shape == (32, 32) if cubic else (32, 16)
+            assert (
+                physics.xray_transform.domain_shape == (1, 16, 16)
+                if cubic
+                else (1, 32, 16)
+            )
+            assert (
+                physics.xray_transform.range_shape == (1, 32, 32)
+                if cubic
+                else (1, 32, 16)
+            )
         else:
-            assert physics.measurement_shape == (32, 32, 32)
-            assert physics.xray_transform.domain_shape == (16, 16, 16)
-            assert physics.xray_transform.range_shape == (32, 32, 32)
-        assert physics.num_angles == 32
+            assert physics.measurement_shape == (32, 32, 32) if cubic else (64, 48, 32)
+            assert (
+                physics.xray_transform.domain_shape == (16, 16, 16)
+                if cubic
+                else (32, 24, 16)
+            )
+            assert (
+                physics.xray_transform.range_shape == (32, 32, 32)
+                if cubic
+                else (64, 48, 32)
+            )
+        assert physics.num_angles == 32 if cubic else 64
         assert physics.xray_transform.object_cell_volume == pytest.approx(1.0)
         assert physics.xray_transform.detector_cell_u_length == pytest.approx(1.0)
         assert physics.xray_transform.detector_cell_v_length == pytest.approx(1.0)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,7 +20,7 @@ Changed
 Fixed
 ^^^^^
 - Add warning when options `reduce="mean"` and `reduce="none"` are used in :class:`deepinv.physics.StackedLinearPhysics`. Remove `reduction` argument from :class:`deepinv.distributed.DistributedStackedLinearPhysics` (:gh:`1071` by `Romain Vo`_)
-- Fix dimensions mismatch in `Tomography` with 3D phantoms (:gh:`1137` by `Baptiste Legouix`_)
+- Fix dimensions mismatch in :class:`deepinv.physics.TomographyWithAstra` with 3D phantoms (:gh:`1137` by `Baptiste Legouix`_)
 
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,7 @@ Changed
 Fixed
 ^^^^^
 - Add warning when options `reduce="mean"` and `reduce="none"` are used in :class:`deepinv.physics.StackedLinearPhysics`. Remove `reduction` argument from :class:`deepinv.distributed.DistributedStackedLinearPhysics` (:gh:`1071` by `Romain Vo`_)
+- Fix dimensions mismatch in `Tomography` with 3D phantoms (:gh:`1137` by `Baptiste Legouix`_)
 
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -602,3 +602,4 @@ Changed
 .. _Tiberiu Sabau: https://github.com/tibisabau
 .. _Benoît Malézieux: https://github.com/bmalezieux
 .. _Paul Escande: https://pescande.perso.math.cnrs.fr/
+.. _Baptiste Legouix: https://github.com/blegouix


### PR DESCRIPTION
Closes #1136 

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
