### PR TITLE
Add default ASTRA conebeam geometry

### DIFF
--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -382,16 +382,16 @@ class TomographyWithAstra(LinearPhysics):
     :param tuple[int, ...] img_size: Shape of the object grid, either a 2 or 3-element tuple, for respectively 2D or 3D.
     :param int angles: Number of angular positions sampled uniformly in ``angular_range`` or a Tensor containing angular positions in degrees. (default: 180)
     :param int | tuple[int, ...], None n_detector_pixels: In 2D, specify an integer for a single line of detector cells. In 3D, specify a 2-element tuple for (row,col) shape of the detector. (default: None)
-    :param tuple[float, float] angular_range: Angular range, defaults to ``(0, 180)``.
-    :param float | tuple[float, float] detector_spacing: In 2D the width of a detector cell. In 3D a 2-element tuple specifying the (vertical, horizontal) dimensions of a detector cell. (default: 1.0)
+    :param tuple[float, float], None angular_range: Angular range. Defaults to ``(0, 360)`` for ``'conebeam'`` geometry and ``(0, 180)`` otherwise.
+    :param float | tuple[float, float], None detector_spacing: In 2D the width of a detector cell. In 3D a 2-element tuple specifying the (vertical, horizontal) dimensions of a detector cell. Defaults to ``1.0``, except for ``'conebeam'`` geometry where it defaults to ``1.5 * pixel_spacing``.
     :param float | tuple[float, ...] pixel_spacing: In 2D, the (x,y) dimensions of a pixel in the reconstructed image. In 3D, the (x,y,z) dimensions of a voxel. Scalar value is interpreted as the same dimension along all axes (default: 1.0)
     :param tuple[float, ...], None bounding_box: Axis-aligned bounding-box of the reconstruction area [min_x, max_x, min_y, max_y, ...]. Optional argument, if specified, overrides argument ``object_spacing``. (default: None)
     :param str geometry_type: The type of geometry among ``'parallel'``, ``'fanbeam'`` in 2D and ``'parallel'`` and ``'conebeam'`` in 3D. (default: ``'parallel'``)
     :param dict[str, float] geometry_parameters: Contains extra parameters specific to certain geometries. When ``geometry_type='fanbeam'`` or  ``'conebeam'``, the dictionary should contains the keys
 
-        - ``"source_radius"``: the distance between the x-ray source and the rotation axis, denoted :math:`D_{s0}`, (default: 80.),
+        - ``"source_radius"``: the distance between the x-ray source and the rotation axis, denoted :math:`D_{s0}`, (default: 80., except for ``'conebeam'`` geometry where it defaults to ``img_size[-1] * 4``),
 
-        - ``"detector_radius"``: the distance between the x-ray detector and the rotation axis, denoted :math:`D_{0d}`. (default: 20.)
+        - ``"detector_radius"``: the distance between the x-ray detector and the rotation axis, denoted :math:`D_{0d}`. (default: 20., except for ``'conebeam'`` geometry where it defaults to ``img_size[-1]``)
 
     :param torch.Tensor, None geometry_vectors: Alternative way to describe a 3D geometry. It is a torch.Tensor of shape [num_angles, 12], where for each angular position of index ``i`` the row consists of a vector of size (12,) with
 
@@ -480,26 +480,18 @@ class TomographyWithAstra(LinearPhysics):
         img_size: tuple[int, ...],
         angles: int | torch.Tensor = 180,
         n_detector_pixels: int | tuple[int, ...] | None = None,
-        angular_range: tuple[float, float] = (0, 180),
-        detector_spacing: float | tuple[float, float] = 1.0,
+        angular_range: tuple[float, float] | None = None,
+        detector_spacing: float | tuple[float, float] | None = None,
         pixel_spacing: float | tuple[float, ...] = 1.0,
         bounding_box: tuple[float, ...] | None = None,
         geometry_type: str = "parallel",
