### PR TITLE
Add a deprecation warning for `plot_inset`

### DIFF
--- a/deepinv/tests/test_deprecated.py
+++ b/deepinv/tests/test_deprecated.py
@@ -163,3 +163,6 @@ def test_deprecated_physics_image_size():
 def test_deprecated_functions():
     with pytest.warns(DeprecationWarning):
         dinv.utils.rescale_img(torch.randn(3, 16, 32), rescale_mode="min_max")
+
+    with pytest.warns(DeprecationWarning):
+        dinv.utils.plot_inset([torch.ones(2, 1, 10, 10)], show=False)

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -867,6 +867,13 @@ def plot_inset(
     :param bool return_fig: return the figure object.
     :param bool return_axs: return the axs object.
     """
+    warn(
+        "The function `deepinv.utils.plot_inset` is deprecated and will be removed in a future version. "
+        "Use `deepinv.utils.plot` with `plot_inset=True` instead, which has the same functionality.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     # Call plot with all parameters including inset-specific ones
     return plot(
         img_list=img_list,

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,7 +20,7 @@ Changed
 Fixed
 ^^^^^
 - Add warning when options `reduce="mean"` and `reduce="none"` are used in :class:`deepinv.physics.StackedLinearPhysics`. Remove `reduction` argument from :class:`deepinv.distributed.DistributedStackedLinearPhysics` (:gh:`1071` by `Romain Vo`_)
-
+- Add a deprecation warning in :func:`deepinv.utils.plot_inset` in favor of :func:`deepinv.utils.plot` with `plot_inset=True` (:gh:`1148` by `Paul Bernard`_).
 
 
 v0.4.0
@@ -601,3 +601,4 @@ Changed
 .. _Tiberiu Sabau: https://github.com/tibisabau
 .. _Benoît Malézieux: https://github.com/bmalezieux
 .. _Paul Escande: https://pescande.perso.math.cnrs.fr/
+.. _Paul Bernard: https://github.com/PAUL-BERNARD


### PR DESCRIPTION
As discussed in #618 , this PR raises a DeprecationWarning for the deprecated function `plot_inset`.

Closes #618.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
