### PR TITLE
Add FFDNet + bugfix DRUNet forward dim==3

### DIFF
--- a/deepinv/models/__init__.py
+++ b/deepinv/models/__init__.py
@@ -48,5 +48,6 @@ from .poisson2sparse import ConvLista, Poisson2Sparse
 from .kernel_network import KernelIdentificationNetwork
 from .bilateral import BilateralFilter
 from .noise_level_estimation import WaveletNoiseEstimator, PatchCovarianceNoiseEstimator
+from .ffdnet import FFDNet
 
 from .third_party import PromptIR

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -237,19 +237,25 @@ class DRUNet(Denoiser):
                         f"Incorrect shape, sigma should be of shape (1,), (batch_size,) or (batch_size, 1, height, width, (depth)), got {tuple(sigma.shape)}"
                     )
             else:
-                noise_level_map = torch.ones(
-                    (x.size(0), 1, *x.shape[2:]), device=x.device
-                ) * sigma[None, None, None, None].to(x.device)
+                noise_level_map = torch.full(
+                    (x.size(0), 1, *x.shape[2:]),
+                    sigma,
+                    device=x.device,
+                    dtype=x.dtype,
+                )
         else:
-            noise_level_map = (
-                torch.ones((x.size(0), 1, *x.shape[2:]), device=x.device) * sigma
+            noise_level_map = torch.full(
+                (x.size(0), 1, *x.shape[2:]),
+                sigma,
+                device=x.device,
+                dtype=x.dtype,
             )
 
         x = torch.cat((x, noise_level_map), 1)
         shape_is_safe = all((s % 8 == 0 and s > 31) for s in x.shape[2:])
         if shape_is_safe:
             x = self.forward_unet(x)
-        elif self.training or (x.size(2) < 32 or x.size(3) < 32):
+        elif self.training or any([x.size(2 + i) < 32 for i in range(self.dim)]):
             x = test_pad(self.forward_unet, x, modulo=16)
         else:
             if self.dim == 3:  # pragma: no cover

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -217,12 +217,23 @@ class DRUNet(Denoiser):
         """
         if isinstance(sigma, torch.Tensor):
             if sigma.ndim > 0:
-                noise_level_map = sigma.view(
-                    x.size(0), 1, *[1 for _ in range(self.dim)]
-                )
-                noise_level_map = noise_level_map.expand(
-                    -1, 1, *[x.size(2 + i) for i in range(self.dim)]
-                )
+                if sigma.shape == (x.size(0), 1, *x.shape[2:]):
+                    noise_level_map = sigma
+                elif sigma.shape in [
+                    (x.size(0)),
+                    (x.size(0), 1, *[1 for _ in range(self.dim)]),
+                ]:
+
+                    noise_level_map = sigma.view(
+                        x.size(0), 1, *[1 for _ in range(self.dim)]
+                    )
+                    noise_level_map = noise_level_map.expand(
+                        -1, 1, *[x.size(2 + i) for i in range(self.dim)]
+                    )
+                else:
+                    raise ValueError(
+                        "Incorrect shape, sigma should be of shape (1,), (batch_size,) or (batch_size, 1, height, width, (depth))"
+                    )
             else:
                 noise_level_map = torch.ones(
                     (x.size(0), 1, *x.shape[2:]), device=x.device

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -222,7 +222,7 @@ class DRUNet(Denoiser):
                 if sigma.shape == (x.size(0), 1, *x.shape[2:]):
                     noise_level_map = sigma
                 elif sigma.shape in [
-                    (x.size(0)),
+                    (x.size(0),),
                     (x.size(0), 1, *[1 for _ in range(self.dim)]),
                 ]:
 
@@ -234,7 +234,7 @@ class DRUNet(Denoiser):
                     )
                 else:
                     raise ValueError(
-                        "Incorrect shape, sigma should be of shape (1,), (batch_size,) or (batch_size, 1, height, width, (depth))"
+                        f"Incorrect shape, sigma should be of shape (1,), (batch_size,) or (batch_size, 1, height, width, (depth)), got {tuple(sigma.shape)}"
                     )
             else:
                 noise_level_map = torch.ones(

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -217,8 +217,12 @@ class DRUNet(Denoiser):
         """
         if isinstance(sigma, torch.Tensor):
             if sigma.ndim > 0:
-                noise_level_map = sigma.view(x.size(0), 1, 1, 1)
-                noise_level_map = noise_level_map.expand(-1, 1, x.size(2), x.size(3))
+                noise_level_map = sigma.view(
+                    x.size(0), 1, *[1 for _ in range(self.dim)]
+                )
+                noise_level_map = noise_level_map.expand(
+                    -1, 1, *[x.size(2 + i) for i in range(self.dim)]
+                )
             else:
                 noise_level_map = torch.ones(
                     (x.size(0), 1, *x.shape[2:]), device=x.device

--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -215,7 +215,7 @@ class DRUNet(Denoiser):
 
         :param torch.Tensor x: noisy image
         :param float, torch.Tensor sigma: noise level. If ``sigma`` is a float, it is used for all images in the batch.
-            If ``sigma`` is a tensor, it can be of shape ``(batch_size,)`` or ``(batch_size, 1, height, width)``.
+            If ``sigma`` is a tensor, it can be of shape ``(batch_size,)`` or ``(batch_size, 1, height, width, (depth))``.
         """
         if isinstance(sigma, torch.Tensor):
             if sigma.ndim > 0:
@@ -255,12 +255,12 @@ class DRUNet(Denoiser):
         shape_is_safe = all((s % 8 == 0 and s > 31) for s in x.shape[2:])
         if shape_is_safe:
             x = self.forward_unet(x)
-        elif self.training or any([x.size(2 + i) < 32 for i in range(self.dim)]):
+        elif self.training or any([x.size(2 + i) < 64 for i in range(self.dim)]):
             x = test_pad(self.forward_unet, x, modulo=16)
         else:
-            if self.dim == 3:  # pragma: no cover
+            if self.dim == 3:
                 raise NotImplementedError(
-                    f"test_onesplit is not implemented yet for 3D. Please pass images with spatial shape smaller than 32, or multiple of 8 and larger than 32 to DRUNet."
+                    f"test_onesplit is not implemented yet for 3D. Please pass images with spatial shape smaller than 64, or multiple of 8 and larger than 31 to DRUNet."
                 )
             x = test_onesplit(self.forward_unet, x, refield=64)
         return x

--- a/deepinv/models/ffdnet.py
+++ b/deepinv/models/ffdnet.py
@@ -21,8 +21,9 @@ class FFDNet(Denoiser):
     :param int img_channels: Number of channels of your input image. Default: 1 (greyscale)
     :param bool residual_denoising: Whether to use a residual connection between input image and the network output. Default: False
     :param str norm: normalization to use in the convolutional layers. Choose from instance_norm, batch_norm, or None (no norm). Default: batch_norm
-    :param bool orthogonal_init: Apply orthogonal initialization to the convolutional weights. Default: True
+    :param bool orthogonal_init: Apply orthogonal initialization to the convolutional weights. Ignored if pretrained not None. Default: True
     :param bool last_conv_bias: Set the learnable bias on or off on the final convolution. Default: False
+    :param str pretrained: Load pretrained weights from a checkpoint. Default: None
     :param torch.device, str device: Device to put the model on.
     """
 
@@ -35,6 +36,7 @@ class FFDNet(Denoiser):
         norm: str | None = "batch_norm",
         orthogonal_init: bool = True,
         last_conv_bias: bool = False,
+        pretrained: str | None = None,
         device: str | torch.device = "cpu",
     ):
         super().__init__()
@@ -76,10 +78,17 @@ class FFDNet(Denoiser):
         )
         self.blocks = nn.Sequential(*blocks)
         self.residual_denoising = residual_denoising
