### PR TITLE
Add changelog section to the contributing instructions 

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,13 +9,14 @@ Current
 New Features
 ^^^^^^^^^^^^
 - Add install guidelines for different platforms (`pixi`, `conda`, `pip`, `uv`) in docs (:gh:`1108` by `Julian Tachella`_)
-- Add :class:`deepinv.optim.SIRT` algorithm for tomographic reconstruction (:gh:`985` by `Thibaut Modrzyk`_`)
+- Add :class:`deepinv.optim.SIRT` algorithm for tomographic reconstruction (:gh:`985` by `Thibaut Modrzyk`_)
 - Add :class:`deepinv.optim.MLEM` algorithm for Poisson inverse problems (:gh:`1051` by `Thibaut Modrzyk`_)
 
 Changed
 ^^^^^^^
 - Refactor CI to use `pixi` for compatibility with mixed conda/pip environments (:gh:`1108` by `Julian Tachella`_)
 - Update references for single pixel demo (:gh:`1151` by `Laura C. Diaz-Delgado`_)
+- Add changelog section to the contributing guidelines (:gh:`1153` by `Thibaut Modrzyk`_)
 
 Fixed
 ^^^^^

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -138,7 +138,28 @@ Code quality is important to us. We require that your code is compliant with PEP
 3. Run ``ruff check``, which will check all linting options we've enabled. If it fails, follow the suggestions to make a fix!
 4. Push your code. The automatic checkers will run in GitHub actions, along with other actions that we have in place.
 
-5. Interact with reviewers
+.. _log_changes:
+
+5. Log your changes
+~~~~~~~~~~~~~~~~~~~
+
+We keep a summary of all changes in the `changelog.rst <https://deepinv.github.io/deepinv/changelog.html>` file in the documentation.
+We separate contributions into three categories: **Added** for new features, **Changed** for changes in existing features, and **Fixed** for bug fixes. 
+To do so, you should first add your GitHub information at the end of the file following the format:
+
+.. code-block:: rest
+
+  .. _<your name>: https://github.com/<your GitHub username>
+
+You can then add a line to the appropriate category under the **Current** section, describing your contribution in a concise way.
+This lins should follow the format:
+
+.. code-block:: rest
+
+  - <description of your contribution> (:gh:`<pull request number>` by `<your name>`_)
+
+
+6. Interact with reviewers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You're done! A maintainer will see your PR and will interact with you. They may suggest changes. It is your responsibility to make all requested fixes!

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -152,7 +152,7 @@ To do so, you should first add your GitHub information at the end of the file fo
   .. _<your name>: https://github.com/<your GitHub username>
 
 You can then add a line to the appropriate category under the **Current** section, describing your contribution in a concise way.
-This lins should follow the format:
+This line should follow the format:
 
 .. code-block:: rest
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -143,7 +143,7 @@ Code quality is important to us. We require that your code is compliant with PEP
 5. Log your changes
 ~~~~~~~~~~~~~~~~~~~
 
-We keep a summary of all changes in the `changelog.rst <https://deepinv.github.io/deepinv/changelog.html>` file in the documentation.
+We keep a summary of all changes in the `changelog.rst <https://deepinv.github.io/deepinv/changelog.html>`_ file in the documentation.
 We separate contributions into three categories: **Added** for new features, **Changed** for changes in existing features, and **Fixed** for bug fixes. 
 To do so, you should first add your GitHub information at the end of the file following the format:
 


### PR DESCRIPTION
This PR add precise instructions for new contributors to update the `changelog.rst` file and closes #1149. 


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
