### PR TITLE
Add DM4CT pre-trained Computed Tomography diffusion models 

### DIFF
--- a/deepinv/models/wrapper.py
+++ b/deepinv/models/wrapper.py
@@ -375,7 +375,7 @@ class DiffusersDenoiserWrapper(ScoreModelWrapper):
     """
     Wraps a `HuggingFace diffusers <https://huggingface.co/docs/diffusers/index>`_ model as a DeepInv Denoiser.
 
-    :param str mode_id: Diffusers model id or HuggingFace hub repository id. For example, 'google/ddpm-cat-256'.
+    :param str model_id: Diffusers model id or HuggingFace hub repository id. For example, 'google/ddpm-cat-256'.
         The id must work with `DiffusionPipeline`.
         See `Diffusers Documentation <https://huggingface.co/docs/diffusers/v0.35.1/en/api/pipelines/overview#diffusers.DiffusionPipeline>`_.
     :param bool clip_output: Whether to clip the output to the model range. Default is `True`.
@@ -396,7 +396,7 @@ class DiffusersDenoiserWrapper(ScoreModelWrapper):
         >>> from deepinv.models import DiffusersDenoiserWrapper
         >>> import torch
         >>> device = dinv.utils.get_device(verbose=False)
-        >>> denoiser = DiffusersDenoiserWrapper(mode_id='google/ddpm-cat-256', device=device)
+        >>> denoiser = DiffusersDenoiserWrapper(model_id='google/ddpm-cat-256', device=device)
         >>> x = dinv.utils.load_example(
         ...         "cat.jpg",
         ...         img_size=256,
@@ -413,7 +413,7 @@ class DiffusersDenoiserWrapper(ScoreModelWrapper):
 
     def __init__(
         self,
-        mode_id: str = None,
+        model_id: str | None = None,
         clip_output: bool = True,
         dtype: torch.dtype = torch.float32,
         device: str | torch.device = "cpu",
@@ -421,7 +421,7 @@ class DiffusersDenoiserWrapper(ScoreModelWrapper):
         **kwargs,
     ):
         assert (
-            mode_id is not None
+            model_id is not None
         ), "Provide a diffusers model id. E.g., 'google/ddpm-cat-256'"
 
         try:
@@ -436,9 +436,10 @@ class DiffusersDenoiserWrapper(ScoreModelWrapper):
                 "diffusers is not installed. Please install it via 'pip install diffusers'."
             )
 
-        pipeline = DiffusionPipeline.from_pretrained(mode_id, torch_dtype=dtype).to(
-            device
-        )
+        pipeline = DiffusionPipeline.from_pretrained(
+            model_id,
+            torch_dtype=dtype,
+        ).to(device)
 
         model = pipeline.unet
         scheduler = getattr(pipeline, "scheduler", None)

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -1272,7 +1272,7 @@ def test_denoiser_perf(device, load_example_image):
         (dinv.models.DScCP(pretrained="download").to(device), (4.5, 9.0, 3.0)),
         (
             dinv.models.DiffusersDenoiserWrapper(
-                mode_id="google/ddpm-ema-celebahq-256"
+                model_id="google/ddpm-ema-celebahq-256"
             ).to(device),
             (2.5, 7, 7),
         ),
@@ -1482,7 +1482,7 @@ def test_diffuser_wrapper(batch_size, clip_output, device):
         "installed with `pip install transformers`",
     )
     model = dinv.models.DiffusersDenoiserWrapper(
-        mode_id="google/ddpm-cifar10-32", clip_output=clip_output, device=device
+        model_id="google/ddpm-cifar10-32", clip_output=clip_output, device=device
     )
 
     x = torch.randn(batch_size, 3, 32, 32, device=device)

--- a/docs/source/user_guide/reconstruction/denoisers.rst
+++ b/docs/source/user_guide/reconstruction/denoisers.rst
@@ -215,7 +215,7 @@ Any diffusion model from the `HuggingFace Diffusers library <https://huggingface
 using the :class:`deepinv.models.DiffusersDenoiserWrapper` class. A model can be instantiated as simply as follows:
 
     >>> from deepinv.models import DiffusersDenoiserWrapper
-    >>> denoiser = DiffusersDenoiserWrapper(mode_id="google/ddpm-ema-celebahq-256")
+    >>> denoiser = DiffusersDenoiserWrapper(model_id="google/ddpm-ema-celebahq-256")
 
 It can be used as any other DeepInv denoiser ``denoised_image = denoiser(noisy_image, sigma)``. It also supports conditional denoising as long as the underlying model does. 
 This wrapper allows you to leverage state-of-the-art diffusion models for other inverse problems beyond image generation, in particular for posterior sampling. 

--- a/examples/sampling/demo_ct_diffusers.py
+++ b/examples/sampling/demo_ct_diffusers.py
@@ -99,42 +99,54 @@ sde = VariancePreservingDiffusion(
     device=device,
 )
 
-prior_sampler = PosteriorDiffusion(
-    data_fidelity=ZeroFidelity(),
-    sde=sde,
-    denoiser=denoiser,
-    solver=solver,
-    dtype=torch.float32,
-    device=device,
-    verbose=True,
-)
+# prior_sampler = PosteriorDiffusion(
+#     data_fidelity=ZeroFidelity(),
+#     sde=sde,
+#     denoiser=denoiser,
+#     solver=solver,
+#     dtype=torch.float32,
+#     device=device,
+#     verbose=True,
+# )
 
-with torch.no_grad():
-    x_prior_slices = []
-    for i in range(n_slices):
-        x_prior_slices.append(
-            prior_sampler(
-                y=None,
-                physics=None,
-                x_init=(1, 1, img_width, img_width),
-                seed=i,
-                get_trajectory=False,
-            )
-        )
-    x_prior = torch.cat(x_prior_slices, dim=0)
+# with torch.no_grad():
+#     x_prior_slices = []
+#     for i in range(n_slices):
+#         x_prior_slices.append(
+#             prior_sampler(
+#                 y=None,
+#                 physics=None,
+#                 x_init=(1, 1, img_width, img_width),
+#                 seed=i,
+#                 get_trajectory=False,
+#             )
+#         )
+#     x_prior = torch.cat(x_prior_slices, dim=0)
 
-dinv.utils.plot(
-    [x_prior],
-    titles=["Unconditional prior sample"],
-    figsize=(4, 4),
-)
+# dinv.utils.plot(
+#     [x_prior],
+#     titles=["Unconditional prior sample"],
+#     figsize=(4, 4),
+# )
+
 # %% 5) Reconstruction / posterior sampling from projections (DPS)
 # ---------------------------------------------------------------
 # We use diffusion posterior sampling to condition the diffusion prior on the measurements.
+num_steps = 100
+timesteps = torch.linspace(1.0, 1e-3, num_steps, device=device)
+solver = EulerSolver(timesteps=timesteps, rng=torch.Generator(device=device))
+
+sde = VariancePreservingDiffusion(
+    denoiser=denoiser,
+    solver=solver,
+    dtype=torch.float64,
+    device=device,
+)
+
 posterior_sampler = PosteriorDiffusion(
     data_fidelity=DPSDataFidelity(denoiser=denoiser, weight=1.0),
-    sde=sde,
     denoiser=denoiser,
+    sde=sde,
     solver=solver,
     dtype=torch.float32,
     device=device,
@@ -161,22 +173,18 @@ dinv.utils.plot(
     titles=["DPS posterior sample"],
     figsize=(4, 4),
 )
-# %% 6) Visualize one slice
-# ------------------------
-# For simplicity, we show a single slice from the volume.
-idx = n_slices // 2
+# %%
+# Show the results
 
-# Filtered back-projection baseline
 x_fbp = physics.A_dagger(y)
 
 dinv.utils.plot(
     [
-        x[idx : idx + 1],
-        x_fbp[idx : idx + 1],
-        x_prior[idx : idx + 1],
-        x_rec[idx : idx + 1],
+        x,
+        x_fbp,
+        x_rec,
     ],
-    titles=["Ground truth", "FBP", "Prior sample", "DPS posterior sample"],
+    titles=["Ground truth", "FBP", "DPS posterior sample"],
     figsize=(10, 3),
 )
 

--- a/examples/sampling/demo_ct_diffusers_tomography.py
+++ b/examples/sampling/demo_ct_diffusers_tomography.py
@@ -1,0 +1,183 @@
+r"""
+CT tomography with a pretrained Diffusers model
+=====================================================================
+
+This demo shows an end-to-end DeepInv workflow with a pretrained diffusion model hosted on
+HuggingFace:
+
+- Load a *volume* (here: a small synthetic CT volume provided by DeepInv) as a stack of 2D slices.
+- Simulate (parallel-beam) X-ray projections using :class:`deepinv.physics.Tomography`.
+- Draw an unconditional sample from the diffusion prior.
+- Perform posterior sampling / reconstruction from projections using diffusion posterior sampling (DPS).
+
+.. note::
+    This example uses the pixel-space diffusion UNet from:
+    https://huggingface.co/jiayangshi/lodochallenge_pixel_diffusion
+
+    The model is a 2D UNet trained on 1-channel 512x512 CT slices with intensities rescaled to ``[-1, 1]``.
+
+.. warning::
+    Running this demo can be compute- and download-heavy on CPU.
+
+    Install requirements:
+
+    - ``pip install diffusers transformers``
+
+"""
+
+# %%
+import torch
+import torch.nn.functional as F
+import deepinv as dinv
+
+from deepinv.models import DiffusersDenoiserWrapper
+from deepinv.physics import Tomography
+from deepinv.sampling import (
+    PosteriorDiffusion,
+    EulerSolver,
+    VariancePreservingDiffusion,
+    DPSDataFidelity,
+)
+from deepinv.optim import ZeroFidelity
+
+# %% Configuration
+# This demo can be memory hungry (512x512 diffusion model). For a robust out-of-the-box
+# experience, default to CPU. Switch to CUDA manually if you have enough free VRAM.
+device = "cuda"
+dtype = torch.float32
+
+# The DM4CT pixel diffusion model is trained for 512x512, 1-channel.
+img_width = 512
+# Number of slices in the volume (increase for a larger volume).
+n_slices = 1
+
+# Tomography configuration (keep small for a quick demo)
+angles = 30
+noise_std = 0.01
+
+# %%
+# Load an example CT slice and simulate X-ray projections with DeepInv physics
+x = dinv.utils.load_example("CT100_256x256_0.pt", img_size=img_width).to(device)
+x = F.interpolate(
+    x, size=(img_width, img_width), mode="bilinear", align_corners=False, antialias=True
+)
+
+physics = dinv.physics.TomographyWithAstra(
+    img_size=(img_width, img_width),
+    angles=angles,
+    device=device,
+    noise_model=dinv.physics.GaussianNoise(sigma=noise_std),
+)
+
+y = physics(x)
+
+dinv.utils.plot(
+    [x, y],
+    titles=["Ground truth slice", "Simulated projections"],
+    figsize=(8, 4),
+)
+
+# %% 3) Load the pretrained diffusion model from HuggingFace via Diffusers
+# -----------------------------------------------------------------------
+# The wrapper exposes the diffusers UNet as a DeepInv denoiser.
+denoiser = DiffusersDenoiserWrapper(
+    model_id="jiayangshi/lodochallenge_pixel_diffusion",
+    device=device,
+)
+
+
+# %%
+# Generates an unconditional slice sample from the diffusion prior.
+num_steps = 100
+timesteps = torch.linspace(1.0, 1e-3, num_steps, device=device)
+solver = EulerSolver(timesteps=timesteps, rng=torch.Generator(device=device))
+
+sde = VariancePreservingDiffusion(
+    denoiser=denoiser,
+    solver=solver,
+    dtype=torch.float64,
+    device=device,
+)
+
+prior_sampler = PosteriorDiffusion(
+    data_fidelity=ZeroFidelity(),
+    sde=sde,
+    denoiser=denoiser,
+    solver=solver,
+    dtype=torch.float32,
+    device=device,
+    verbose=True,
+)
+
+with torch.no_grad():
+    x_prior_slices = []
+    for i in range(n_slices):
+        x_prior_slices.append(
+            prior_sampler(
+                y=None,
+                physics=None,
+                x_init=(1, 1, img_width, img_width),
+                seed=i,
+                get_trajectory=False,
+            )
+        )
+    x_prior = torch.cat(x_prior_slices, dim=0)
+
+dinv.utils.plot(
+    [x_prior],
+    titles=["Unconditional prior sample"],
+    figsize=(4, 4),
+)
+# %% 5) Reconstruction / posterior sampling from projections (DPS)
+# ---------------------------------------------------------------
+# We use diffusion posterior sampling to condition the diffusion prior on the measurements.
+posterior_sampler = PosteriorDiffusion(
+    data_fidelity=DPSDataFidelity(denoiser=denoiser, weight=1.0),
+    sde=sde,
+    denoiser=denoiser,
+    solver=solver,
+    dtype=torch.float32,
+    device=device,
+    verbose=True,
+)
+
+with torch.no_grad():
+    x_rec_slices = []
+    for i in range(n_slices):
+        x_rec_slices.append(
+            posterior_sampler(
+                y=y[i : i + 1],
+                physics=physics,
+                x_init=(1, 1, img_width, img_width),
+                seed=100 + i,
+                get_trajectory=False,
+            )
+        )
+    x_rec = torch.cat(x_rec_slices, dim=0)
+
+# %%
+dinv.utils.plot(
+    [x_rec],
+    titles=["DPS posterior sample"],
+    figsize=(4, 4),
+)
+# %% 6) Visualize one slice
+# ------------------------
+# For simplicity, we show a single slice from the volume.
+idx = n_slices // 2
+
+# Filtered back-projection baseline
+x_fbp = physics.A_dagger(y)
+
+dinv.utils.plot(
+    [
+        x[idx : idx + 1],
+        x_fbp[idx : idx + 1],
+        x_prior[idx : idx + 1],
+        x_rec[idx : idx + 1],
+    ],
+    titles=["Ground truth", "FBP", "Prior sample", "DPS posterior sample"],
+    figsize=(10, 3),
+)
+
+# %%

--- a/examples/sampling/demo_diffusers.py
+++ b/examples/sampling/demo_diffusers.py
@@ -31,7 +31,7 @@ from deepinv.optim import ZeroFidelity
 
 # We can wrap any diffusers model as a DeepInv denoiser using one line of code:
 denoiser = DiffusersDenoiserWrapper(
-    mode_id="google/ddpm-ema-celebahq-256", device=device
+    model_id="google/ddpm-ema-celebahq-256", device=device
 )
 
 # Load an example image


### PR DESCRIPTION
This PR adds a demo to showcase the integration of pre-trained diffusion models for Computed Tomography.
The pre-trained models are taken from https://github.com/DM4CT/DM4CT hosted on HuggingFace https://huggingface.co/jiayangshi/models and integrated via the diffusers wrapper implemented in #783.

Towards #1062.

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
