### PR TITLE
docs(optim): fix bregman_prox description from right to left

### DIFF
--- a/deepinv/optim/potential.py
+++ b/deepinv/optim/potential.py
@@ -136,7 +136,7 @@ class Potential(nn.Module):
         **kwargs,
     ):
         r"""
-        Calculates the (right) Bregman proximity operator of h` at :math:`x`, with Bregman potential `bregman_potential`.
+        Calculates the (left) Bregman proximity operator of h` at :math:`x`, with Bregman potential `bregman_potential`.
 
         .. math::
 


### PR DESCRIPTION
Closes #1112.

## Summary

The `bregman_prox` function docstring in `deepinv/optim/potential.py` describes itself as calculating the **(right)** Bregman proximity operator, but the math block directly below it (and the implementation) compute the **left** Bregman proximity operator:

$$\operatorname{prox}^h_{\gamma \hbar}(x) = \arg\min_u \left\\{ \frac{\gamma}{2} h(u) + D_\phi(u, x) \right\\}$$

The divergence is `D_phi(u, x)` — from x to u — which is the left Bregman prox by convention. The right Bregman prox would use `D_phi(x, u)`.

## Change

One-word swap in the docstring at `deepinv/optim/potential.py:139`: `(right)` → `(left)`. No behavior change.

PR #1113 by @tysoncung made this same change but was closed by the author without comment. The issue is still open, the body and implementation still mismatch, so re-submitting.