-        if device is not None:
-            self.to(device)
         if orthogonal_init:
             self.apply(weights_init_drunet)  # DRUNet also applies orthogonal init.
+        if pretrained is not None:
+            if pretrained == "download":
+                raise ValueError(
+                    'Received pretrained "download", but FFDNet has no downloadable weights.'
+                )
+            state = torch.load(pretrained, map_location=lambda storage, loc: storage)
+            self.load_state_dict(state, strict=True)
+        if device is not None:
+            self.to(device)
 
     def forward(self, x: torch.Tensor, sigma: torch.Tensor | float) -> torch.Tensor:
         r"""
@@ -98,9 +107,12 @@ class FFDNet(Denoiser):
                 noise_level_map = sigma.view(x.size(0), 1, 1, 1)
                 noise_level_map = noise_level_map.expand(-1, 1, x.size(2), x.size(3))
             else:
-                noise_level_map = torch.ones(
-                    (x.size(0), 1, x.size(2), x.size(3)), device=x.device
-                ) * sigma[None, None, None, None].to(x.device)
+                noise_level_map = torch.full(
+                    (x.size(0), 1, x.size(2), x.size(3)),
+                    sigma,
+                    device=x.device,
+                    dtype=x.dtype,
+                )
         else:
             noise_level_map = (
                 torch.ones((x.size(0), 1, *x.shape[2:]), device=x.device) * sigma

--- a/deepinv/models/ffdnet.py
+++ b/deepinv/models/ffdnet.py
@@ -53,14 +53,14 @@ class FFDNet(Denoiser):
         blocks = []
         blocks.append(
             nn.Sequential(
-                nn.Conv2d((img_channels + 1) * downsample_factor**2, nf, padding=1),
+                nn.Conv2d((img_channels + 1) * downsample_factor**2, nf, 3, padding=1),
                 nn.ReLU(inplace=True),
             )
         )
         for _ in range(n_conv_layers - 2):
             blocks.append(
                 nn.Sequential(
-                    nn.Conv2d(nf, nf, padding=1),
+                    nn.Conv2d(nf, nf, 3, padding=1),
                     norm(nf),
                     nn.ReLU(inplace=True),
                 )
@@ -68,7 +68,8 @@ class FFDNet(Denoiser):
         blocks.append(
             nn.Conv2d(
                 nf,
-                (img_channels + 1) * downsample_factor**2,
+                (img_channels) * downsample_factor**2,
+                3,
                 padding=1,
                 bias=last_conv_bias,
             )
@@ -88,6 +89,10 @@ class FFDNet(Denoiser):
         :param float, torch.Tensor sigma: noise level. If ``sigma`` is a float, it is used for all images in the batch.
             If ``sigma`` is a tensor, it must be of shape ``(batch_size,)``.
         """
