### PR TITLE
HOTFIX GeneratorMixture

### DIFF
--- a/deepinv/physics/generator/base.py
+++ b/deepinv/physics/generator/base.py
@@ -223,11 +223,14 @@ class GeneratorMixture(PhysicsGenerator):
         verbose: bool = False,
     ) -> None:
         super().__init__(device=device, rng=rng)
-        probs = torch.tensor(probs)
+
+        probs = torch.tensor(probs, device=device)
         assert torch.sum(probs) == 1, "The sum of the probabilities must be 1."
+
+        self.register_buffer("probs", probs)
+        self.register_buffer("cum_probs", torch.cumsum(probs, dim=0))
+
         self.generators = generators
-        self.probs = probs
-        self.cum_probs = torch.cumsum(probs, dim=0)
 
         self.use_batch_sampling = use_batch_sampling
         if self.use_batch_sampling:
@@ -306,15 +309,15 @@ class GeneratorMixture(PhysicsGenerator):
                     params = generator.step(batch_size=num_samples, seed=seed, **kwargs)
 
                     # Store with position information for later reordering
-                for key, value in params.items():
-                    if key not in result:
-                        result[key] = torch.empty(
-                            batch_size,
-                            *value.shape[1:],
-                            dtype=value.dtype,
-                            device=value.device,
-                        )
-                    result[key][batch_positions] = value
+                    for key, value in params.items():
+                        if key not in result:
+                            result[key] = torch.empty(
+                                batch_size,
+                                *value.shape[1:],
+                                dtype=value.dtype,
+                                device=value.device,
+                            )
+                        result[key][batch_positions] = value
 
             return result
 

--- a/deepinv/tests/test_generators.py
+++ b/deepinv/tests/test_generators.py
@@ -30,6 +30,12 @@ GENERATORS = [
 ]
 
 MIXTURES = list(itertools.combinations(GENERATORS, 2))
+# To test GeneratorMixture.use_batch_sampling feature, when compatible
+# generators (same output keys and shapes), samples from different generators
+# per batch element
+MIXTURES += [("MotionBlurGenerator", "MotionBlurGenerator")]
+MIXTURES += [("DiffractionBlurGenerator", "DiffractionBlurGenerator")]
+
 SIZES = [(5, 5), (6, 6)]
 NUM_CHANNELS = [1, 3]
 
@@ -736,6 +742,15 @@ def test_generator_mixture(
         rng=rng,
         verbose=True,
     )
+
+    # When two generators belong to the same class and have same output keys and shapes
+    # use_batch_sampling must be True if specified
+    if type(generator_pair[0]) == type(generator_pair[1]):
+        assert mixture.use_batch_sampling == use_batch_sampling
+
+        # Check that the mixture functions properly when use_batch_sampling is True
+        # and all params from the batch are from the same generator (force it by using batch_size=1)
+        params = mixture.step(batch_size=1, seed=0)
 
     params = mixture.step(batch_size=4, seed=0)
     assert isinstance(params, dict)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -360,7 +360,7 @@ New Features
 - Added example on image generation, working for :class:`deepinv.models.NCSNpp`, :class:`deepinv.models.ADMUNet`, :class:`deepinv.models.DRUNet` and :class:`deepinv.models.DiffUNet` (by `Minh Hai Nguyen`_ and `Matthieu Terris`_)
 - Added VP-SDE for image generation and posterior sampling (:gh:`434` by `Minh Hai Nguyen`_)
 
-- global path for datasets :func:`deepinv.utils.get_data_home` (:gh:`347` by `Julian Tachella`_ and `Thomas Moreau`_)
+- global path for datasets `deepinv.utils.get_data_home` (:gh:`347` by `Julian Tachella`_ and `Thomas Moreau`_)
 - New docs user guide (:gh:`347` by `Julian Tachella`_ and `Thomas Moreau`_)
 - Added UNSURE loss (:gh:`313` by `Julian Tachella`_)
 - Add transform symmetrisation, further transform arithmetic, and new equivariant denoiser (:gh:`259` by `Andrew Wang`_)


### PR DESCRIPTION
The recent PR #1093 supposed to fix GeneratorMixture actually broke it:
- adding `register_buffer` for `self.probs` and `self.cum_probs` to avoid device mismatch in `self.step`
- add pairs of compatible generators in `MIXTURES` in `test_generators.py` to effectively test the new `use_batch_sampling` feature of GeneratorMixture
- fix logic in `self.step` so that GeneratorMixture functions properly when all batch elements are sampled from the same generator.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
