### PR TITLE
GPU fixes + remove FrEIA dependency + fix patchNR demo

### DIFF
--- a/.github/workflows/docs_cpu.yml
+++ b/.github/workflows/docs_cpu.yml
@@ -70,7 +70,7 @@ jobs:
           SG_PATTERN: ${{ steps.get_pattern.outputs.SG_PATTERN }}
         run: |
            echo "Running Sphinx with filename_pattern: $SG_PATTERN"
-           pixi run -e docs sphinx-build -W docs/source _build -D "sphinx_gallery_conf.filename_pattern=$SG_PATTERN"
+           pixi run -e docs-cpu sphinx-build -W docs/source _build -D "sphinx_gallery_conf.filename_pattern=$SG_PATTERN"
 
       - name: Notebook generation
         run: |
@@ -82,7 +82,7 @@ jobs:
             mkdir -p "$out_dir"
             base="$(basename "$rel" .py)"
             out_path="$out_dir/$base.ipynb"
-            pixi run -e doctest python .github/scripts/convert_to_notebook.py --input "$f" --output "$out_path"
+            pixi run -e doctest-cpu python .github/scripts/convert_to_notebook.py --input "$f" --output "$out_path"
           done
 
       - name: Upload Documentation Artifact

--- a/.github/workflows/docs_cpu.yml
+++ b/.github/workflows/docs_cpu.yml
@@ -103,6 +103,6 @@ jobs:
           HF_HUB_DISABLE_PROGRESS_BARS: 1
           DEEPINV_DOWNLOAD_VERBOSE: 0
         run: |
-          pixi run -e doctest pytest --doctest-glob="*.rst" docs/ \
+          pixi run -e doctest-cpu pytest --doctest-glob="*.rst" docs/ \
             --ignore=docs/source/user_guide/training/multigpu.rst \
             --ignore=docs/source/user_guide/training/datasets.rst

--- a/.github/workflows/docs_cpu.yml
+++ b/.github/workflows/docs_cpu.yml
@@ -24,7 +24,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
-          environments: docs doctest
+          environments: docs-cpu doctest-cpu
 
       - name: Fetch base branch
         run: git fetch origin ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/docs_cpu.yml
+++ b/.github/workflows/docs_cpu.yml
@@ -57,7 +57,7 @@ jobs:
             else
               BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
               HEAD_REF="HEAD"
-              PATTERN=$(pixi run -e docs python .github/scripts/diff_sphinx_gallery.py "$BASE_REF" "$HEAD_REF")
+              PATTERN=$(pixi run -e docs-cpu python .github/scripts/diff_sphinx_gallery.py "$BASE_REF" "$HEAD_REF")
               echo "Conditional PR Pattern: $PATTERN"
             fi
           else

--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -23,6 +23,7 @@ jobs:
       WORKING_DIR: "/local/jtachell"
       PIXI_HOME: "/local/jtachell/.pixi"
       TMP_DIR: "/local/jtachell/tmp"
+      DEEPINV_CACHE: "/local/jtachell/.cache/deepinv"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -21,6 +21,8 @@ jobs:
       DEEPINV_MOCK_TESTS: "True"
       DEEPINV_DOWNLOAD_VERBOSE: "False"
       WORKING_DIR: "/local/jtachell"
+      PIXI_HOME: "/local/jtachell/.pixi"
+      TMP_DIR: "/local/jtachell/tmp"
 
     steps:
       - uses: actions/checkout@v5
@@ -33,7 +35,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
-          pixi-bin-path: /local/jtachell/pixi/bin/pixi
+          post-cleanup: true
           environments: docs doctest
 
       - name: Check import

--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -26,6 +26,7 @@ jobs:
       DEEPINV_CACHE: "/local/jtachell/.cache/deepinv"
       HF_HOME: "/local/jtachell/.cache/huggingface"
       TORCH_HOME: "/local/jtachell/.cache/torch"
+      HOME: "/local/jtachell"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -40,6 +40,20 @@ jobs:
         run: |
           pixi run -e docs python -c "import deepinv"
 
+      - name: Check CUDA is available
+        run: |
+          pixi run -e docs python -c "
+          import torch
+          assert torch.cuda.is_available(), (
+              f'torch.cuda.is_available() returned False. '
+              f'Device count: {torch.cuda.device_count()}, '
+              f'PyTorch build: {torch.version.cuda}'
+          )
+          print(f'CUDA OK — {torch.cuda.device_count()} device(s), '
+                f'CUDA {torch.version.cuda}, '
+                f'GPU: {torch.cuda.get_device_name(0)}')
+          "
+
       - name: Determine which examples to run
         id: get_pattern
         env:

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -43,6 +43,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
+          environments: full-cpu test-cpu
 
       - name: Restore .testmondata
         uses: actions/cache/restore@v3

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -21,15 +21,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            environment: "full"
+            environment: "full-cpu"
             name: "ubuntu all optional dependencies and doctests"
             pytest_args: "-n 2 --dist=loadgroup --doctest-modules"
           - os: ubuntu-latest
-            environment: "test"
+            environment: "test-cpu"
             name: "ubuntu no optional dependencies"
             pytest_args: "-n 2 --dist=loadgroup"
           - os: windows-latest
-            environment: "full"
+            environment: "full-cpu"
             name: "windows all optional dependencies"
             pytest_args: "-n 2 --dist=loadgroup"
     env:

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -23,6 +23,7 @@ jobs:
       WORKING_DIR: "/local/jtachell"
       PIXI_HOME: "/local/jtachell/.pixi"
       TMP_DIR: "/local/jtachell/tmp"
+      DEEPINV_CACHE: "/local/jtachell/.cache/deepinv"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -21,6 +21,8 @@ jobs:
       DEEPINV_MOCK_TESTS: "True"
       DEEPINV_DOWNLOAD_VERBOSE: "False"
       WORKING_DIR: "/local/jtachell"
+      PIXI_HOME: "/local/jtachell/.pixi"
+      TMP_DIR: "/local/jtachell/tmp"
 
     steps:
       - uses: actions/checkout@v5
@@ -33,7 +35,8 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
-          pixi-bin-path: /local/jtachell/pixi/bin/pixi
+          post-cleanup: true
+          environments: full
 
       - name: Check import
         run: |

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -39,6 +39,20 @@ jobs:
         run: |
           pixi run -e full python -c "import deepinv"
 
+      - name: Check CUDA is available
+        run: |
+          pixi run -e full python -c "
+          import torch
+          assert torch.cuda.is_available(), (
+              f'torch.cuda.is_available() returned False. '
+              f'Device count: {torch.cuda.device_count()}, '
+              f'PyTorch build: {torch.version.cuda}'
+          )
+          print(f'CUDA OK — {torch.cuda.device_count()} device(s), '
+                f'CUDA {torch.version.cuda}, '
+                f'GPU: {torch.cuda.get_device_name(0)}')
+          "
+
       - name: Restore .testmondata # Restore testmon data from main to speed up tests
         uses: actions/cache/restore@v3
         id: restore-cache

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -803,7 +803,7 @@ class PatchNR(Prior):
         coupling blocks and the hidden neurons of the sub-networks are determined by ``num_layers`` and ``sub_net_size`` respectively.
         If `None`, it is set to :class:`deepinv.optim.prior.NormalizingFlow` model.
     :param str pretrained: Define pretrained weights by its path checkpoint, `None` for random initialization,
-        `"PatchNR_lodopab_small"` for the weights from the :ref:`limited-angle CT example <sphx_glr_auto_examples_optimization_demo_patch_priors_CT.py>`.
+        `"PatchNR_lodopab_small2"` for the weights from the :ref:`limited-angle CT example <sphx_glr_auto_examples_optimization_demo_patch_priors_CT.py>`.
     :param int patch_size: size of patches
     :param int channels: number of channels for the underlying images/patches.
     :param int num_layers: defines the number of coupling blocks of the normalizing flow if `normalizing_flow` is ``None``.