+        if x.size(2) % 2 != 0 or x.size(3) % 2 != 0:  # pragma: no cover
+            raise ValueError(
+                f"FFDNet requires H,W both divisble by 2. Got tensor of shape {tuple(x.shape)}"
+            )
         if isinstance(sigma, torch.Tensor):
             if sigma.ndim > 0:
                 noise_level_map = sigma.view(x.size(0), 1, 1, 1)

--- a/deepinv/models/ffdnet.py
+++ b/deepinv/models/ffdnet.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+import torch
+import torch.nn as nn
+
+from .base import Denoiser
+from .drunet import weights_init_drunet
+
+
+class FFDNet(Denoiser):
+    r"""
+    FFDNet denoiser network.
+
+    The network architecture is based on the paper :footcite:t:`zhang2018ffdnet`.
+    and consists of a ``PixelUnshuffle`` downsampling operation, a series of 3x3 convolutional layers
+    (similar to DnCNN), followed by a ``PixelShuffle`` upsampling operation to get back to the original shape.
+
+    The network takes into account the noise level of the input image, which is encoded as an additional input channel.
+
+    :param int n_conv_layers: Number of convolutional layers used. Default: 15
+    :param int nf: Number of channels per convolutional layer. Default: 64
+    :param int img_channels: Number of channels of your input image. Default: 1 (greyscale)
+    :param bool residual_denoising: Whether to use a residual connection between input image and the network output. Default: False
+    :param str norm: normalization to use in the convolutional layers. Choose from instance_norm, batch_norm, or None (no norm). Default: batch_norm
+    :param bool orthogonal_init: Apply orthogonal initialization to the convolutional weights. Default: True
+    :param bool last_conv_bias: Set the learnable bias on or off on the final convolution. Default: False
+    :param torch.device, str device: Device to put the model on.
+    """
+
+    def __init__(
+        self,
+        n_conv_layers: int = 15,
+        nf: int = 64,
+        img_channels: int = 1,
+        residual_denoising: bool = False,
+        norm: str | None = "batch_norm",
+        orthogonal_init: bool = True,
+        last_conv_bias: bool = False,
+        device: str | torch.device = "cpu",
+    ):
+        super().__init__()
+        downsample_factor = 2
+        self.downsampler = nn.PixelUnshuffle(downsample_factor)
+        self.upsampler = nn.PixelShuffle(downsample_factor)
+        norm = {
+            "instance_norm": nn.InstanceNorm2d,
+            "batch_norm": nn.BatchNorm2d,
+            None: nn.Identity(),
+        }[norm]
+        blocks = []
+        blocks.append(
+            nn.Sequential(
+                nn.Conv2d((img_channels + 1) * downsample_factor**2, nf, padding=1),
+                nn.ReLU(inplace=True),
+            )
+        )
+        for _ in range(n_conv_layers - 2):
+            blocks.append(
+                nn.Sequential(
+                    nn.Conv2d(nf, nf, padding=1),
+                    norm(nf),
+                    nn.ReLU(inplace=True),
+                )
+            )
+        blocks.append(
+            nn.Conv2d(
+                nf,
+                (img_channels + 1) * downsample_factor**2,
+                padding=1,
+                bias=last_conv_bias,
+            )
+        )
+        self.blocks = nn.Sequential(*blocks)
+        self.residual_denoising = residual_denoising
+        if device is not None:
+            self.to(device)
+        if orthogonal_init:
+            self.apply(weights_init_drunet)  # DRUNet also applies orthogonal init.
+
+    def forward(self, x: torch.Tensor, sigma: torch.Tensor | float) -> torch.Tensor:
+        r"""
+        Run the denoiser on image with noise level :math:`\sigma`.
+
+        :param torch.Tensor x: noisy image
+        :param float, torch.Tensor sigma: noise level. If ``sigma`` is a float, it is used for all images in the batch.
+            If ``sigma`` is a tensor, it must be of shape ``(batch_size,)``.
+        """
+        if isinstance(sigma, torch.Tensor):
+            if sigma.ndim > 0:
+                noise_level_map = sigma.view(x.size(0), 1, 1, 1)
+                noise_level_map = noise_level_map.expand(-1, 1, x.size(2), x.size(3))
+            else:
+                noise_level_map = torch.ones(
+                    (x.size(0), 1, x.size(2), x.size(3)), device=x.device
+                ) * sigma[None, None, None, None].to(x.device)
+        else:
+            noise_level_map = (
+                torch.ones((x.size(0), 1, *x.shape[2:]), device=x.device) * sigma
+            )
+        if self.residual_denoising:
+            noisy_img = x
+        x = torch.cat((x, noise_level_map), 1)
+        x = self.downsampler(x)
+        x = self.blocks(x)
+        x = self.upsampler(x)
+        if self.residual_denoising:
+            x = x + noisy_img
+        return x

