### PR TITLE
Fix 'mode' option of the wavelet transform

### DIFF
--- a/deepinv/models/wavdict.py
+++ b/deepinv/models/wavdict.py
@@ -528,6 +528,7 @@ class WaveletDictDenoiser(Denoiser):
     :param torch.device, str device: cpu or gpu.
     :param int max_iter: number of iterations of the optimization algorithm (default: 10).
     :param str non_linearity: "soft", "hard" or "topk" thresholding (default: "soft")
+    :param str mode: padding mode, "reflect", "zero", "constant", "periodic", "symmetric" (default: "zero")
     :param int wvdim: dimension of the wavelet transform (either 2 or 3) (default: 2).
     :param bool is_complex: whether the input is complex-valued (default: False).
     """
@@ -538,6 +539,7 @@ class WaveletDictDenoiser(Denoiser):
         list_wv: Sequence[str] = ("db8", "db4"),
         max_iter: int = 10,
         non_linearity: str = "soft",
+        mode: str = "zero",
         wvdim: int = 2,
         is_complex: bool = False,
         device: str | torch.device = "cpu",
@@ -554,6 +556,7 @@ class WaveletDictDenoiser(Denoiser):
                     wvdim=wvdim,
                     device=device,
                     is_complex=is_complex,
+                    mode=mode,
                 )
                 for wv in list_wv
             ]
@@ -590,5 +593,7 @@ class WaveletDictDenoiser(Denoiser):
         """
         vec = []
         for p in self.list_prox:
-            vec += p.psi(x, wavelet=p.wv, level=p.level, dimension=p.dimension)
+            vec += p.psi(
+                x, wavelet=p.wv, level=p.level, dimension=p.dimension, mode=p.mode
+            )
         return vec

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -386,6 +386,7 @@ class WaveletPrior(Prior):
                 non_linearity=self.non_linearity,
                 is_complex=self.is_complex,
                 wvdim=self.wvdim,
+                mode=self.mode,
             )
         elif type(self.wv) == list:
             self.WaveletDenoiser = WaveletDictDenoiser(
@@ -395,6 +396,7 @@ class WaveletPrior(Prior):
                 non_linearity=self.non_linearity,
                 is_complex=self.is_complex,
                 wvdim=self.wvdim,
+                mode=self.mode,
             )
         else:
             raise ValueError(

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,6 +35,7 @@ Fixed
 - Fix dimensions mismatch in :class:`deepinv.physics.TomographyWithAstra` with 3D phantoms (:gh:`1137` by `Baptiste Legouix`_)
 - Add warning and error handling for negative inputs in BlurFFT and Poisson noise (:gh:`1155` by `Thibaut Modrzyk`_)
 - Fix a bug in the custom backward of the least-squares solvers for non-leaf tensors (:gh:`1146` by `Minh Hai Nguyen`_)
+- Fix option "mode" for the wavelet transform, which was not correctly propagated; add this option in :class:`deepinv.models.WaveletDictDenoiser` (:gh:`1162` by `Irène Waldspurger`_)
 
 
 v0.4.0
@@ -619,3 +620,4 @@ Changed
 .. _Laura C. Diaz-Delgado: https://github.com/LauraCD2
 .. _Paul Bernard: https://github.com/PAUL-BERNARD
 .. _Baptiste Legouix: https://github.com/blegouix
+.. _Irène Waldspurger: https://github.com/IWalds


### PR DESCRIPTION
The prior "WaveletPrior" could be given an option 'mode'. However, when self.WaveletDenoiser was defined, this option was not passed along, so that the default value was actually always used.

In addition, it seems reasonable that this option is also usable when using a union of wavelet families, so I added it to "WaveletDictDenoiser".