### PR TITLE
Close #1145: fix bug in custom backward of least square solver for non-leaf tensor

### DIFF
--- a/deepinv/optim/linear/least_squares.py
+++ b/deepinv/optim/linear/least_squares.py
@@ -330,10 +330,14 @@ class LeastSquaresSolver(torch.autograd.Function):
             )
             for p, g in zip(params, g_params, strict=True):
                 if g is not None:
+                    g_det = g.detach()
+                    if not p.is_leaf and not p.retains_grad:
+                        # Avoid warning when reading .grad on non-leaf tensors.
+                        p.retain_grad()
                     if p.grad is None:
-                        p.grad = g.detach()
+                        p.grad = g_det
                     else:
-                        p.grad = p.grad + g.detach()
+                        p.grad = p.grad + g_det
 
         return tuple(grads)
 

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1262,6 +1262,77 @@ def test_least_squares_implicit_backward(device, solver, physics_name, batch_siz
     torch.use_deterministic_algorithms(prev_deterministic)
 
 
+def test_least_squares_implicit_backward_nonleaf_buffer_grad(device):
+    """Compare explicit vs implicit gradient on an intermediate non-leaf physics buffer."""
+    torch.manual_seed(0)
+    dtype = torch.float64
+
+    batch_size = 2
+    dim = 12
+
+    # A simple physics for faster test
+    class DummyPhysics(dinv.physics.LinearPhysics):
+        def __init__(self, mat):
+            super().__init__()
+            self.register_buffer("mat", mat)
+
+        def A(self, x):
+            return x @ self.mat.transpose(0, 1)
+
+        def A_adjoint(self, y):
+            return y @ self.mat
+
+    mat = torch.randn((dim, dim), device=device, dtype=dtype)
+    physics = DummyPhysics(mat)
+
+    # Fixed inputs for a fair branch-to-branch comparison.
+    x = torch.randn((batch_size, dim), device=device, dtype=dtype)
+    y = physics.A(x)
+    y = y + 0.01 * torch.randn_like(y)
+    z = physics.A_adjoint(y)
+
+    # Tiny dummy net that outputs an operator matrix from measurements.
+    kernel_net = torch.nn.Sequential(
+        torch.nn.Linear(dim, 2 * dim),
+        torch.nn.Tanh(),
+        torch.nn.Linear(2 * dim, dim * dim),
+    ).to(device=device, dtype=dtype)
+
+    # Explicit gradient (reference)
+    physics.implicit_backward_solver = False
+    for p in kernel_net.parameters():
+        p.grad = None
+    mat_hat = kernel_net(y).mean(dim=0).view(dim, dim)
+
+    physics.update_parameters(mat=mat_hat)
+    x_hat = physics.prox_l2(z, y, solver="CG", tol=1e-6, max_iter=50, gamma=1e-3)
+    loss = (x_hat - x).pow(2).mean()
+    physics.mat.retain_grad()
+    loss.backward()
+    explicit_grad = physics.mat.grad.detach().clone()
+
+    # Implicit gradient
+    physics.implicit_backward_solver = True
+    # First reset all gradients
+    for p in kernel_net.parameters():
+        p.grad = None
+
+    mat_hat = kernel_net(y).mean(dim=0).view(dim, dim)
+    physics.update_parameters(mat=mat_hat)
+    x_hat = physics.prox_l2(z, y, solver="CG", tol=1e-6, max_iter=50, gamma=1e-3)
+    loss = (x_hat - x).pow(2).mean()
+    loss.backward()
+    implicit_grad = physics.mat.grad.detach().clone()
+
+    torch.testing.assert_close(
+        implicit_grad,
+        explicit_grad,
+        rtol=1e-2,
+        atol=1e-2,
+        msg=f"Implicit gradient {implicit_grad} does not match explicit gradient {explicit_grad}",
+    )
+
+
 def test_sirt(device):
     # Tests that the SIRT algorithm converges to the least-squares solution for a linear inverse problem.
 

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1270,7 +1270,6 @@ def test_least_squares_implicit_backward_nonleaf_buffer_grad(device):
     batch_size = 2
     dim = 12
 
-    # A simple physics for faster test
     class DummyPhysics(dinv.physics.LinearPhysics):
         def __init__(self, mat):
             super().__init__()
@@ -1285,7 +1284,6 @@ def test_least_squares_implicit_backward_nonleaf_buffer_grad(device):
     mat = torch.randn((dim, dim), device=device, dtype=dtype)
     physics = DummyPhysics(mat)
 
-    # Fixed inputs for a fair branch-to-branch comparison.
     x = torch.randn((batch_size, dim), device=device, dtype=dtype)
     y = physics.A(x)
     y = y + 0.01 * torch.randn_like(y)
@@ -1313,7 +1311,6 @@ def test_least_squares_implicit_backward_nonleaf_buffer_grad(device):
 
     # Implicit gradient
     physics.implicit_backward_solver = True
-    # First reset all gradients
     for p in kernel_net.parameters():
         p.grad = None
 
@@ -1327,8 +1324,8 @@ def test_least_squares_implicit_backward_nonleaf_buffer_grad(device):
     torch.testing.assert_close(
         implicit_grad,
         explicit_grad,
-        rtol=1e-2,
-        atol=1e-2,
+        rtol=1e-4,
+        atol=1e-4,
         msg=f"Implicit gradient {implicit_grad} does not match explicit gradient {explicit_grad}",
     )
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -30,7 +30,7 @@ Fixed
 - Add support for computing the evaluation loss for splitting losses like :class:`deepinv.loss.SplittingLoss` in the trainer (:gh:`881` by `Jérémy Scanvic`_)
 - Add a deprecation warning in :func:`deepinv.utils.plot_inset` in favor of :func:`deepinv.utils.plot` with `plot_inset=True` (:gh:`1148` by `Paul Bernard`_).
 - Fix dimensions mismatch in :class:`deepinv.physics.TomographyWithAstra` with 3D phantoms (:gh:`1137` by `Baptiste Legouix`_)
-
+- Fix a bug in the custom backward of the least-squares solvers for non-leaf tensors (:gh:`1146` by `Minh Hai Nguyen`_)
 
 v0.4.0
 ------


### PR DESCRIPTION
This PR fixes #1145 by properly handle the gradient for non-leaf tensors, in the custom backward of the least squares solvers. 


Thank you for contributing to DeepInverse!

Please refer to our [contributing guidelines](https://deepinv.github.io/deepinv/contributing.html) for full instructions on how to contribute, including writing tests, documentation and code style.

Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/docs_cpu.yml). Look for the workflow run corresponding to your pull request.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