--- a/deepinv/models/ffdnet.py
+++ b/deepinv/models/ffdnet.py
@@ -41,6 +41,10 @@ class FFDNet(Denoiser):
         downsample_factor = 2
         self.downsampler = nn.PixelUnshuffle(downsample_factor)
         self.upsampler = nn.PixelShuffle(downsample_factor)
+        if norm not in ["instance_norm", "batch_norm", None]:  # pragma: no cover
+            raise ValueError(
+                f"norm must be one of (instance_norm, batch_norm, None), but got {norm}"
+            )
         norm = {
             "instance_norm": nn.InstanceNorm2d,
             "batch_norm": nn.BatchNorm2d,

--- a/deepinv/models/ffdnet.py
+++ b/deepinv/models/ffdnet.py
@@ -114,8 +114,8 @@ class FFDNet(Denoiser):
                     dtype=x.dtype,
                 )
         else:
-            noise_level_map = (
-                torch.ones((x.size(0), 1, *x.shape[2:]), device=x.device) * sigma
+            noise_level_map = torch.full(
+                (x.size(0), 1, *x.shape[2:]), sigma, dtype=x.dtype, device=x.device
             )
         if self.residual_denoising:
             noisy_img = x

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -27,6 +27,7 @@ MODEL_LIST_1_CHANNEL = [
     "promptir",
     "ncsnpp",
     "adinv.modelsunet",
+    "ffdnet",
 ]
 MODEL_LIST = MODEL_LIST_1_CHANNEL + [
     "bm3d",
@@ -149,6 +150,8 @@ def choose_denoiser(name, imsize):
         out = dinv.models.DScCP()
     elif name == "bilateral":
         out = dinv.models.BilateralFilter()
+    elif name == "ffdnet":
+        out = dinv.models.FFDNet(img_channels=imsize[0], n_conv_layers=2, nf=16)
     else:
         raise Exception("Unknown denoiser")
 
@@ -353,6 +356,10 @@ def test_denoiser_color(imsize, device, denoiser):
     if denoiser in ["ncsnpp", "adinv.modelsunet"]:
         imsize = (imsize[0], (imsize[1] // 8) * 8, (imsize[2] // 8) * 8)
 
+    # FFDNet requires spatial size divisble 2
+    if denoiser in ["ffdnet"]:
+        imsize = (imsize[0], (imsize[1] // 2) * 2, (imsize[2] // 2) * 2)
+
     model = choose_denoiser(denoiser, imsize).to(device)
     torch.manual_seed(0)
     sigma = 0.2
@@ -375,7 +382,13 @@ def test_denoiser_gray(imsize_1_channel, device, denoiser):
                 (imsize_1_channel[1] // 8) * 8,
                 (imsize_1_channel[2] // 8) * 8,
             )
-
+        # FFDNet requires spatial size divisble 2
+        if denoiser in ["ffdnet"]:
+            imsize_1_channel = (
+                imsize_1_channel[0],
+                (imsize_1_channel[1] // 2) * 2,
+                (imsize_1_channel[2] // 2) * 2,
+            )
         model = choose_denoiser(denoiser, imsize_1_channel).to(device)
 
         torch.manual_seed(0)
@@ -447,6 +460,13 @@ def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
             imsize_1_channel[1] = 32
         if imsize_1_channel[2] % 8 > 0:
             imsize_1_channel[2] = 32
+    # FFDNet requires spatial size divisble 2
+    if denoiser in ["ffdnet"]:
+        imsize_1_channel = (
+            imsize_1_channel[0],
+            (imsize_1_channel[1] // 2) * 2,
+            (imsize_1_channel[2] // 2) * 2,
+        )
     model = choose_denoiser(denoiser, imsize_1_channel).to(device)
 
     torch.manual_seed(0)

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -647,31 +647,49 @@ def test_wavelet_decomposition(channels, dimension, is_complex, batch_size, devi
     assert torch.allclose(x, x_hat, rtol=tol, atol=tol)
 
 
-def test_drunet_inputs(imsize_1_channel, device):
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("spatial_size", [31, 32, 37, 40, 65])
+def test_drunet_inputs(dim, spatial_size, device):
     f = dinv.models.DRUNet(
-        in_channels=imsize_1_channel[0], out_channels=imsize_1_channel[0], device=device
+        in_channels=1,
+        out_channels=1,
+        nc=(4, 4, 4, 4),
+        nb=2,
+        dim=dim,
+        device=device,
+        pretrained=None,
     ).eval()
 
+    imsize = [1, *(spatial_size for _ in range(dim))]
     torch.manual_seed(0)
     sigma = 0.2
     physics = dinv.physics.Denoising(dinv.physics.GaussianNoise(sigma))
-    x = torch.ones(imsize_1_channel, device=device).unsqueeze(0)
+    x = torch.ones(imsize, device=device).unsqueeze(0)
     y = physics(x)
 
     # Case 1: sigma is a float
+    if dim == 3 and (spatial_size == 65):
+        with pytest.raises(NotImplementedError) as exc_info:
+            x_hat = f(y, sigma)
+        assert (
+            str(exc_info.value)
+            == "test_onesplit is not implemented yet for 3D. Please pass images with spatial shape smaller than 64, or multiple of 8 and larger than 31 to DRUNet."
+        )
+        return
     x_hat = f(y, sigma)
     assert x_hat.shape == x.shape
 
     # Case 2: sigma is a torch tensor with batch dimension
     batch_size = 3
-    x = torch.ones((batch_size, 1, 31, 37), device=device)
+    x = torch.ones((batch_size, *imsize), device=device)
     y = physics(x)
     sigma_tensor = torch.tensor([sigma] * batch_size).to(device)
     x_hat = f(y, sigma_tensor)
     assert x_hat.shape == x.shape
 
-    # Case 3: image has shape mulitple of 8
-    x = torch.ones((3, 1, 32, 40), device=device)
+    # Case 3: sigma is a torch tensor with shape (batch, 1, *x.shape[2:])
+    x = torch.ones((batch_size, *imsize), device=device)
+    sigma_tensor = torch.full((batch_size, 1, *imsize[1:]), sigma, device=device)
     y = physics(x)
     x_hat = f(y, sigma_tensor)
     assert x_hat.shape == x.shape

--- a/docs/source/api/deepinv.models.rst
+++ b/docs/source/api/deepinv.models.rst
@@ -67,6 +67,7 @@ Deep Architectures
    deepinv.models.DScCP
    deepinv.models.RAM
    deepinv.models.ArtifactRemoval
+   deepinv.models.FFDNet
 
 Model Utils
 -----------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,7 @@ New Features
 - Add :class:`deepinv.optim.MLEM` algorithm for Poisson inverse problems (:gh:`1051` by `Thibaut Modrzyk`_)
 - Add the equivariant splitting loss :class:`deepinv.loss.EquivariantSplittingLoss` with equivariant reconstructors :class:`deepinv.models.EquivariantReconstructor` and virtual physics :class:`deepinv.physics.VirtualLinearPhysics` (:gh:`881` by `Jérémy Scanvic`_)
 - Add `DEEPINV_CACHE_DIR` environment variable to set the cache directory for datasets and pretrained weights (:gh:`1105` by `Minh Hai Nguyen`_)
-- Add :class:`deepinv.models.FFDNet` for non-blind Gaussian denoising (:gh:`976` by `Vicky De Ridder`_)
+- Add :class:`deepinv.models.FFDNet` for non-blind Gaussian denoising (:gh:`1174` by `Vicky De Ridder`_)
 - Extend :func:`deepinv.physics.functional.gaussian_blur` to 1D and 3D. Add :class:`deepinv.physics.generator.GaussianBlurGenerator` (:gh:`1152` by `Romain Vo`_)
 
 Changed

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ New Features
 - Add :class:`deepinv.optim.MLEM` algorithm for Poisson inverse problems (:gh:`1051` by `Thibaut Modrzyk`_)
 - Add the equivariant splitting loss :class:`deepinv.loss.EquivariantSplittingLoss` with equivariant reconstructors :class:`deepinv.models.EquivariantReconstructor` and virtual physics :class:`deepinv.physics.VirtualLinearPhysics` (:gh:`881` by `Jérémy Scanvic`_)
 - Add `DEEPINV_CACHE_DIR` environment variable to set the cache directory for datasets and pretrained weights (:gh:`1105` by `Minh Hai Nguyen`_)
+- Add :class:`deepinv.models.FFDNet` for non-blind Gaussian denoising (:gh:`976` by `Vicky De Ridder`_)
 
 Changed
 ^^^^^^^

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1387,7 +1387,9 @@ journal = {ACM Trans. Graph.}
   volume={27},
   number={9},
   pages={4608--4622},
-  year={2018},
+  year={2018}
+}
+
 @article{scanvic2026scale,
   title={Scale-equivariant imaging: Self-supervised learning for image super-resolution and deblurring},
   author={Scanvic, J{\'e}r{\'e}my and Davies, Mike and Abry, Patrice and Tachella, Juli{\'a}n},

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1394,4 +1394,13 @@ journal = {ACM Trans. Graph.}
   year={2017}
 }
 
-
+@article{zhang2018ffdnet,
+  title={FFDNet: Toward a fast and flexible solution for CNN-based image denoising},
+  author={Zhang, Kai and Zuo, Wangmeng and Zhang, Lei},
+  journal={IEEE Transactions on Image Processing},
+  volume={27},
+  number={9},
+  pages={4608--4622},
+  year={2018},
+  publisher={IEEE}
+}

--- a/docs/source/user_guide/reconstruction/denoisers.rst
+++ b/docs/source/user_guide/reconstruction/denoisers.rst
@@ -126,7 +126,12 @@ See :ref:`pretrained-weights` for more information on pretrained denoisers.
      - C=1, 2, 3
      - Yes
      - No
-
+   * - :class:`deepinv.models.FFDNet`
+     - CNN
+     - Any C; H,W must be even
+     - No
+     - Yes
+     - No
 .. _non-learned-denoisers:
 
 Classical denoisers


### PR DESCRIPTION
- Add FFDNet , a non-blind (Gaussian) denoiser, which can be seen DRUNet's predecessor
- Fix a bug in DRUNet regarding sigma shaping when dim is 3d


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
