### PR TITLE
Fix cone_vec geom with Astra FDK

### DIFF
--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -604,7 +604,7 @@ class TomographyWithAstra(LinearPhysics):
         sinogram_scaled = torch.clone(sinogram)
         is_3d = len(sinogram.shape) == 5
 
-        if self.geometry_type == "conebeam" and is_3d:
+        if self.geometry_type in ("conebeam", "cone_vec") and is_3d:
             # dimensions (V,N) are (row,col) of the 2D detector
             # A is the number of angles
             B, C, V, A, N = sinogram.shape


### PR DESCRIPTION
`cone_vec` geom type of an Astra proj geom should also count as a conebeam geometry. Therefore, it should get the FDK weighting in the FBP weight calc in the Astra wrapper.

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
