### PR TITLE
BlurFFT + Poisson noise doc/error message for negative values 

### DIFF
--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -577,7 +577,9 @@ class BlurFFT(DecomposablePhysics):
     Blur operator based on ``torch.fft`` operations, which assumes a circular padding of the input, and allows for
     the singular value decomposition via ``deepinv.Physics.DecomposablePhysics`` and has fast pseudo-inverse and prox operators.
 
-
+    .. warning::
+        The FFT computations can lead to small numerical errors, which may result in negative values in the output even when the input is non-negative.
+        If used in combination with :class:`deepinv.physics.PoissonNoise`, it is recommended to set ``clip_positive=True`` in the noise model to avoid runtime errors.
 
     :param tuple img_size: Input image size in the form `(C, H, W)`.
     :param torch.Tensor filter: torch.Tensor of size `(1, c, h, w)` containing the blur filter with h<=H, w<=W and c=1 or c=C e.g.,

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -494,6 +494,10 @@ class PoissonNoise(NoiseModel):
         This may be needed when a NN outputs negative values e.g. when using leaky ReLU.
     :param torch.Generator, None rng: (optional) a pseudorandom random number generator for the parameter generation.
 
+    .. note::
+        Poisson noise is only defined for non-negative inputs.
+        When used in combination with physics operators that can produce negative outputs (such as :class:`deepinv.physics.BlurFFT`), it is recommended to set ``clip_positive=True`` to avoid runtime errors.
+
     |sep|
 
     :Examples:
@@ -545,16 +549,15 @@ class PoissonNoise(NoiseModel):
         if self.clip_positive:
             z = torch.clip(x / gain, min=0.0)
         else:
-            # NOTE: PyTorch operations are generally run asynchronously on CUDA
-            # devices and the underlying CUDA kernel under
-            # torch.poisson typically raises a CUDA-level assertion error
-            # when its input has negative entries. Those errors can't be
-            # recovered from using Python's exception system due to their
-            # asynchronous nature. For this reason we add a manual check if the
-            # RNG is on a CUDA device.
-            if self.rng is not None and self.rng.device.type == "cuda":
-                assert gain > 0, "Gain must be positive"
-                assert torch.all(x >= 0), "Input tensor must be non-negative"
+            # We perform a manual check for negative gain and negative values
+            # to print a clear error message both on CPU and GPU
+            if torch.any(gain <= 0):
+                raise ValueError("Poisson noise gain must be positive.")
+            if torch.any(x < 0):
+                raise ValueError(
+                    "Input tensor for Poisson noise must be non-negative.\n"
+                    "Consider setting ``clip_positive=True`` to avoid this error."
+                )
 
             z = x / gain
 

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -598,6 +598,10 @@ class GammaNoise(NoiseModel):
         :returns: noisy measurements
         """
         self.update_parameters(l=l, **kwargs)
+        if torch.any(self.l <= 0):
+            raise ValueError("Gamma noise level must be positive.")
+        if torch.any(x <= 0):
+            raise ValueError("Input tensor for Gamma noise must be strictly positive.")
         self.to(x.device)
         d = torch.distributions.gamma.Gamma(self.l, self.l / x)
         return d.sample()

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -690,10 +690,10 @@ class PoissonGaussianNoise(NoiseModel):
             # We perform a manual check for negative gain and negative values
             # to print a clear error message both on CPU and GPU
             if torch.any(gain <= 0):
-                raise ValueError("Poisson noise gain must be positive.")
+                raise ValueError("Poisson-Gaussian noise gain must be positive.")
             if torch.any(x < 0):
                 raise ValueError(
-                    "Input tensor for Poisson noise must be non-negative.\n"
+                    "Input tensor for Poisson-Gaussian noise must be non-negative.\n"
                     "Consider setting ``clip_positive=True`` to avoid this error."
                 )
 

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -687,16 +687,15 @@ class PoissonGaussianNoise(NoiseModel):
         if self.clip_positive:
             y = torch.poisson(torch.clip(x / gain, min=0.0), generator=self.rng) * gain
         else:
-            # NOTE: PyTorch operations are generally run asynchronously on CUDA
-            # devices and the underlying CUDA kernel under
-            # torch.poisson typically raises a CUDA-level assertion error
-            # when its input has negative entries. Those errors can't be
-            # recovered from using Python's exception system due to their
-            # asynchronous nature. For this reason we add a manual check if the
-            # RNG is on a CUDA device.
-            if self.rng is not None and self.rng.device.type == "cuda":
-                assert gain > 0, "Gain must be positive"
-                assert torch.all(x >= 0), "Input tensor must be non-negative"
+            # We perform a manual check for negative gain and negative values
+            # to print a clear error message both on CPU and GPU
+            if torch.any(gain <= 0):
+                raise ValueError("Poisson noise gain must be positive.")
+            if torch.any(x < 0):
+                raise ValueError(
+                    "Input tensor for Poisson noise must be non-negative.\n"
+                    "Consider setting ``clip_positive=True`` to avoid this error."
+                )
 
             y = torch.poisson(x / gain, generator=self.rng) * gain
 

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -1288,6 +1288,13 @@ def test_noise(device, noise_type):
     )
     assert y1.shape == x.shape
 
+    # Test that negative values input are handled correctly
+    if noise_type in ["Poisson", "PoissonGaussian", "Gamma"]:
+        x_neg = -torch.ones((1, 3, 2), device=device).unsqueeze(0)
+
+        with pytest.raises(ValueError):
+            y_neg = physics(x_neg)
+
 
 def test_noise_domain(device):
     r"""

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -29,6 +29,7 @@ Fixed
 - Add support for computing the evaluation loss for splitting losses like :class:`deepinv.loss.SplittingLoss` in the trainer (:gh:`881` by `Jérémy Scanvic`_)
 - Add a deprecation warning in :func:`deepinv.utils.plot_inset` in favor of :func:`deepinv.utils.plot` with `plot_inset=True` (:gh:`1148` by `Paul Bernard`_).
 - Fix dimensions mismatch in :class:`deepinv.physics.TomographyWithAstra` with 3D phantoms (:gh:`1137` by `Baptiste Legouix`_)
+- Add warning and error handling for negative inputs in BlurFFT and Poisson noise (:gh:`1155` by `Thibaut Modrzyk`_)
 
 
 v0.4.0


### PR DESCRIPTION
Add a warning in `BlurFTT`'s doc about using it in combination with `PoissonNoise`.
Add a note in `PoissonNoise`'s doc about negative inputs and the `clip_negative` param.
Change the runtime error message to suggest using `clip_negative` param.
Replace asserts with `if + raise ValueError`, which was not taken into account in PR #1132.

I replaced the former logic to catch negative values in the input and negative `gain` in `PoissonNoise`, which was conditioned on `rng` being on CUDA. I'm not sure why that was the case, @jscanvic do you think it's ok to remove this condition ?

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