@@ -857,10 +857,10 @@ class PatchNR(Prior):
         else:
             self.normalizing_flow = normalizing_flow
         if pretrained:
-            if pretrained == "PatchNR_lodopab_small":
+            if pretrained == "PatchNR_lodopab_small2":
                 assert patch_size == 3
                 assert channels == 1
-                file_name = "PatchNR_lodopab_small.pt"
+                file_name = "PatchNR_lodopab_small2.pt"
                 url = get_weights_url(model_name="demo", file_name=file_name)
                 weights = load_state_dict_from_url(
                     url, map_location=lambda storage, loc: storage, file_name=file_name

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Callable
 import numpy as np
 import torch
 import torch.nn as nn
-from typing import Callable
+import torch.nn.functional as F
 
 from deepinv.optim.potential import Potential
 from deepinv.models.tv import TVDenoiser

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -608,36 +608,26 @@ class GLOWCouplingBlock(nn.Module):
     r"""GLOW-style affine coupling block.
 
     Each block performs two successive affine coupling steps on the input vector,
-    which is split into two halves ``(x1, x2)``:
+    which is split into two halves :math:`(x_1, x_2)`:
 
-    * Step 1 — a subnetwork acting on ``x1`` produces a pointwise scale ``s1`` and
-      shift ``t1`` that are applied to ``x2``: ``y2 = x2 * exp(s1) + t1``.
-    * Step 2 — a second subnetwork acting on ``y2`` produces ``s2, t2`` that are
-      applied to ``x1``: ``y1 = x1 * exp(s2) + t2``.
+    * Step 1 — a subnetwork acting on :math:`x_1` produces a pointwise scale :math:`s1` and
+      shift :math:`t_1` that are applied to :math:`x_2`: :math:`y_2 = x_2 \cdot \exp(s_1) + t_1`.
+    * Step 2 — a second subnetwork acting on :math:`y_2` produces :math:`(s_2, t_2)` that are
+      applied to :math:`x_1` : :math:`y_1 = x_1 \cdot \exp(s_2) + t_2`.
 
     Both steps are exactly invertible, and their combined log-determinant of the
-    Jacobian is ``sum(s1) + sum(s2)``.  The scale outputs are soft-clamped via
-    ``clamp * (2/π) * arctan(s / clamp)`` to keep the log-determinant bounded and
+    Jacobian is :math:`1^{\top}(s_1 + s_2)`.  The scale outputs are soft-clamped via
+    :math:`\text{clamp} \frac{2}{\pi} \text{arctan}(s / \text{clamp})` to keep the log-determinant bounded and
     training stable.
 
     The two-step affine coupling structure follows :footcite:t:`dinh2017density`, and
     the soft-clamping of scales is introduced in :footcite:t:`kingma2018glow`.
 
     :param int dim: total input/output dimension (will be split evenly).
-    :param callable subnet: a callable ``subnet(channels_in, channels_out) -> nn.Module``
+    :param Callable subnet: a callable ``subnet(channels_in, channels_out) -> nn.Module``
         that constructs the subnetworks used inside each coupling step.
-
-        For example:
-
-        ::
-
-            subnet = lambda c_in, c_out: nn.Sequential(
-                nn.Linear(c_in, 256), nn.ReLU(),
-                nn.Linear(256, 256), nn.ReLU(),
-                nn.Linear(256, c_out),
-            )
-
     :param float clamp: soft-clamping magnitude for the log-scale outputs. Default is ``1.6``.
+
     """
 
     def __init__(self, dim: int, subnet: Callable, clamp: float = 1.6):
@@ -719,20 +709,33 @@ class NormalizingFlow(nn.Module):
 
     :param int dimension: dimension of each input sample (flattened patch size).
     :param int num_layers: number of coupling blocks to stack.
-    :param callable subnet: a callable ``subnet(channels_in, channels_out) -> nn.Module``
+    :param Callable subnet: a callable ``subnet(channels_in, channels_out) -> nn.Module``
         that constructs the subnetworks used inside each coupling block.
-
-        For example
-
-        ::
-
-            subnet = lambda c_in, c_out: nn.Sequential(
-                nn.Linear(c_in, 256), nn.ReLU(),
-                nn.Linear(256, 256), nn.ReLU(),
-                nn.Linear(256, c_out),
-            )
-
     :param float clamp: soft-clamping magnitude passed to every coupling block. Default is ``1.6``.
+
+    |sep|
+
+    :Examples:
+
+
+    >>> import torch
+    >>> import torch.nn as nn
+    >>> subnet = lambda c_in, c_out: nn.Sequential(
+    ...     nn.Linear(c_in, 32), nn.ReLU(),
+    ...     nn.Linear(32, 32), nn.ReLU(),
+    ...     nn.Linear(32, c_out),
+    ... )
+    >>> flow = NormalizingFlow(dimension=8, num_layers=2, subnet=subnet)
+    >>> x = torch.randn(4, 8)
+    >>> z, log_det = flow(x)
+    >>> z.shape
+    torch.Size([4, 8])
+    >>> log_det.shape
+    torch.Size([4])
+    >>> x_rec, _ = flow(z, rev=True)  # inverse flow recovers the input
+    >>> torch.allclose(x, x_rec, atol=1e-5)
+    True
+
     """
 
     def __init__(
@@ -807,6 +810,19 @@ class PatchNR(Prior):
     :param int sub_net_size: defines the number of hidden neurons in the subnetworks of the normalizing flow
         if `normalizing_flow` is ``None``.
     :param str device: used device
+
+    |sep|
+
+    :Examples:
+
+    >>> import torch
+    >>> import deepinv as dinv
+    >>> prior = dinv.optim.PatchNR(patch_size=6, channels=1)
+    >>> x = torch.randn(2, 10, 36)  # (batch, n_patches, patch_size^2 * channels)
+    >>> nll = prior.fn(x)
+    >>> nll.shape
+    torch.Size([2, 10])
+
     """
 
     def __init__(

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -610,14 +610,14 @@ class GLOWCouplingBlock(nn.Module):
     Each block performs two successive affine coupling steps on the input vector,
     which is split into two halves :math:`(x_1, x_2)`:
 
-    * Step 1 — a subnetwork acting on :math:`x_1` produces a pointwise scale :math:`s1` and
+    * Step 1 — a subnetwork acting on :math:`x_1` produces a pointwise scale :math:`s_1` and
       shift :math:`t_1` that are applied to :math:`x_2`: :math:`y_2 = x_2 \cdot \exp(s_1) + t_1`.
     * Step 2 — a second subnetwork acting on :math:`y_2` produces :math:`(s_2, t_2)` that are
       applied to :math:`x_1` : :math:`y_1 = x_1 \cdot \exp(s_2) + t_2`.
 
     Both steps are exactly invertible, and their combined log-determinant of the
     Jacobian is :math:`1^{\top}(s_1 + s_2)`.  The scale outputs are soft-clamped via
-    :math:`\text{clamp} \frac{2}{\pi} \text{arctan}(s / \text{clamp})` to keep the log-determinant bounded and
+    :math:`\text{clamp} \times \frac{2}{\pi} \text{arctan}(s / \text{clamp})` to keep the log-determinant bounded and
     training stable.
 
     The two-step affine coupling structure follows :footcite:t:`dinh2017density`, and

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -551,30 +551,214 @@ class PatchPrior(Prior):
         return reg
 
 
+class _SubnetFC(nn.Module):
+    r"""Fully-connected subnetwork used inside GLOW coupling blocks.
+
+    :param int c_in: number of input features.
+    :param int c_out: number of output features.
+    :param int hidden_size: number of hidden units in each of the two intermediate layers.
+    """
+
+    def __init__(self, c_in: int, c_out: int, hidden_size: int):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(c_in, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, c_out),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        r"""
+        Applies the fully-connected subnetwork to the input.
+
+        :param torch.Tensor x: input tensor of shape ``(N, c_in)``.
+        :return: (:class:`torch.Tensor`) output tensor of shape ``(N, c_out)``.
+        """
+        return self.net(x)
+
+
+class _GLOWCouplingBlock(nn.Module):
+    r"""GLOW-style affine coupling block.
+
+    Each block performs two successive affine coupling steps on the input vector,
+    which is split into two halves ``(x1, x2)``:
+
+    * Step 1 — a subnetwork acting on ``x1`` produces a pointwise scale ``s1`` and
+      shift ``t1`` that are applied to ``x2``: ``y2 = x2 * exp(s1) + t1``.
+    * Step 2 — a second subnetwork acting on ``y2`` produces ``s2, t2`` that are
+      applied to ``x1``: ``y1 = x1 * exp(s2) + t2``.
+
+    Both steps are exactly invertible, and their combined log-determinant of the
+    Jacobian is ``sum(s1) + sum(s2)``.  The scale outputs are soft-clamped via
+    ``clamp * (2/π) * arctan(s / clamp)`` to keep the log-determinant bounded and
+    training stable.
+
+    The two-step affine coupling structure follows :footcite:t:`dinh2016density`, and
+    the soft-clamping of scales is introduced in :footcite:t:`kingma2018glow`.
+
+    :param int dim: total input/output dimension (will be split evenly).
+    :param int sub_net_size: number of hidden units in each :class:`_SubnetFC` subnetwork.
+    :param float clamp: soft-clamping magnitude for the log-scale outputs. Default is ``1.6``.
+    """
+
+    def __init__(self, dim: int, sub_net_size: int, clamp: float = 1.6):
+        super().__init__()
+        self.clamp = clamp
+        self.split1 = dim // 2
+        self.split2 = dim - self.split1
+        # subnet1: x1 -> (s1, t1) that acts on x2
+        self.subnet1 = _SubnetFC(self.split1, self.split2 * 2, sub_net_size)
+        # subnet2: y2 -> (s2, t2) that acts on x1
+        self.subnet2 = _SubnetFC(self.split2, self.split1 * 2, sub_net_size)
+
+    def _soft_clamp(self, s: torch.Tensor) -> torch.Tensor:
+        r"""
+        Applies soft clamping ``clamp * (2/π) * arctan(s / clamp)`` to the log-scale tensor.
+
+        :param torch.Tensor s: unconstrained log-scale tensor.
+        :return: (:class:`torch.Tensor`) soft-clamped log-scale tensor with values in ``(-clamp, clamp)``.
+        """
+        return self.clamp * (2.0 / np.pi) * torch.atan(s / self.clamp)
+
+    def forward(self, x: torch.Tensor, rev: bool = False):
+        r"""
+        Applies the coupling block in the forward or inverse direction.
+
+        :param torch.Tensor x: input tensor of shape ``(N, dim)``.
+        :param bool rev: if ``True``, applies the inverse transformation. Default is ``False``.
+        :return: tuple ``(y, log_det)`` where ``y`` (:class:`torch.Tensor`) is the
+            transformed tensor of shape ``(N, dim)`` and ``log_det`` (:class:`torch.Tensor`)
+            is the log-determinant of the Jacobian of shape ``(N,)``.
+        """
+        x1, x2 = x[:, : self.split1], x[:, self.split1 :]
+
+        if not rev:
+            # Step 1: transform x2 using x1
+            st1 = self.subnet1(x1)
+            s1 = self._soft_clamp(st1[:, : self.split2])
+            t1 = st1[:, self.split2 :]
+            y2 = x2 * torch.exp(s1) + t1
+            log_det = s1.sum(dim=1)
+
+            # Step 2: transform x1 using y2
+            st2 = self.subnet2(y2)
+            s2 = self._soft_clamp(st2[:, : self.split1])
+            t2 = st2[:, self.split1 :]
+            y1 = x1 * torch.exp(s2) + t2
+            log_det = log_det + s2.sum(dim=1)
+
+            return torch.cat([y1, y2], dim=1), log_det
+        else:
+            # Inverse step 2: recover x1 from x2 (which is y2 in forward)
+            st2 = self.subnet2(x2)
+            s2 = self._soft_clamp(st2[:, : self.split1])
+            t2 = st2[:, self.split1 :]
+            y1 = (x1 - t2) * torch.exp(-s2)
+            log_det = -s2.sum(dim=1)
+
+            # Inverse step 1: recover x2 using y1
+            st1 = self.subnet1(y1)
+            s1 = self._soft_clamp(st1[:, : self.split2])
+            t1 = st1[:, self.split2 :]
+            y2 = (x2 - t1) * torch.exp(-s1)
+            log_det = log_det - s1.sum(dim=1)
+
+            return torch.cat([y1, y2], dim=1), log_det
+
+
+class _NormalizingFlow(nn.Module):
+    r"""Sequential normalizing flow built from :class:`_GLOWCouplingBlock` modules.
+
+    The flow maps an input sample ``x`` to a latent representation ``z`` by passing
+    it through ``num_layers`` invertible coupling blocks in sequence.  The
+    log-determinant of the full Jacobian is accumulated additively across blocks.
+    Setting ``rev=True`` runs the blocks in reverse order to recover the original
+    sample from a latent code.
+
+    The architecture follows the generative flow of :footcite:t:`kingma2018glow`.
+
+    :param int dimension: dimension of each input sample (flattened patch size).
+    :param int num_layers: number of :class:`_GLOWCouplingBlock` blocks to stack.
+    :param int sub_net_size: number of hidden units in each subnetwork of every coupling block.
+    :param float clamp: soft-clamping magnitude passed to every coupling block. Default is ``1.6``.
+    """
+
+    def __init__(
+        self, dimension: int, num_layers: int, sub_net_size: int, clamp: float = 1.6
+    ):
+        super().__init__()
+        self.blocks = nn.ModuleList(
+            [
+                _GLOWCouplingBlock(dimension, sub_net_size, clamp)
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(self, x: torch.Tensor, rev: bool = False):
+        r"""
+        Passes the input through all coupling blocks sequentially.
+
+        :param torch.Tensor x: input tensor of shape ``(N, dimension)``.
+        :param bool rev: if ``True``, applies the blocks in reverse order (inverse flow). Default is ``False``.
+        :return: tuple ``(z, log_det)`` where ``z`` (:class:`torch.Tensor`) is the latent
+            representation of shape ``(N, dimension)`` and ``log_det`` (:class:`torch.Tensor`)
+            is the total log-determinant of the Jacobian of shape ``(N,)``.
+        """
+        log_det = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
+        blocks = self.blocks if not rev else reversed(self.blocks)
+        for block in blocks:
+            x, ld = block(x, rev=rev)
+            log_det = log_det + ld
+        return x, log_det
+
+
 class PatchNR(Prior):
     r"""
-    Patch prior via normalizing flows.
+    Patch prior via normalizing flows :footcite:t:`altekruger2023patchnr`.
 
-    The forward method evaluates its negative log likelihood.
+    The prior is defined as the sum of the negative log-likelihoods of all
+    (overlapping) patches of the image under a learned normalizing flow model.
+    Denoting by :math:`E_i x` the :math:`i`-th patch of image :math:`x` (out of :math:`N`) and by
+    :math:`f_\theta` the normalizing flow with parameters :math:`\theta`, the prior reads
+
+    .. math::
+
+        \reg{x} = \frac{1}{N} \sum_{i=1}^{N} -\log p_\theta(E_i x)
+
+    where :math:`p_\theta` is the patch distribution implicitly defined by the flow.
+    Applying the change-of-variables formula with the standard Gaussian base distribution
+    :math:`p_z = \mathcal{N}(0, I)`, this expands to
+
+    .. math::
+
+        \reg{x} = \frac{1}{N} \sum_{i=1}^{N} \left(
+            \frac{1}{2}\| f_\theta(E_i x) \|_2^2
+            - \log \left|\det J_{f_\theta}(E_i x)\right|
+        \right)
+
+    where :math:`J_{f_\theta}` is the Jacobian of :math:`f_\theta`.  Both terms are
+    computed in a single forward pass through the flow, which returns the latent code
+    :math:`z = f_\theta(E_i x)` and the log-determinant
+    :math:`\log |\det J_{f_\theta}(E_i x)|` simultaneously.
+
+    The forward method evaluates this negative log likelihood.
 
     :param torch.nn.Module normalizing_flow: describes the normalizing flow of the model. Generally it can be any :class:`torch.nn.Module`
-        supporting backpropagation. It takes a (batched) tensor of flattened patches and the boolean rev (default `False`)
-        as input and provides the value and the log-determinant of the Jacobian of the normalizing flow as an output
-        If `rev=True`, it considers the inverse of the normalizing flow.
-        When set to ``None`` it is set to a dense invertible neural network built with the FrEIA library, where the number of
-        invertible blocks and the size of the subnetworks is determined by the parameters `num_layers` and `sub_net_size`.
+        supporting backpropagation. It takes a (batched) tensor of flattened patches and the boolean ``rev`` (default ``False``)
+        as input and returns ``(latent, log_det_jacobian)`` as output.
+        If ``rev=True``, it applies the inverse of the flow.
+        When set to ``None``, a GLOW-style invertible neural network is built from native PyTorch layers, where the number of
+        coupling blocks and the size of the sub-networks is determined by ``num_layers`` and ``sub_net_size``.
     :param str pretrained: Define pretrained weights by its path to a `.pt` file, None for random initialization,
         `"PatchNR_lodopab_small"` for the weights from the limited-angle CT example.
     :param int patch_size: size of patches
     :param int channels: number of channels for the underlying images/patches.
-    :param int num_layers: defines the number of blocks of the generated normalizing flow if `normalizing_flow` is ``None``.
-    :param int sub_net_size: defines the number of hidden neurons in the subnetworks of the generated normalizing flow
+    :param int num_layers: defines the number of coupling blocks of the normalizing flow if `normalizing_flow` is ``None``.
+    :param int sub_net_size: defines the number of hidden neurons in the subnetworks of the normalizing flow
         if `normalizing_flow` is ``None``.
     :param str device: used device
-
-    .. note::
-
-        This class requires the ``FrEIA`` package to be installed. Install with ``pip install FrEIA``.
     """
 
     def __init__(
@@ -587,36 +771,15 @@ class PatchNR(Prior):
         sub_net_size=256,
         device="cpu",
     ):
-        import FrEIA.framework as Ff
-        import FrEIA.modules as Fm
-
         super(PatchNR, self).__init__()
         if normalizing_flow is None:
-            # Create Normalizing Flow with FrEIA
             dimension = patch_size**2 * channels
-
-            def subnet_fc(c_in, c_out):
-                return nn.Sequential(
-                    nn.Linear(c_in, sub_net_size),
-                    nn.ReLU(),
-                    nn.Linear(sub_net_size, sub_net_size),
-                    nn.ReLU(),
-                    nn.Linear(sub_net_size, c_out),
-                )
-
-            nodes = [Ff.InputNode(dimension, name="input")]
-            for k in range(num_layers):
-                nodes.append(
-                    Ff.Node(
-                        nodes[-1],
-                        Fm.GLOWCouplingBlock,
-                        {"subnet_constructor": subnet_fc, "clamp": 1.6},
-                        name=f"coupling_{k}",
-                    )
-                )
-            nodes.append(Ff.OutputNode(nodes[-1], name="output"))
-
-            self.normalizing_flow = Ff.GraphINN(nodes, verbose=False).to(device)
+            self.normalizing_flow = _NormalizingFlow(
+                dimension=dimension,
+                num_layers=num_layers,
+                sub_net_size=sub_net_size,
+                clamp=1.6,
+            ).to(device)
         else:
             self.normalizing_flow = normalizing_flow
         if pretrained:

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -1,12 +1,13 @@
 import numpy as np
 import torch
 import torch.nn as nn
+from typing import Callable
 
 from deepinv.optim.potential import Potential
 from deepinv.models.tv import TVDenoiser
 from deepinv.models.wavdict import WaveletDenoiser, WaveletDictDenoiser
 from deepinv.utils import patch_extractor
-from deepinv.models.utils import load_state_dict_from_url
+from deepinv.models.utils import load_state_dict_from_url, get_weights_url
 
 
 class Prior(Potential):
@@ -551,35 +552,7 @@ class PatchPrior(Prior):
         return reg
 
 
-class _SubnetFC(nn.Module):
-    r"""Fully-connected subnetwork used inside GLOW coupling blocks.
-
-    :param int c_in: number of input features.
-    :param int c_out: number of output features.
-    :param int hidden_size: number of hidden units in each of the two intermediate layers.
-    """
-
-    def __init__(self, c_in: int, c_out: int, hidden_size: int):
-        super().__init__()
-        self.net = nn.Sequential(
-            nn.Linear(c_in, hidden_size),
-            nn.ReLU(),
-            nn.Linear(hidden_size, hidden_size),
-            nn.ReLU(),
-            nn.Linear(hidden_size, c_out),
-        )
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        r"""
-        Applies the fully-connected subnetwork to the input.
-
-        :param torch.Tensor x: input tensor of shape ``(N, c_in)``.
-        :return: (:class:`torch.Tensor`) output tensor of shape ``(N, c_out)``.
-        """
-        return self.net(x)
-
-
-class _GLOWCouplingBlock(nn.Module):
+class GLOWCouplingBlock(nn.Module):
     r"""GLOW-style affine coupling block.
 
     Each block performs two successive affine coupling steps on the input vector,
@@ -595,23 +568,35 @@ class _GLOWCouplingBlock(nn.Module):
     ``clamp * (2/π) * arctan(s / clamp)`` to keep the log-determinant bounded and
     training stable.
 
-    The two-step affine coupling structure follows :footcite:t:`dinh2016density`, and
+    The two-step affine coupling structure follows :footcite:t:`dinh2017density`, and
     the soft-clamping of scales is introduced in :footcite:t:`kingma2018glow`.
 
     :param int dim: total input/output dimension (will be split evenly).
-    :param int sub_net_size: number of hidden units in each :class:`_SubnetFC` subnetwork.
+    :param callable subnet: a callable ``subnet(channels_in, channels_out) -> nn.Module``
+        that constructs the subnetworks used inside each coupling step.
+
+        For example:
+
+        ::
+
+            subnet = lambda c_in, c_out: nn.Sequential(
+                nn.Linear(c_in, 256), nn.ReLU(),
+                nn.Linear(256, 256), nn.ReLU(),
+                nn.Linear(256, c_out),
+            )
+
     :param float clamp: soft-clamping magnitude for the log-scale outputs. Default is ``1.6``.
     """
 
-    def __init__(self, dim: int, sub_net_size: int, clamp: float = 1.6):
+    def __init__(self, dim: int, subnet: Callable, clamp: float = 1.6):
         super().__init__()
         self.clamp = clamp
         self.split1 = dim // 2
         self.split2 = dim - self.split1
         # subnet1: x1 -> (s1, t1) that acts on x2
-        self.subnet1 = _SubnetFC(self.split1, self.split2 * 2, sub_net_size)
+        self.subnet1 = subnet(self.split1, self.split2 * 2)
         # subnet2: y2 -> (s2, t2) that acts on x1
-        self.subnet2 = _SubnetFC(self.split2, self.split1 * 2, sub_net_size)
+        self.subnet2 = subnet(self.split2, self.split1 * 2)
 
     def _soft_clamp(self, s: torch.Tensor) -> torch.Tensor:
         r"""
@@ -668,8 +653,8 @@ class _GLOWCouplingBlock(nn.Module):
             return torch.cat([y1, y2], dim=1), log_det
 
 
-class _NormalizingFlow(nn.Module):
-    r"""Sequential normalizing flow built from :class:`_GLOWCouplingBlock` modules.
+class NormalizingFlow(nn.Module):
+    r"""Sequential normalizing flow built from GLOW-style affine coupling blocks.
 
     The flow maps an input sample ``x`` to a latent representation ``z`` by passing
     it through ``num_layers`` invertible coupling blocks in sequence.  The
@@ -677,23 +662,33 @@ class _NormalizingFlow(nn.Module):
     Setting ``rev=True`` runs the blocks in reverse order to recover the original
     sample from a latent code.
 
-    The architecture follows the generative flow of :footcite:t:`kingma2018glow`.
+    The architecture follows the generative flow of :footcite:t:`kingma2018glow`,
+    using :class:`deepinv.optim.prior.GLOWCouplingBlock` as the building block.
 
     :param int dimension: dimension of each input sample (flattened patch size).
-    :param int num_layers: number of :class:`_GLOWCouplingBlock` blocks to stack.
-    :param int sub_net_size: number of hidden units in each subnetwork of every coupling block.
+    :param int num_layers: number of coupling blocks to stack.
+    :param callable subnet: a callable ``subnet(channels_in, channels_out) -> nn.Module``
+        that constructs the subnetworks used inside each coupling block.
+
+        For example
+
+        ::
+
+            subnet = lambda c_in, c_out: nn.Sequential(
+                nn.Linear(c_in, 256), nn.ReLU(),
+                nn.Linear(256, 256), nn.ReLU(),
+                nn.Linear(256, c_out),
+            )
+
     :param float clamp: soft-clamping magnitude passed to every coupling block. Default is ``1.6``.
     """
 
     def __init__(
-        self, dimension: int, num_layers: int, sub_net_size: int, clamp: float = 1.6
+        self, dimension: int, num_layers: int, subnet: Callable, clamp: float = 1.6
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
-            [
-                _GLOWCouplingBlock(dimension, sub_net_size, clamp)
-                for _ in range(num_layers)
-            ]
+            [GLOWCouplingBlock(dimension, subnet, clamp) for _ in range(num_layers)]
         )
 
     def forward(self, x: torch.Tensor, rev: bool = False):
@@ -720,12 +715,12 @@ class PatchNR(Prior):
 
     The prior is defined as the sum of the negative log-likelihoods of all
     (overlapping) patches of the image under a learned normalizing flow model.
-    Denoting by :math:`E_i x` the :math:`i`-th patch of image :math:`x` (out of :math:`N`) and by
+    Denoting by :math:`P_i x` the :math:`i`-th patch of image :math:`x` (out of :math:`N`) and by
     :math:`f_\theta` the normalizing flow with parameters :math:`\theta`, the prior reads
 
     .. math::
 
-        \reg{x} = \frac{1}{N} \sum_{i=1}^{N} -\log p_\theta(E_i x)
+        \reg{x} = \frac{1}{N} \sum_{i=1}^{N} -\log p_\theta(P_i x)
 
     where :math:`p_\theta` is the patch distribution implicitly defined by the flow.
     Applying the change-of-variables formula with the standard Gaussian base distribution
@@ -734,14 +729,14 @@ class PatchNR(Prior):
     .. math::
 
         \reg{x} = \frac{1}{N} \sum_{i=1}^{N} \left(
-            \frac{1}{2}\| f_\theta(E_i x) \|_2^2
-            - \log \left|\det J_{f_\theta}(E_i x)\right|
+            \frac{1}{2}\| f_\theta(P_i x) \|_2^2
+            - \log \left|\det J_{f_\theta}(P_i x)\right|
         \right)
 
     where :math:`J_{f_\theta}` is the Jacobian of :math:`f_\theta`.  Both terms are
     computed in a single forward pass through the flow, which returns the latent code
-    :math:`z = f_\theta(E_i x)` and the log-determinant
-    :math:`\log |\det J_{f_\theta}(E_i x)|` simultaneously.
+    :math:`z = f_\theta(P_i x)` and the log-determinant
+    :math:`\log |\det J_{f_\theta}(P_i x)|` simultaneously.
 
     The forward method evaluates this negative log likelihood.
 
@@ -749,10 +744,11 @@ class PatchNR(Prior):
         supporting backpropagation. It takes a (batched) tensor of flattened patches and the boolean ``rev`` (default ``False``)
         as input and returns ``(latent, log_det_jacobian)`` as output.
         If ``rev=True``, it applies the inverse of the flow.
-        When set to ``None``, a GLOW-style invertible neural network is built from native PyTorch layers, where the number of
-        coupling blocks and the size of the sub-networks is determined by ``num_layers`` and ``sub_net_size``.
-    :param str pretrained: Define pretrained weights by its path to a `.pt` file, None for random initialization,
-        `"PatchNR_lodopab_small"` for the weights from the limited-angle CT example.
+        When set to ``None``, a GLOW-style invertible neural network is built, where the number of
+        coupling blocks and the hidden neurons of the sub-networks are determined by ``num_layers`` and ``sub_net_size`` respectively.
+        If `None`, it is set to :class:`deepinv.optim.prior.NormalizingFlow` model.
+    :param str pretrained: Define pretrained weights by its path checkpoint, `None` for random initialization,
+        `"PatchNR_lodopab_small"` for the weights from the :ref:`limited-angle CT example <sphx_glr_auto_examples_optimization_demo_patch_priors_CT.py>`.
     :param int patch_size: size of patches
     :param int channels: number of channels for the underlying images/patches.
     :param int num_layers: defines the number of coupling blocks of the normalizing flow if `normalizing_flow` is ``None``.
@@ -774,29 +770,37 @@ class PatchNR(Prior):
         super(PatchNR, self).__init__()
         if normalizing_flow is None:
             dimension = patch_size**2 * channels
-            self.normalizing_flow = _NormalizingFlow(
+
+            def subnet_fc(c_in, c_out):
+                return nn.Sequential(
+                    nn.Linear(c_in, sub_net_size),
+                    nn.ReLU(),
+                    nn.Linear(sub_net_size, sub_net_size),
+                    nn.ReLU(),
+                    nn.Linear(sub_net_size, c_out),
+                )
+
+            self.normalizing_flow = NormalizingFlow(
                 dimension=dimension,
                 num_layers=num_layers,
-                sub_net_size=sub_net_size,
+                subnet=subnet_fc,
                 clamp=1.6,
             ).to(device)
         else:
             self.normalizing_flow = normalizing_flow
         if pretrained:
-            if pretrained[-3:] == ".pt":
-                weights = torch.load(pretrained, map_location=device)
-            else:
-                if pretrained.startswith("PatchNR_lodopab_small"):
-                    assert patch_size == 3
-                    assert channels == 1
-                    file_name = "PatchNR_lodopab_small.pt"
-                    url = "https://drive.google.com/uc?export=download&id=1Z2us9ZHjDGOlU6r1Jee0s2BBej2XV5-i"
-                else:
-                    raise ValueError("Pretrained weights not found!")
+            if pretrained == "PatchNR_lodopab_small":
+                assert patch_size == 3
+                assert channels == 1
+                file_name = "PatchNR_lodopab_small.pt"
+                url = get_weights_url(model_name="demo", file_name=file_name)
                 weights = load_state_dict_from_url(
                     url, map_location=lambda storage, loc: storage, file_name=file_name
                 )
-            self.normalizing_flow.load_state_dict(weights)
+            else:
+                weights = torch.load(pretrained, map_location=device)
+
+            self.load_state_dict(weights)
 
     def fn(self, x, *args, **kwargs):
         r"""

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -766,10 +766,10 @@ class NormalizingFlow(nn.Module):
 
 class PatchNR(Prior):
     r"""
-    Patch prior via normalizing flows :footcite:t:`altekruger2023patchnr`.
+    Patch prior via normalizing flows.
 
     The prior is defined as the sum of the negative log-likelihoods of all
-    (overlapping) patches of the image under a learned normalizing flow model.
+    (overlapping) patches of the image under a learned normalizing flow model :footcite:p:`altekruger2023patchnr`.
     Denoting by :math:`P_i x` the :math:`i`-th patch of image :math:`x` (out of :math:`N`) and by
     :math:`f_\theta` the normalizing flow with parameters :math:`\theta`, the prior reads
 

--- a/deepinv/tests/test_external_libraries.py
+++ b/deepinv/tests/test_external_libraries.py
@@ -31,7 +31,7 @@ class TestTomographyWithAstra:
     @pytest.mark.parametrize("cubic", [True, False])
     @pytest.mark.parametrize("channels", [1, 3])
     def test_tomography_with_astra_logic(
-        self, is_2d, geometry_type, normalize, fbp, monkeypatch, cubic, channels
+        self, is_2d, geometry_type, normalize, fbp, monkeypatch, cubic, channels, device
     ):
         r"""
         Tests tomography operator with astra backend which does not have a numerically precise adjoint.
@@ -42,6 +42,7 @@ class TestTomographyWithAstra:
         :param bool fbp: Whether or not to approximate the pseudo-inverse with filtered back-projection.
         :param bool cubic: Whether or not the input image is cubic (i.e. has the same size in all dimensions).
         :param int channels: Number of input channels. The tomography operator is applied per channel.
+        :param str device: The device to run the test on.
         """
 
         pytest.importorskip(
@@ -50,8 +51,7 @@ class TestTomographyWithAstra:
             "installed with `conda install -c astra-toolbox -c nvidia astra-toolbox`",
         )
 
-        device = dinv.utils.get_device(verbose=False)
-        if str(device) != "cuda":
+        if "cuda" not in str(device):
             monkeypatch.setattr(
                 target=dinv.physics.functional.XrayTransform,
                 name="_forward_projection",

--- a/deepinv/tests/test_external_libraries.py
+++ b/deepinv/tests/test_external_libraries.py
@@ -1,6 +1,7 @@
 import deepinv as dinv
 import torch
 import pytest
+import astra
 
 
 class TestTomographyWithAstra:
@@ -16,6 +17,14 @@ class TestTomographyWithAstra:
 
     def dummy_projection(self, x: torch.Tensor, out: torch.Tensor) -> None:
         out[:] = 1.0
+
+    def dummy_create_projector(
+        self,
+        type: str,
+        projection_geometry: dict[str, float],
+        object_geometry: dict[str, float],
+    ) -> int:
+        return 1
 
     @pytest.mark.parametrize("normalize", [True, False, None])
     @pytest.mark.parametrize("fbp", [True, False])
@@ -66,6 +75,11 @@ class TestTomographyWithAstra:
                 target=dinv.physics.TomographyWithAstra,
                 name="compute_norm",
                 value=self.dummy_compute_norm,
+            )
+            monkeypatch.setattr(
+                target=astra,
+                name="create_projector",
+                value=self.dummy_create_projector,
             )
 
         ## Test 2d transforms

--- a/deepinv/tests/test_external_libraries.py
+++ b/deepinv/tests/test_external_libraries.py
@@ -1,7 +1,6 @@
 import deepinv as dinv
 import torch
 import pytest
-import astra
 
 
 class TestTomographyWithAstra:
@@ -54,7 +53,7 @@ class TestTomographyWithAstra:
         :param str device: The device to run the test on.
         """
 
-        pytest.importorskip(
+        astra = pytest.importorskip(
             "astra",
             reason="This test requires astra-toolbox. It should be "
             "installed with `conda install -c astra-toolbox -c nvidia astra-toolbox`",

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -937,11 +937,6 @@ def test_MLEM(imsize, dummy_dataset, device):
 
 
 def test_patch_prior(imsize, dummy_dataset, device):
-    pytest.importorskip(
-        "FrEIA",
-        reason="This test requires FrEIA. It should be "
-        "installed with `pip install FrEIA",
-    )
     torch.manual_seed(0)
 
     dataloader = DataLoader(

--- a/docs/source/_templates/myclass_template.rst
+++ b/docs/source/_templates/myclass_template.rst
@@ -12,3 +12,4 @@
 
 .. minigallery:: {{module}}.{{objname}}
     :add-heading: Examples using ``{{objname}}``:
+

--- a/docs/source/api/deepinv.optim.rst
+++ b/docs/source/api/deepinv.optim.rst
@@ -202,3 +202,4 @@ Utils
    :nosignatures:
 
    deepinv.optim.utils.GaussianMixtureModel
+

--- a/docs/source/api/deepinv.optim.rst
+++ b/docs/source/api/deepinv.optim.rst
@@ -89,8 +89,10 @@ Priors
    deepinv.optim.WaveletPrior
    deepinv.optim.TVPrior
    deepinv.optim.PatchPrior
-   deepinv.optim.PatchNR
    deepinv.optim.L12Prior
+   deepinv.optim.PatchNR
+   deepinv.optim.prior.NormalizingFlow
+   deepinv.optim.prior.GLOWCouplingBlock
 
 Predefined models
 -----------------

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -650,7 +650,7 @@ doi = {10.1287/moor.2016.0817}
 }
 
 @article{altekruger2023patchnr,
-  title={PatchNR: learning from very few images by patch normalizing flow regularization},
+  title={{PatchNR}: Learning from Very Few Images by Patch Normalizing Flow Regularization},
   author={Altekr{\"u}ger, Fabian and Denker, Alexander and Hagemann, Paul and Hertrich, Johannes and Maass, Peter and Steidl, Gabriele},
   journal={Inverse Problems},
   volume={39},
@@ -1367,3 +1367,19 @@ journal = {ACM Trans. Graph.}
   pages={071101},
   year={2023}
 }
+
+@inproceedings{kingma2018glow,
+  title={Glow: Generative flow with invertible 1x1 convolutions},
+  author={Kingma, Durk P and Dhariwal, Prafull},
+  booktitle={Advances in Neural Information Processing Systems},
+  volume={31},
+  year={2018}
+}
+
+@inproceedings{dinh2016density,
+  title={Density estimation using real-valued non-volume preserving (real NVP) transformations},
+  author={Dinh, Laurent and Sohl-Dickstein, Jascha and Bengio, Samy},
+  booktitle={International Conference on Learning Representations},
+  year={2017}
+}
+

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1369,17 +1369,20 @@ journal = {ACM Trans. Graph.}
 }
 
 @inproceedings{kingma2018glow,
-  title={Glow: Generative flow with invertible 1x1 convolutions},
-  author={Kingma, Durk P and Dhariwal, Prafull},
-  booktitle={Advances in Neural Information Processing Systems},
-  volume={31},
-  year={2018}
+ author = {Kingma, Durk P and Dhariwal, Prafulla},
+ booktitle = {Advances in Neural Information Processing Systems},
+ editor = {S. Bengio and H. Wallach and H. Larochelle and K. Grauman and N. Cesa-Bianchi and R. Garnett},
+ publisher = {Curran Associates, Inc.},
+ title = {Glow: Generative Flow with Invertible 1x1 Convolutions},
+ url = {https://proceedings.neurips.cc/paper_files/paper/2018/file/d139db6a236200b21cc7f752979132d0-Paper.pdf},
+ volume = {31},
+ year = {2018}
 }
 
-@inproceedings{dinh2016density,
-  title={Density estimation using real-valued non-volume preserving (real NVP) transformations},
+
+@inproceedings{dinh2017density,
+  title={Density estimation using Real NVP},
   author={Dinh, Laurent and Sohl-Dickstein, Jascha and Bengio, Samy},
   booktitle={International Conference on Learning Representations},
   year={2017}
 }
-

--- a/examples/optimization/demo_patch_priors_CT.py
+++ b/examples/optimization/demo_patch_priors_CT.py
@@ -10,17 +10,14 @@ with :math:`100` equispace angles between 20 and 160 degrees.
 For the reconstruction, we minimize the variational problem
 
 .. math::
-    \begin{equation*}
-    \label{eq:min_prob}
+
     \underset{x}{\arg\min} \quad \datafid{x}{y} + \lambda g(x).
-    \end{equation*}
 
 Here, the regularizer :math:`g` is explicitly defined as
 
 .. math::
-    \begin{equation*}
+
     g(x)=\sum_{i\in\mathcal{I}} h(P_i x),
-    \end{equation*}
 
 where :math:`P_i` is the linear operator which extracts the :math:`i`-th patch from the image :math:`x` and
 :math:`h` is a regularizer on the space of patches.
@@ -33,8 +30,7 @@ We consider the following two choices of :math:`h`:
   an expectation maximization algorithm.
   In contrast to the original paper by Zoran and Weiss, we minimize the arising variational problem by simply applying
   the Adam optimizer. For an example using the (approximated) half-quadratic splitting algorithm proposed by
- :footcite:t:`zoran2011learning`, we refer to the example :ref:`sphx_glr_auto_examples_optimization_demo_epll.py`.
-
+  :footcite:t:`zoran2011learning`, we refer to the example :ref:`sphx_glr_auto_examples_optimization_demo_epll.py`.
 * The patch normalizing flow regularizer (PatchNR) was proposed by :footcite:t:`altekruger2023patchnr`.
   It models :math:`h(x)=-\log(p_{\theta}(x))` as negative log-likelihood function of a probaility density function
   :math:`p_\theta={\mathcal{T}_\theta}_\#\mathcal{N}(0,I)` which is given as the push-forward measure of a standard
@@ -180,7 +176,7 @@ if retrain:
     model_epll.GMM.fit(epll_dataloader, verbose=verbose, max_iters=epll_max_iter)
 else:
     model_patchnr = PatchNR(
-        pretrained="PatchNR_lodopab_small",
+        pretrained="PatchNR_lodopab_small2",
         sub_net_size=patchnr_subnetsize,
         device=device,
         patch_size=patch_size,

--- a/examples/optimization/demo_patch_priors_CT.py
+++ b/examples/optimization/demo_patch_priors_CT.py
@@ -24,6 +24,7 @@ Here, the regularizer :math:`g` is explicitly defined as
 
 where :math:`P_i` is the linear operator which extracts the :math:`i`-th patch from the image :math:`x` and
 :math:`h` is a regularizer on the space of patches.
+
 We consider the following two choices of :math:`h`:
 
 * The expected patch log-likelihood (EPLL) prior was proposed by :footcite:t:`zoran2011learning`.
@@ -31,8 +32,8 @@ We consider the following two choices of :math:`h`:
   The parameters :math:`\theta` are estimated a-priori on a (possibly small) data set of training patches using
   an expectation maximization algorithm.
   In contrast to the original paper by Zoran and Weiss, we minimize the arising variational problem by simply applying
-  the Adam optimizers. For an example for using the (approximated) half-quadratic splitting algorithm proposed by Zoran
-  and Weiss, we refer to the denoising example...
+  the Adam optimizer. For an example using the (approximated) half-quadratic splitting algorithm proposed by
+ :footcite:t:`zoran2011learning`, we refer to the example :ref:`sphx_glr_auto_examples_optimization_demo_epll.py`.
 
 * The patch normalizing flow regularizer (PatchNR) was proposed by :footcite:t:`altekruger2023patchnr`.
   It models :math:`h(x)=-\log(p_{\theta}(x))` as negative log-likelihood function of a probaility density function
@@ -90,19 +91,19 @@ epll_batch_size = 10000
 # Training / EM algorithm
 # -----------------------------------------
 # If the parameter retrain is False, we just load pretrained weights. Set the parameter to True for retraining.
-# On the cpu, this takes up to a couple of minutes.
+# This takes up to a couple of minutes on a GPU.
 # After training, we define the corresponding patch priors
 #
 # .. note::
 #
 #          The normalizing flow training minimizes the forward Kullback-Leibler (maximum likelihood) loss function given by
 #
-#            .. math::
+#          .. math::
 #                       \mathcal{L}(\theta)=\mathrm{KL}(P_X,{\mathcal{T}_\theta}_\#P_Z)=
 #                       \mathbb{E}_{x\sim P_X}[p_{{\mathcal{T}_\theta}_\#P_Z}(x)]+\mathrm{const},
 #
-#            where :math:`\mathcal{T}_\theta` is the normalizing flow with parameters :math:`\theta`, latent distribution
-#            :math:`P_Z`, data distribution :math:`P_X` and push-forward measure :math:`{\mathcal{T}_\theta}_\#P_Z`.
+#          where :math:`\mathcal{T}_\theta` is the normalizing flow with parameters :math:`\theta`, latent distribution
+#          :math:`P_Z`, data distribution :math:`P_X` and push-forward measure :math:`{\mathcal{T}_\theta}_\#P_Z`.
 
 
 retrain = False
@@ -121,7 +122,7 @@ if retrain:
     )
 
     class NFTrainer(Trainer):
-        def compute_loss(self, physics, x, y, train=True, epoch=None):
+        def compute_loss(self, physics, x, y, train=True, epoch=None, **kwargs):
             logs = {}
 
             self.optimizer.zero_grad()  # Zero the gradients
@@ -144,7 +145,7 @@ if retrain:
                 loss_total.backward()  # Backward the total loss
                 self.optimizer.step()  # Optimizer step
 
-            return invs, logs
+            return loss_total, invs, logs
 
     optimizer = torch.optim.Adam(
         model_patchnr.normalizing_flow.parameters(), lr=patchnr_learning_rate
@@ -178,7 +179,7 @@ if retrain:
     model_epll.GMM.fit(epll_dataloader, verbose=verbose, max_iters=epll_max_iter)
 else:
     model_patchnr = PatchNR(
-        pretrained="PatchNR_lodopab_small2",
+        pretrained="PatchNR_lodopab_small",
         sub_net_size=patchnr_subnetsize,
         device=device,
         patch_size=patch_size,

--- a/examples/optimization/demo_patch_priors_CT.py
+++ b/examples/optimization/demo_patch_priors_CT.py
@@ -1,6 +1,4 @@
 r"""
-.. _patch-prior-demo:
-
 Patch priors for limited-angle computed tomography
 ====================================================================================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,43 +128,73 @@ training = [
 channels = ["conda-forge"]
 platforms = ["linux-64", "win-64"]
 
-[tool.pixi.dependencies] # install from conda-forge for all environments
-python = ">=3.10"
+[tool.pixi.dependencies]
+python = "<3.13.0"
+pytorch = "*"
+torchvision = "*"
+numpy = "*"
+matplotlib = "*"
+tqdm = "*"
+torchmetrics = "*"
+einops = "*"
+requests = "*"
+h5py = "*"
+natsort = "*"
 
 [tool.pixi.feature.gpu.system-requirements]
 cuda = "12.0"
 
 [tool.pixi.feature.gpu.dependencies]
 cuda-version = "*"
-pytorch-gpu = "*"
-torchvision = "*"
 
-[tool.pixi.feature.cpu.dependencies]
-pytorch-cpu = "*"
-torchvision = "*"
-
-# fix python version for the docs environment to avoid issues with Sphinx and Python 3.14
 [tool.pixi.feature.py312.dependencies]
 python = "3.12.*"
 
 [tool.pixi.feature.dataset.dependencies]
 datasets = ">=3.5.0"
+pandas = "*"
+scipy = "*"
+nibabel = "*"
+rasterio = "*"
+pydicom = "*"
+# mat73 is PyPI-only, stays in optional deps
+
+[tool.pixi.feature.denoisers.dependencies]
+scipy = "*"
+kornia = "*"
+pywavelets = "*"
+numba = ">=0.60.0"
+timm = "*"
+diffusers = "*"
+transformers = "*"
+# bm3d, bm4d, libcpab, ptwt are PyPI-only, stay in optional deps
+
+[tool.pixi.feature.physics.dependencies]
+astra-toolbox = ">=2.2.0,!=2.3.0"
+torchkbnufft = "*"
+array-api-compat = "*"
+sigpy = "*"
+# spyrit is PyPI-only, stays in optional deps
+
+[tool.pixi.feature.training.dependencies]
+wandb = "*"
+mlflow = "*"
 
 [tool.pixi.pypi-dependencies] # install from PyPI for all environments
-deepinv = { path = ".", editable = true }
+deepinv = { path = ".", editable = true}
 
 [tool.pixi.environments]
 # gpu environments
 default   = { features = ["gpu"], solve-group = "gpu" }
 test      = { features = ["gpu", "test"], solve-group = "gpu" }
-full      = { features = ["gpu", "test", "dataset", "denoisers", "physics", "training"], solve-group = "gpu" }
+full      = { features = ["gpu", "doc", "test", "dataset", "denoisers", "physics", "training"], solve-group = "gpu" }
 docs      = { features = ["gpu", "doc", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "gpu-docs" }
 doctest   = { features = ["gpu", "doc", "test", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "gpu-docs" }
 # cpu environments (same as gpu but without the gpu dependencies)
-test-cpu  = { features = ["cpu", "test"],  solve-group = "cpu" }
-full-cpu  = { features = ["cpu", "test", "dataset", "denoisers", "physics", "training"], solve-group = "cpu" }
-docs-cpu  = { features = ["cpu", "doc", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "cpu-docs" }
-doctest-cpu = { features = ["cpu", "doc", "test", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "cpu-docs" }
+test-cpu  = { features = ["test"],  solve-group = "cpu" }
+full-cpu  = { features = ["doc", "test", "dataset", "denoisers", "physics", "training"], solve-group = "cpu" }
+docs-cpu  = { features = ["doc", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "cpu-docs" }
+doctest-cpu = { features = ["doc", "test", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "cpu-docs" }
 
 ##############################################
 # Pytest configuration and coverage reporting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ denoisers = [
     "PyWavelets",
     "ptwt",
     "kornia",
-     # "FrEIA",  # handled separately in [tool.pixi.pypi-dependencies]
     "libcpab",
     "scipy",
     "diffusers",
@@ -237,7 +236,7 @@ select = ["UP006", "F401", "B905", "B006", "RUF008", "RUF012", "TID253", "UP004"
 
 [tool.ruff.lint.flake8-tidy-imports]
 # Modules that slow down startup and should be imported lazily
-banned-module-level-imports = ["timm", "torchmetrics", "matplotlib", "datasets", "FrEIA", "bm3d", "einops", "wandb", "pandas", "kornia", "ptwt", "pywt", "astra", "torchkbnufft"]
+banned-module-level-imports = ["timm", "torchmetrics", "matplotlib", "datasets", "bm3d", "einops", "wandb", "pandas", "kornia", "ptwt", "pywt", "astra", "torchkbnufft"]
 
 # Deprecated functions that should be replaced
 [tool.ruff.lint.flake8-tidy-imports.banned-api]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,8 @@ denoisers = [
     "timm",
     "PyWavelets",
     "ptwt",
-    "FrEIA",
     "kornia",
+     # "FrEIA",  # handled separately in [tool.pixi.pypi-dependencies]
     "libcpab",
     "scipy",
     "diffusers",
@@ -120,16 +120,28 @@ training = [
     "mlflow",
 ]
 
+
 ##############################################################
 # Pixi configuration for managing conda optional dependencies
+
 [tool.pixi.workspace]
 channels = ["conda-forge"]
-platforms = ["linux-64", "win-64", "osx-arm64"]
+platforms = ["linux-64", "win-64"]
 
 [tool.pixi.dependencies] # install from conda-forge for all environments
-pytorch = "*"
-torchvision = "*"
 python = ">=3.10"
+
+[tool.pixi.feature.gpu.system-requirements]
+cuda = "12.0"
+
+[tool.pixi.feature.gpu.dependencies]
+cuda-version = "*"
+pytorch-gpu = "*"
+torchvision = "*"
+
+[tool.pixi.feature.cpu.dependencies]
+pytorch-cpu = "*"
+torchvision = "*"
 
 # fix python version for the docs environment to avoid issues with Sphinx and Python 3.14
 [tool.pixi.feature.py312.dependencies]
@@ -142,11 +154,17 @@ datasets = ">=3.5.0"
 deepinv = { path = ".", editable = true }
 
 [tool.pixi.environments]
-default = { solve-group = "default" }
-test = { features = ["test"], solve-group = "default" }
-docs = { features = ["doc", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "docs" }
-doctest = { features = ["doc", "test", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "docs" }
-full = { features = ["test", "dataset", "denoisers", "physics", "training"], solve-group = "default" }
+# gpu environments
+default   = { features = ["gpu"], solve-group = "gpu" }
+test      = { features = ["gpu", "test"], solve-group = "gpu" }
+full      = { features = ["gpu", "test", "dataset", "denoisers", "physics", "training"], solve-group = "gpu" }
+docs      = { features = ["gpu", "doc", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "gpu-docs" }
+doctest   = { features = ["gpu", "doc", "test", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "gpu-docs" }
+# cpu environments (same as gpu but without the gpu dependencies)
+test-cpu  = { features = ["cpu", "test"],  solve-group = "cpu" }
+full-cpu  = { features = ["cpu", "test", "dataset", "denoisers", "physics", "training"], solve-group = "cpu" }
+docs-cpu  = { features = ["cpu", "doc", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "cpu-docs" }
+doctest-cpu = { features = ["cpu", "doc", "test", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "cpu-docs" }
 
 ##############################################
 # Pytest configuration and coverage reporting


### PR DESCRIPTION
- Updates `pixi` config in `pyproject.toml` to install GPU torch versions, which allows running the CI on GPU (not currently the case)
- Removes `FrEIA` dependency, which breaks the pixi resolve, and is used very little in the library - replace with a custom pytorch implementation of normalizing flow
- Fix `PatchNR` demo, by fixing the trainer, and updating pretrained weights

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