-        geometry_parameters: dict[str, float] = MappingProxyType(
-            {
-                "source_radius": 80.0,
-                "detector_radius": 20.0,
-            }
-        ),
+        geometry_parameters: dict[str, float] | None = None,
         geometry_vectors: torch.Tensor | None = None,
         normalize: bool | None = None,
         device: torch.device | str = torch.device("cuda"),
         **kwargs,
     ):
         super().__init__(device=device, **kwargs)
-
-        if isinstance(geometry_parameters, MappingProxyType):
-            geometry_parameters = geometry_parameters.copy()
 
         assert len(img_size) in (
             2,
@@ -514,12 +506,44 @@ class TomographyWithAstra(LinearPhysics):
 
         self.img_size = img_size
         self.is_2d = len(img_size) == 2
+        self.geometry_type = geometry_type
+
+        if n_detector_pixels is None and geometry_type == "conebeam" and not self.is_2d:
+            n_detector_pixels = img_size[-1]
         self.n_detector_pixels = (
             math.ceil(math.sqrt(2) * img_size[0])
             if n_detector_pixels is None
             else n_detector_pixels
         )
-        self.geometry_type = geometry_type
+
+        if angular_range is None:
+            angular_range = (0, 360) if geometry_type == "conebeam" else (0, 180)
+
+        if geometry_parameters is None:
+            if geometry_type == "conebeam" and not self.is_2d:
+                geometry_parameters = {
+                    "source_radius": img_size[-1] * 4.0,
+                    "detector_radius": img_size[-1] * 1.0,
+                }
+            else:
+                geometry_parameters = {
+                    "source_radius": 80.0,
+                    "detector_radius": 20.0,
+                }
+        elif isinstance(geometry_parameters, MappingProxyType):
+            geometry_parameters = geometry_parameters.copy()
+
+        if detector_spacing is None:
+            if geometry_type == "conebeam" and not self.is_2d:
+                if isinstance(pixel_spacing, (float, int)):
+                    detector_spacing = 1.5 * pixel_spacing
+                else:
+                    detector_spacing = (
+                        1.5 * pixel_spacing[2],
+                        1.5 * pixel_spacing[0],
+                    )
+            else:
+                detector_spacing = 1.0
 
         if isinstance(angles, int):
             angles = torch.linspace(*angular_range, steps=angles + 1)[:-1]

--- a/deepinv/tests/test_external_libraries.py
+++ b/deepinv/tests/test_external_libraries.py
@@ -205,9 +205,50 @@ class TestTomographyWithAstra:
         assert physics.xray_transform.detector_cell_u_length == pytest.approx(1.0)
         assert physics.xray_transform.detector_cell_v_length == pytest.approx(1.0)
         assert physics.xray_transform.detector_cell_area == pytest.approx(1.0)
-        if geometry_type in ["fanbeam", "conebeam"]:
+        if geometry_type == "fanbeam":
             assert physics.xray_transform.source_radius == pytest.approx(80.0)
             assert physics.xray_transform.detector_radius == pytest.approx(20.0)
             assert physics.xray_transform.magnification_factor == pytest.approx(1.25)
+        elif geometry_type == "conebeam":
+            assert physics.xray_transform.source_radius == pytest.approx(
+                4.0 * img_size[-1]
+            )
+            assert physics.xray_transform.detector_radius == pytest.approx(img_size[-1])
+            assert physics.xray_transform.magnification_factor == pytest.approx(1.25)
         else:
             assert physics.xray_transform.magnification_factor == pytest.approx(1.0)
+
+    def test_tomography_with_astra_default_conebeam_geometry(self, monkeypatch, device):
+        astra = pytest.importorskip(
+            "astra",
+            reason="This test requires astra-toolbox. It should be "
+            "installed with `conda install -c astra-toolbox -c nvidia astra-toolbox`",
+        )
+
+        if "cuda" not in str(device):
+            monkeypatch.setattr(
+                target=dinv.physics.TomographyWithAstra,
+                name="compute_norm",
+                value=self.dummy_compute_norm,
+            )
+            monkeypatch.setattr(
+                target=astra,
+                name="create_projector",
+                value=self.dummy_create_projector,
+            )
+
+        physics = dinv.physics.TomographyWithAstra(
+            img_size=(8, 10, 12),
+            angles=4,
+            geometry_type="conebeam",
+            pixel_spacing=1.0,
+            normalize=False,
+            device=device,
+        )
+
+        assert physics.measurement_shape == (12, 4, 12)
+        assert physics.num_angles == 4
+        assert physics.xray_transform.detector_cell_u_length == pytest.approx(1.5)
+        assert physics.xray_transform.detector_cell_v_length == pytest.approx(1.5)
+        assert physics.xray_transform.source_radius == pytest.approx(48.0)
+        assert physics.xray_transform.detector_radius == pytest.approx(12.0)

--- a/examples/external-libraries/generate_astra_default_conebeam_results.py
+++ b/examples/external-libraries/generate_astra_default_conebeam_results.py
@@ -1,0 +1,123 @@
+"""Generate result images for the default ASTRA cone-beam geometry.
+
+This script requires CUDA and astra-toolbox. It creates simple 3D phantoms,
+projects them with ``TomographyWithAstra(geometry_type="conebeam")`` using the
+default parameters, reconstructs them with FDK, and saves summary PNG figures.
+
+Run from the repository root:
+
+    python examples/external-libraries/generate_astra_default_conebeam_results.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import torch
+
+from deepinv.physics import TomographyWithAstra
+
+
+def make_phantom(img_size: tuple[int, int, int], device: torch.device) -> torch.Tensor:
+    z, y, x = torch.meshgrid(
+        torch.linspace(-1, 1, img_size[0], device=device),
+        torch.linspace(-1, 1, img_size[1], device=device),
+        torch.linspace(-1, 1, img_size[2], device=device),
+        indexing="ij",
+    )
+
+    sphere = ((x**2 + y**2 + z**2) < 0.45**2).float()
+    small_sphere = (
+        ((x - 0.25) ** 2 + (y + 0.15) ** 2 + (z - 0.10) ** 2) < 0.18**2
+    ).float()
+    ellipsoid = (
+        ((x + 0.20) / 0.20) ** 2 + ((y - 0.25) / 0.12) ** 2 + ((z + 0.05) / 0.26) ** 2
+        < 1
+    ).float()
+
+    return (sphere + 0.6 * small_sphere + 0.35 * ellipsoid)[None, None]
+
+
+def save_cbct_result(
+    img_size: tuple[int, int, int],
+    pixel_spacing: float | tuple[float, float, float],
+    output_path: Path,
+    angles: int = 90,
+) -> None:
+    device = torch.device("cuda")
+    x = make_phantom(img_size, device)
+
+    physics = TomographyWithAstra(
+        img_size=img_size,
+        angles=angles,
+        geometry_type="conebeam",
+        pixel_spacing=pixel_spacing,
+        normalize=False,
+        device=device,
+    )
+
+    y = physics(x)
+    x_fdk = physics.A_dagger(y, fbp=True)
+
+    slice_idx = img_size[0] // 2
+    detector_row = y.shape[2] // 2
+
+    fig, axs = plt.subplots(1, 3, figsize=(11, 3.5), constrained_layout=True)
+    axs[0].imshow(x[0, 0, slice_idx].detach().cpu(), cmap="gray")
+    axs[0].set_title("Ground truth slice")
+    axs[0].axis("off")
+
+    axs[1].imshow(y[0, 0, detector_row].detach().cpu(), cmap="magma", aspect="auto")
+    axs[1].set_title("Default CBCT projection")
+    axs[1].axis("off")
+
+    axs[2].imshow(x_fdk[0, 0, slice_idx].detach().cpu(), cmap="gray")
+    axs[2].set_title("FDK reconstruction")
+    axs[2].axis("off")
+
+    n = img_size[-1]
+    if isinstance(pixel_spacing, tuple):
+        detector_spacing = (1.5 * pixel_spacing[2], 1.5 * pixel_spacing[0])
+    else:
+        detector_spacing = (1.5 * pixel_spacing, 1.5 * pixel_spacing)
+
+    fig.suptitle(
+        "Default conebeam setup: "
+        f"img_size={img_size}, n_detector_pixels=({n}, {n}), "
+        f"detector_spacing=({detector_spacing[0]:.2g}, {detector_spacing[1]:.2g}), "
+        f"source_radius={4 * n}, detector_radius={n}, angular_range=(0, 360)"
+    )
+    fig.savefig(output_path, dpi=200)
+    plt.close(fig)
+
+
+def main() -> None:
+    if importlib.util.find_spec("astra") is None:
+        raise ModuleNotFoundError(
+            "astra-toolbox is required. Install it with "
+            "`conda install -c astra-toolbox -c nvidia astra-toolbox`."
+        )
+    if not torch.cuda.is_available():
+        raise RuntimeError("This script requires a CUDA-capable NVIDIA GPU.")
+
+    output_dir = Path("results") / "astra_default_conebeam"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    save_cbct_result(
+        img_size=(64, 64, 64),
+        pixel_spacing=1.0,
+        output_path=output_dir / "default_conebeam_isotropic.png",
+    )
+    save_cbct_result(
+        img_size=(48, 64, 80),
+        pixel_spacing=(1.0, 1.0, 1.5),
+        output_path=output_dir / "default_conebeam_anisotropic.png",
+    )
+
+    print(f"Saved default CBCT result figures to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary 

Fixes #1154 

This PR adds out-of-the-box default parameters for `deepinv.physics.TomographyWithAstra` when using `geometry_type="conebeam"`.

The new conebeam defaults are computed from `img_size` and `pixel_spacing`:

- `n_detector_pixels = img_size[-1]`
- `detector_spacing = 1.5 * pixel_spacing`
- `geometry_parameters["source_radius"] = img_size[-1] * 4`
- `geometry_parameters["detector_radius"] = img_size[-1]`
- `angular_range = (0, 360)`

Existing defaults for parallel and fanbeam geometries are preserved.

## Tests

Local checks run:

- `python -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text()) for p in ['deepinv/physics/tomography.py','deepinv/tests/test_external_libraries.py']]; print('syntax ok')"`: passed
- `git diff --check`: passed
- `python -m pytest deepinv\tests\test_external_libraries.py::TestTomographyWithAstra::test_tomography_with_astra_default_conebeam_geometry -q`: skipped locally because `astra-toolbox` is unavailable on Windows/Python 3.14

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
  - `python3` is not available on this Windows shell.
  - Retried with `py -3.12 -m pytest deepinv\tests --basetemp D:\deepinv\pytest_tmp`.
  - The suite reached 100% collection/execution, but had many unrelated local environment failures/errors and ended with a Windows permission error cleaning `D:\deepinv\pytest_tmp`.
  - Focused new test:
    `py -3.12 -m pytest deepinv\tests\test_external_libraries.py::TestTomographyWithAstra::test_tomography_with_astra_default_conebeam_geometry -q --basetemp D:\deepinv\pytest_tmp`
    Result: `1 skipped`, because `astra-toolbox` is unavailable locally.

- [x] `black .` and `ruff check .` run successfully.
  - Ran as:
    `py -3.12 -m black .`
    `py -3.12 -m ruff check .`
  - Result: passed.
  - Ruff warned it could not write cache files due to `.ruff_cache` permissions, but checks passed.

- [x] `make html` runs successfully (in the `docs/` directory).
  - Windows/PATH required equivalent command:
    `py -3.12 -m sphinx -M html source build`
  - Result: build succeeded.
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
