### PR TITLE
Migrate the domain name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 
 Thank you for contributing to DeepInverse!
 
-Please refer to our [contributing guidelines](https://deepinv.github.io/deepinv/contributing.html) for full instructions on how to contribute, including writing tests, documentation and code style.
+Please refer to our [contributing guidelines](https://deepinv.org/contributing.html) for full instructions on how to contribute, including writing tests, documentation and code style.
 
 Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/docs_cpu.yml). Look for the workflow run corresponding to your pull request.
 

--- a/.github/scripts/convert_to_notebook.py
+++ b/.github/scripts/convert_to_notebook.py
@@ -245,9 +245,9 @@ def _extract_html_baseurl(conf_path: Path) -> str:
                         url = ast.literal_eval(node.value)
                         if isinstance(url, str) and url:
                             return url.rstrip("/") + "/"
-        return "https://deepinv.github.io/deepinv/"
+        return "https://deepinv.org/"
     except Exception:
-        return "https://deepinv.github.io/deepinv/"
+        return "https://deepinv.org/"
 
 
 def _convert_sphinx_roles_to_links(text: str, baseurl: str) -> str:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@ Thank you for your interest in contributing to DeepInverse!
 
 Before submitting issues or pull requests, please take a moment to review our full contributing guidelines available here:
 
-👉 [Contributing to DeepInverse](https://deepinv.github.io/deepinv/contributing.html)
+👉 [Contributing to DeepInverse](https://deepinv.org/contributing.html)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -36,7 +36,7 @@ Maintainers are active and visible members of the community, and have [maintain-
 
 - **Uphold code of conduct**: model the behavior set forward by the [code of conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers.
 
-- **Pull requests**: ensure PRs adhere to our [contributing guidelines](https://deepinv.github.io/deepinv/contributing.html) and have completed the checklist in the [PR template](.github/pull_request_template.md). Triage the PR and assign them to maintainers for review. Provide actionable feedback to guide the PR towards a conclusion. In cases of uncertainty, or where contributed code is out of your domain of expertise, reach out to additional maintainers or contributors.
+- **Pull requests**: ensure PRs adhere to our [contributing guidelines](https://deepinv.org/contributing.html) and have completed the checklist in the [PR template](.github/pull_request_template.md). Triage the PR and assign them to maintainers for review. Provide actionable feedback to guide the PR towards a conclusion. In cases of uncertainty, or where contributed code is out of your domain of expertise, reach out to additional maintainers or contributors.
 
 - **Issues**: manage labels, review issues regularly, and triage by labelling them, e.g. `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`. Request further information from a submitter if an issue is not clear. See the [issue template](.github/ISSUE_TEMPLATE.md) for an example.
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ The library is part of the `official PyTorch Ecosystem <https://pytorch.landscap
 Get started
 -----------
 
-Read our **documentation** at `deepinv.github.io <https://deepinv.github.io>`_. Check out our `5 minute quickstart tutorial <https://deepinv.org/auto_examples/basics/demo_quickstart.html>`_, our `comprehensive examples <https://deepinv.org/auto_examples/index.html>`_, or our `User Guide <https://deepinv.org/user_guide.html>`_.
+Read our **documentation** at `deepinv.org <https://deepinv.org>`_. Check out our `5 minute quickstart tutorial <https://deepinv.org/auto_examples/basics/demo_quickstart.html>`_, our `comprehensive examples <https://deepinv.org/auto_examples/index.html>`_, or our `User Guide <https://deepinv.org/user_guide.html>`_.
 
 ``deepinv`` features
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@
 
 Introduction
 ------------
-`DeepInverse <https://deepinv.github.io/deepinv>`_ is an open-source PyTorch-based library for solving imaging inverse problems with deep learning.
+`DeepInverse <https://deepinv.org>`_ is an open-source PyTorch-based library for solving imaging inverse problems with deep learning.
 The library is part of the `official PyTorch Ecosystem <https://pytorch.landscape2.io/?item=modeling--computer-vision--deepinverse>`_.
 ``deepinv`` accelerates deep learning research across imaging domains, enhances research reproducibility via a common modular framework of problems and algorithms, and lowers the entrance bar to new practitioners.
 
@@ -22,16 +22,16 @@ The library is part of the `official PyTorch Ecosystem <https://pytorch.landscap
 Get started
 -----------
 
-Read our **documentation** at `deepinv.github.io <https://deepinv.github.io>`_. Check out our `5 minute quickstart tutorial <https://deepinv.github.io/deepinv/auto_examples/basics/demo_quickstart.html>`_, our `comprehensive examples <https://deepinv.github.io/deepinv/auto_examples/index.html>`_, or our `User Guide <https://deepinv.github.io/deepinv/user_guide.html>`_.
+Read our **documentation** at `deepinv.github.io <https://deepinv.github.io>`_. Check out our `5 minute quickstart tutorial <https://deepinv.org/auto_examples/basics/demo_quickstart.html>`_, our `comprehensive examples <https://deepinv.org/auto_examples/index.html>`_, or our `User Guide <https://deepinv.org/user_guide.html>`_.
 
 ``deepinv`` features
 
-* A large framework of `predefined imaging operators <https://deepinv.github.io/deepinv/user_guide/physics/physics.html>`_
-* Many `state-of-the-art deep neural networks <https://deepinv.github.io/deepinv/user_guide/reconstruction/introduction.html>`_, including pretrained out-of-the-box `reconstruction models <https://deepinv.github.io/deepinv/user_guide/reconstruction/pretrained-models.html>`_ and `denoisers <https://deepinv.github.io/deepinv/user_guide/reconstruction/denoisers.html>`_ 
-* Comprehensive frameworks for `plug-and-play restoration <https://deepinv.github.io/deepinv/user_guide/reconstruction/iterative.html>`_, `optimization <https://deepinv.github.io/deepinv/user_guide/reconstruction/optimization.html>`_ and `unfolded architectures <https://deepinv.github.io/deepinv/user_guide/reconstruction/unfolded.html>`_
-* `Training losses <https://deepinv.github.io/deepinv/user_guide/training/loss.html>`_ for inverse problems
-* `Sampling algorithms and diffusion models <https://deepinv.github.io/deepinv/user_guide/reconstruction/sampling.html>`_ for uncertainty quantification
-* A framework for `building datasets <https://deepinv.github.io/deepinv/user_guide/training/datasets.html>`_ for inverse problems
+* A large framework of `predefined imaging operators <https://deepinv.org/user_guide/physics/physics.html>`_
+* Many `state-of-the-art deep neural networks <https://deepinv.org/user_guide/reconstruction/introduction.html>`_, including pretrained out-of-the-box `reconstruction models <https://deepinv.org/user_guide/reconstruction/pretrained-models.html>`_ and `denoisers <https://deepinv.org/user_guide/reconstruction/denoisers.html>`_ 
+* Comprehensive frameworks for `plug-and-play restoration <https://deepinv.org/user_guide/reconstruction/iterative.html>`_, `optimization <https://deepinv.org/user_guide/reconstruction/optimization.html>`_ and `unfolded architectures <https://deepinv.org/user_guide/reconstruction/unfolded.html>`_
+* `Training losses <https://deepinv.org/user_guide/training/loss.html>`_ for inverse problems
+* `Sampling algorithms and diffusion models <https://deepinv.org/user_guide/reconstruction/sampling.html>`_ for uncertainty quantification
+* A framework for `building datasets <https://deepinv.org/user_guide/training/datasets.html>`_ for inverse problems
 
 Mailing list
 ~~~~~~~~~~~~
@@ -42,7 +42,7 @@ Install
 -------
 
 Install the latest stable release of ``deepinv`` with python 3.10 or higher
-(see `docs <https://deepinv.github.io/deepinv/#install>`_ installing with `uv`, `pixi` and `conda`):
+(see `docs <https://deepinv.org/#install>`_ installing with `uv`, `pixi` and `conda`):
 
 .. code-block:: bash
 
@@ -83,11 +83,11 @@ Get in touch with our `MAINTAINERS <https://github.com/deepinv/deepinv/blob/main
 Contributing
 ------------
 
-DeepInverse is a `community-driven project <https://deepinv.github.io/deepinv/community.html>`_ and we encourage contributions of all forms.
+DeepInverse is a `community-driven project <https://deepinv.org/community.html>`_ and we encourage contributions of all forms.
 We are building a comprehensive library of inverse problems and deep learning,
 and we need your help to get there! 
 
-Interested? `Check out how you can contribute <https://deepinv.github.io/deepinv/contributing.html>`_!
+Interested? `Check out how you can contribute <https://deepinv.org/contributing.html>`_!
 
 Citation
 --------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Only the latest stable release of DeepInverse is officially supported with secur
 
 ## Reporting a Vulnerability
 
-If you believe you have found a security vulnerability in DeepInverse, we encourage you to let us know right away. We will investigate all legitimate reports and do our best to quickly fix the problem. Please report issues by contacting a [lead developer](https://deepinv.github.io/).
+If you believe you have found a security vulnerability in DeepInverse, we encourage you to let us know right away. We will investigate all legitimate reports and do our best to quickly fix the problem. Please report issues by contacting a [lead developer](https://deepinv.org/).
 
 ## Using DeepInverse securely
 

--- a/deepinv/datasets/datagenerator.py
+++ b/deepinv/datasets/datagenerator.py
@@ -77,7 +77,7 @@ class HDF5Dataset(ImageDataset):
 
     :Entries:
 
-    HDF5 datasets adhere to our `conventions for datasets <https://deepinv.github.io/deepinv/user_guide/training/datasets.html>`_.
+    HDF5 datasets adhere to our `conventions for datasets <https://deepinv.org/user_guide/training/datasets.html>`_.
     In particular, their entries are either pairs of ground truth images and measuements ``(x, y)`` or triplets with additional
     physics parameters ``(x, y, params)``. It is possible that the datast does not contain ground truth data and in this case
     the ground truth is replaced by a scalar NaN tensor.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,7 +74,7 @@ intersphinx_mapping = {
     "torch": ("https://pytorch.org/docs/stable/", None),
     "torchvision": ("https://pytorch.org/vision/stable/", None),
     "python": ("https://docs.python.org/3.9/", None),
-    "deepinv": ("https://deepinv.github.io/deepinv/", None),
+    "deepinv": ("https://deepinv.org/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
@@ -94,7 +94,7 @@ autodoc_inherit_docstrings = False
 # For bibtex
 bibtex_footbibliography_backrefs = True
 # for sitemap
-html_baseurl = "https://deepinv.github.io/deepinv/"
+html_baseurl = "https://deepinv.org/"
 html_extra_path = ["robots.txt"]
 # Include reStructuredText sources
 html_copy_source = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,7 +74,6 @@ intersphinx_mapping = {
     "torch": ("https://pytorch.org/docs/stable/", None),
     "torchvision": ("https://pytorch.org/vision/stable/", None),
     "python": ("https://docs.python.org/3.9/", None),
-    "deepinv": ("https://deepinv.org/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
@@ -311,7 +310,8 @@ sphinx_gallery_conf = {
     "ignore_pattern": ignore_pattern,
     "reference_url": {
         # The module you locally document uses None
-        "sphinx_gallery": None
+        "sphinx_gallery": None,
+        "deepinv": None,
     },
     # directory where function/class granular galleries are stored
     "backreferences_dir": "gen_modules/backreferences",

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -99,8 +99,8 @@ How to write and run tests:
 Writing good documentation is also crucial for helping other users use your code. This is how:
 
 1. Write good quality `docstrings <https://realpython.com/how-to-write-docstrings-in-python/>`_ for each new class, method or function. Have a look at any other class or method in DeepInverse to see examples! Please follow our :ref:`docstring guidelines below <docstring_guidelines>`.
-2. If you wrote a new class or function, add it to the lists in the `API reference <https://deepinv.github.io/deepinv/API.html>`_ and `User Guide <https://deepinv.github.io/deepinv/user_guide.html>`_. For API, add to the appropriate `.rst` file `here <https://github.com/deepinv/deepinv/tree/main/docs/source/api>`__. For User Guide, `here <https://github.com/deepinv/deepinv/tree/main/docs/source/user_guide>`__.
-3. Want to share more about your new feature? Consider writing an `example <https://deepinv.github.io/deepinv/auto_examples/index.html>`_ in `examples/`!
+2. If you wrote a new class or function, add it to the lists in the `API reference <https://deepinv.org/API.html>`_ and `User Guide <https://deepinv.org/user_guide.html>`_. For API, add to the appropriate `.rst` file `here <https://github.com/deepinv/deepinv/tree/main/docs/source/api>`__. For User Guide, `here <https://github.com/deepinv/deepinv/tree/main/docs/source/user_guide>`__.
+3. Want to share more about your new feature? Consider writing an `example <https://deepinv.org/auto_examples/index.html>`_ in `examples/`!
 4. Check that your documentation is correct by building the docs locally. First `cd docs`, then we use `sphinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ to build:
   
 .. list-table::
@@ -143,7 +143,7 @@ Code quality is important to us. We require that your code is compliant with PEP
 5. Log your changes
 ~~~~~~~~~~~~~~~~~~~
 
-We keep a summary of all changes in the `changelog.rst <https://deepinv.github.io/deepinv/changelog.html>`_ file in the documentation.
+We keep a summary of all changes in the `changelog.rst <https://deepinv.org/changelog.html>`_ file in the documentation.
 We separate contributions into three categories: **Added** for new features, **Changed** for changes in existing features, and **Fixed** for bug fixes. 
 To do so, you should first add your GitHub information at the end of the file following the format:
 
@@ -251,7 +251,7 @@ Contributing new physics
 
 Adding a physical operator follows the general contribution guidelines. Specifically, your constribution must include proper :ref:`tests <write_tests>` and :ref:`documentation <write_docs>`, as well as meet our :ref:`code quality standards <code_quality>`. Additionally, the provided code is expected to follow specific design rules to ensure seamless integration into the codebase, this means:
 
-- Implementing a new class that inherits from the appropriate physics base class. Refer to the design outlined in `Bring your own physics <https://deepinv.github.io/deepinv/auto_examples/basics/demo_custom_physics.html>`_ for guidance.
+- Implementing a new class that inherits from the appropriate physics base class. Refer to the design outlined in `Bring your own physics <https://deepinv.org/auto_examples/basics/demo_custom_physics.html>`_ for guidance.
 
 - Registering the physics in the appropriate test suite and verifying that the tests pass -- when inheriting from :class:`deepinv.physics.LinearPhysics`, it involves the following modifications to `deepinv/tests/test_physics.py`:
 
@@ -261,7 +261,7 @@ Adding a physical operator follows the general contribution guidelines. Specific
 
   3. If applicable, write the tests specific to your physics, e.g., if it has a specific behavior that is not covered by the existing tests, see `test_MRI` in `here <https://github.com/deepinv/deepinv/blob/main/deepinv/tests/test_physics.py>`_ for an example
 
-- Completing the `API reference <https://deepinv.github.io/deepinv/api/deepinv.physics.html>`__ and `User Guide <https://deepinv.github.io/deepinv/user_guide/physics/physics.html>`__ with the new operator, and checking that the documentation builds correctly.
+- Completing the `API reference <https://deepinv.org/api/deepinv.physics.html>`__ and `User Guide <https://deepinv.org/user_guide/physics/physics.html>`__ with the new operator, and checking that the documentation builds correctly.
 
 Refer to these pull requests for examples of contributing new physics:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,7 +34,7 @@ GitHub: `<https://github.com/deepinv/deepinv>`_
 Get started
 -----------
 
-Check out our `5 minute quickstart tutorial <https://deepinv.github.io/deepinv/auto_examples/basics/demo_quickstart.html>`_, our `comprehensive examples <https://deepinv.github.io/deepinv/auto_examples/index.html>`_, or our :ref:`User Guide <user_guide>`.
+Check out our `5 minute quickstart tutorial <https://deepinv.org/auto_examples/basics/demo_quickstart.html>`_, our `comprehensive examples <https://deepinv.org/auto_examples/index.html>`_, or our :ref:`User Guide <user_guide>`.
 
 
 ``deepinv`` features

--- a/docs/source/miccai-2026.rst
+++ b/docs/source/miccai-2026.rst
@@ -14,8 +14,8 @@ Strasbourg, **Sept 27th 2026**.
 
 .. admonition:: New here?
    
-   `DeepInverse <https://deepinv.github.io/>`_ is an open-source PyTorch-based library for solving imaging inverse problems with deep learning. Check out our `5 minute quickstart tutorial <https://deepinv.github.io/deepinv/auto_examples/basics/demo_quickstart.html>`_,
-   our `comprehensive examples <https://deepinv.github.io/deepinv/auto_examples/index.html>`_,
+   `DeepInverse <https://deepinv.github.io/>`_ is an open-source PyTorch-based library for solving imaging inverse problems with deep learning. Check out our `5 minute quickstart tutorial <https://deepinv.org/auto_examples/basics/demo_quickstart.html>`_,
+   our `comprehensive examples <https://deepinv.org/auto_examples/index.html>`_,
    or our :ref:`User Guide <user_guide>`.
 
 Tutorial description
@@ -29,7 +29,7 @@ At the same time, a growing plethora of algorithms, from diffusion to foundation
 DeepInverse is a member of the official `PyTorch ecosystem <https://pytorch.org/blog/deepinverse-joins-pytorch-ecosystem/>`_.
 
 In this tutorial, we will show researchers how to use DeepInverse for their own experiments and imaging modalities.
-We will do this by walking through our `award-winning <https://www.ouvrirlascience.fr/category/prix-logiciel-libre/>`_ `documentation <https://deepinv.github.io/>`_ and comprehensive `examples <https://deepinv.github.io/deepinv/auto_examples/index.html>`_,
+We will do this by walking through our `award-winning <https://www.ouvrirlascience.fr/category/prix-logiciel-libre/>`_ `documentation <https://deepinv.github.io/>`_ and comprehensive `examples <https://deepinv.org/auto_examples/index.html>`_,
 showing how to use neural networks on real clinical images, including clinical case studies e.g. using AI to reduce scan time, reduce CT dose etc.
 Then, we will provide template notebooks to prompt participants to use DeepInverse tools to reconstruct their own clinical data, such as MRI, CT or ultrasound.
 The template notebooks will be crafted around popular MICCAI topics whose methods are available in DeepInverse, such as generative diffusion and GAN models (DPS, DDRM etc.), foundation models for image reconstruction (Reconstruct Anything Model), and uncertainty quantification. 
@@ -38,7 +38,7 @@ The template notebooks will be crafted around popular MICCAI topics whose method
 
 - Write code to reconstruct medical images with AI using the DeepInverse framework and PyTorch.
 - Use and train various SotA neural networks algorithms for medical imaging, such as diffusion models, foundation models, and denoising and reconstruction models (SwinIR, Restormer, DRUNet etc.).
-- Accelerate their own research using reusable modules in DeepInverse, such as `losses <https://deepinv.github.io/deepinv/user_guide/training/loss.html>`_, `models <https://deepinv.github.io/deepinv/user_guide/reconstruction/introduction.html>`_, `datasets <https://deepinv.github.io/deepinv/user_guide/training/datasets.html>`_, `trainers <https://deepinv.github.io/deepinv/user_guide/training/trainer.html>`_, `optimisation objectives <https://deepinv.github.io/deepinv/user_guide/reconstruction/optimization.html>`_ and `sampling algorithms <https://deepinv.github.io/deepinv/user_guide/reconstruction/sampling.html>`_.
+- Accelerate their own research using reusable modules in DeepInverse, such as `losses <https://deepinv.org/user_guide/training/loss.html>`_, `models <https://deepinv.org/user_guide/reconstruction/introduction.html>`_, `datasets <https://deepinv.org/user_guide/training/datasets.html>`_, `trainers <https://deepinv.org/user_guide/training/trainer.html>`_, `optimisation objectives <https://deepinv.org/user_guide/reconstruction/optimization.html>`_ and `sampling algorithms <https://deepinv.org/user_guide/reconstruction/sampling.html>`_.
 - Enhance reproducibility of their own research by implementing their methods with the common framework.
 - Contribute to a modern open-source deep learning library, adopt Python best-practices and join an international community of users.
 
@@ -57,7 +57,7 @@ There will be a hands-on workshop during the tutorial. So that you can make the 
 - Option 1 (cloud): Familiarity with `Google Colab <https://colab.research.google.com/>`_ (free, online, GPU access provided, Python installation managed). E.g. `open the DeepInverse quickstart in Colab <https://colab.research.google.com/github/deepinv/deepinv/blob/gh-pages/auto_examples/_notebooks/basics/demo_quickstart.ipynb>`_.
 - Option 2 (local): Familiarity with local IDE, and already installed Python 3.10+ and PyTorch 2+.
 - Basic understanding of `PyTorch <https://docs.pytorch.org/tutorials/beginner/basics/quickstart_tutorial.html>`_.
-- Optional: step through our `5 minute quickstart tutorial <https://deepinv.github.io/deepinv/auto_examples/basics/demo_quickstart.html>`_!
+- Optional: step through our `5 minute quickstart tutorial <https://deepinv.org/auto_examples/basics/demo_quickstart.html>`_!
 
 
 Organisers

--- a/docs/source/miccai-2026.rst
+++ b/docs/source/miccai-2026.rst
@@ -14,7 +14,7 @@ Strasbourg, **Sept 27th 2026**.
 
 .. admonition:: New here?
    
-   `DeepInverse <https://deepinv.github.io/>`_ is an open-source PyTorch-based library for solving imaging inverse problems with deep learning. Check out our `5 minute quickstart tutorial <https://deepinv.org/auto_examples/basics/demo_quickstart.html>`_,
+   `DeepInverse <https://deepinv.org/>`_ is an open-source PyTorch-based library for solving imaging inverse problems with deep learning. Check out our `5 minute quickstart tutorial <https://deepinv.org/auto_examples/basics/demo_quickstart.html>`_,
    our `comprehensive examples <https://deepinv.org/auto_examples/index.html>`_,
    or our :ref:`User Guide <user_guide>`.
 
@@ -25,11 +25,11 @@ Tutorial description
 Writing code to reconstruct medical images with AI requires defining many moving parts, such as the imaging operator or network architecture.
 At the same time, a growing plethora of algorithms, from diffusion to foundation models, offer to solve inverse problems.
 
-`DeepInverse <https://deepinv.github.io/>`_ is a modern PyTorch-based open-source library for imaging with deep learning, with state-of-the-art methods contributed by an international community of users and researchers across the globe and 3k monthly users.
+`DeepInverse <https://deepinv.org/>`_ is a modern PyTorch-based open-source library for imaging with deep learning, with state-of-the-art methods contributed by an international community of users and researchers across the globe and 3k monthly users.
 DeepInverse is a member of the official `PyTorch ecosystem <https://pytorch.org/blog/deepinverse-joins-pytorch-ecosystem/>`_.
 
 In this tutorial, we will show researchers how to use DeepInverse for their own experiments and imaging modalities.
-We will do this by walking through our `award-winning <https://www.ouvrirlascience.fr/category/prix-logiciel-libre/>`_ `documentation <https://deepinv.github.io/>`_ and comprehensive `examples <https://deepinv.org/auto_examples/index.html>`_,
+We will do this by walking through our `award-winning <https://www.ouvrirlascience.fr/category/prix-logiciel-libre/>`_ `documentation <https://deepinv.org/>`_ and comprehensive `examples <https://deepinv.org/auto_examples/index.html>`_,
 showing how to use neural networks on real clinical images, including clinical case studies e.g. using AI to reduce scan time, reduce CT dose etc.
 Then, we will provide template notebooks to prompt participants to use DeepInverse tools to reconstruct their own clinical data, such as MRI, CT or ultrasound.
 The template notebooks will be crafted around popular MICCAI topics whose methods are available in DeepInverse, such as generative diffusion and GAN models (DPS, DDRM etc.), foundation models for image reconstruction (Reconstruct Anything Model), and uncertainty quantification. 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -4,4 +4,4 @@ Quickstart
 .. raw:: html
 
    <meta http-equiv="refresh" content="0; url=auto_examples/basics/demo_quickstart.html">
-   <link rel="canonical" href="https://deepinv.github.io/deepinv/auto_examples/basics/demo_quickstart.html">
+   <link rel="canonical" href="https://deepinv.org/auto_examples/basics/demo_quickstart.html">

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -2,4 +2,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://deepinv.github.io/deepinv/sitemap.xml
+Sitemap: https://deepinv.org/sitemap.xml

--- a/docs/source/user_guide/reconstruction/sampling.rst
+++ b/docs/source/user_guide/reconstruction/sampling.rst
@@ -34,7 +34,7 @@ The **forward-time SDE** is defined as follows, from time :math:`0` to :math:`T`
 
     d x_t = f(t) x_t dt + g(t) d w_t.
 
-where :math:`w_t` is a Brownian process. 
+where :math:`w_t` is a Brownian process.
 Let :math:`p_t` denote the distribution of the random vector :math:`x_t`.
 Under this forward process, we have that:
 
@@ -67,7 +67,7 @@ that is :math:`\denoiser{x+\sigma\omega}{\sigma} \approx \mathbb{E} [ x|x+\sigma
     Using a normalized noise levels :math:`\sigma(t)` and scalings :math:`s(t)` lets us use `any denoiser in the library <denoisers>`_
     trained for multiple noise levels assuming pixel values are in the range :math:`[0,1]`.
 
-Starting from a random point following the end-point distribution :math:`p_T` of the forward process, 
+Starting from a random point following the end-point distribution :math:`p_T` of the forward process,
 solving the reverse-time SDE gives us a sample of the data distribution :math:`p_0`.
 
 The base classes for defining a SDEs are :class:`deepinv.sampling.BaseSDE` and :class:`deepinv.sampling.DiffusionSDE`.
@@ -98,6 +98,8 @@ Solvers
 
 Once the SDE is defined, we can obtain an approximate sample with any of the following solvers:
 
+.. _sde_ode_solvers
+
 .. list-table:: SDE/ODE solvers
    :header-rows: 1
 
@@ -124,9 +126,9 @@ by the conditional score function :math:`\nabla \log p_t(x_t|y)`. The conditiona
 .. math::
     \nabla_{x_t} \log p_t(x_t | y) &= \nabla_{x_t} \log p_t(x_t) + \nabla_{x_t} \log p_t \left(y \vert x_t \right) \\
                             &= \nabla_{x_t} \log p_t(x_t) + \frac{1}{s_t} \nabla_{\hat x_t} \log \hat p_t \left(y \vert \hat x_{t} = \frac{x_t}{s(t)} = x_0 + \sigma(t) \omega \right).
-    
-where :math:`\hat p_t` stands for the distribution of the unscaled data :math:`x_t / s(t)`. 
-The first term is the unconditional score function and can be approximated by using a denoiser as explained previously. 
+
+where :math:`\hat p_t` stands for the distribution of the unscaled data :math:`x_t / s(t)`.
+The first term is the unconditional score function and can be approximated by using a denoiser as explained previously.
 The second term is the conditional score function, which is untractable:
 
 .. math::
@@ -179,7 +181,7 @@ Uncertainty quantification
 
 Diffusion methods obtain a single sample per call. If multiple samples are required, the
 :class:`deepinv.sampling.DiffusionSampler` can be used to convert a diffusion method into a sampler that
-obtains multiple samples to compute posterior statistics such as the mean or variance. 
+obtains multiple samples to compute posterior statistics such as the mean or variance.
 It uses the helper class :class:`deepinv.sampling.DiffusionIterator` to interface diffusion samplers with :class:`deepinv.sampling.BaseSampling`.
 
 .. _mcmc:
@@ -232,7 +234,7 @@ A custom iterator needs to implement two methods:
 
 *   ``initialize_latent_variables(self, x_init, y, physics, data_fidelity, prior)``: This method sets up the initial state of your Markov chain. It receives the initial image estimate :math:`x_{\text{init}}`, measurements :math:`y`, the physics operator, data fidelity term, and prior. It should return a dictionary representing the initial state :math:`X_0`, which must include the image as ``{"x": x_init, ...}`` and can include any other latent variables your sampler requires. The default (non overridden) behavior is returning ``{"x":x_init}``
 
-*   ``forward(self, X, y, physics, data_fidelity, prior, iteration_number, **iterator_specific_params)``: This method defines a single step of your MCMC algorithm. It takes the previous state :math:`X` (a dictionary containing at least the previous image ``{"x": x, ...}``), measurements :math:`y`, the data fidelity, the prior, and returns the new state :math:`X_{next}` (again, a dictionary including ``{"x": x_next, ...}``). 
+*   ``forward(self, X, y, physics, data_fidelity, prior, iteration_number, **iterator_specific_params)``: This method defines a single step of your MCMC algorithm. It takes the previous state :math:`X` (a dictionary containing at least the previous image ``{"x": x, ...}``), measurements :math:`y`, the data fidelity, the prior, and returns the new state :math:`X_{next}` (again, a dictionary including ``{"x": x_next, ...}``).
 
 
 Some predefined iterators are provided:

--- a/docs/source/user_guide/reconstruction/sampling.rst
+++ b/docs/source/user_guide/reconstruction/sampling.rst
@@ -98,7 +98,7 @@ Solvers
 
 Once the SDE is defined, we can obtain an approximate sample with any of the following solvers:
 
-.. _sde_ode_solvers
+.. _sde_ode_solvers:
 
 .. list-table:: SDE/ODE solvers
    :header-rows: 1

--- a/examples/sampling/demo_diffusers.py
+++ b/examples/sampling/demo_diffusers.py
@@ -5,7 +5,7 @@ Using state-of-the-art diffusion models from HuggingFace Diffusers with DeepInve
 This demo shows you how to use our wrapper
 :class:`deepinv.models.DiffusersDenoiserWrapper` to turn any SOTA models from the HuggingFace Hub to an image denoiser. It also can be used to perform unconditional image generation or for posterior sampling.
 
-See more about the `diffusers pipeline <https://huggingface.co/docs/diffusers/index>`_ and our posterior sampling `user guide <https://deepinv.github.io/deepinv/auto_examples/sampling/demo_diffusion_sde.html>`_.
+See more about the `diffusers pipeline <https://huggingface.co/docs/diffusers/index>`_ and our posterior sampling `user guide <https://deepinv.org/auto_examples/sampling/demo_diffusion_sde.html>`_.
 
 .. note:: This example requires the `diffusers` and `transformers` package. You can install it via `pip install diffusers transformers`.
 

--- a/examples/sampling/demo_diffusers.py
+++ b/examples/sampling/demo_diffusers.py
@@ -5,7 +5,7 @@ Using state-of-the-art diffusion models from HuggingFace Diffusers with DeepInve
 This demo shows you how to use our wrapper
 :class:`deepinv.models.DiffusersDenoiserWrapper` to turn any SOTA models from the HuggingFace Hub to an image denoiser. It also can be used to perform unconditional image generation or for posterior sampling.
 
-See more about the `diffusers pipeline <https://huggingface.co/docs/diffusers/index>`_ and our posterior sampling `user guide <https://deepinv.org/auto_examples/sampling/demo_diffusion_sde.html>`_.
+See more about the `diffusers pipeline <https://huggingface.co/docs/diffusers/index>`_ and our posterior sampling :ref:`user guide <sphx_glr_auto_examples_sampling_demo_diffusion_sde.py>`.
 
 .. note:: This example requires the `diffusers` and `transformers` package. You can install it via `pip install diffusers transformers`.
 

--- a/examples/sampling/demo_diffusion_sde.py
+++ b/examples/sampling/demo_diffusion_sde.py
@@ -36,7 +36,7 @@ The (conditional) score function :math:`\nabla_{x_t} \log p_t(x_t | y)` can be d
 
 The first term is the score function of the unconditional SDE, which is typically approximated by an MMSE denoiser (`denoiser`) using the well-known Tweedie's formula, while the
 second term is approximated by the (noisy) data-fidelity term (`data_fidelity`).
-We implement various data-fidelity terms in `the user guide <https://deepinv.org/user_guide/reconstruction/sampling.html#id2>`_.
+We implement various data-fidelity terms in ref:`the user guide <sde_ode_solvers>`.
 
 .. note::
 

--- a/examples/sampling/demo_diffusion_sde.py
+++ b/examples/sampling/demo_diffusion_sde.py
@@ -36,7 +36,7 @@ The (conditional) score function :math:`\nabla_{x_t} \log p_t(x_t | y)` can be d
 
 The first term is the score function of the unconditional SDE, which is typically approximated by an MMSE denoiser (`denoiser`) using the well-known Tweedie's formula, while the
 second term is approximated by the (noisy) data-fidelity term (`data_fidelity`).
-We implement various data-fidelity terms in `the user guide <https://deepinv.github.io/deepinv/user_guide/reconstruction/sampling.html#id2>`_.
+We implement various data-fidelity terms in `the user guide <https://deepinv.org/user_guide/reconstruction/sampling.html#id2>`_.
 
 .. note::
 

--- a/examples/sampling/demo_diffusion_sde.py
+++ b/examples/sampling/demo_diffusion_sde.py
@@ -36,7 +36,7 @@ The (conditional) score function :math:`\nabla_{x_t} \log p_t(x_t | y)` can be d
 
 The first term is the score function of the unconditional SDE, which is typically approximated by an MMSE denoiser (`denoiser`) using the well-known Tweedie's formula, while the
 second term is approximated by the (noisy) data-fidelity term (`data_fidelity`).
-We implement various data-fidelity terms in ref:`the user guide <sde_ode_solvers>`.
+We implement various data-fidelity terms in :ref:`the user guide <sde_ode_solvers>`.
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ file = "README.rst"
 content-type = "text/x-rst"
 
 [project.urls]
-Homepage = "https://deepinv.github.io/"
+Homepage = "https://deepinv.org/"
 Source = "https://github.com/deepinv/deepinv"
 Tracker = "https://github.com/deepinv/deepinv/issues"
 


### PR DESCRIPTION
The goal of this PR is to move away from deepinv.github.io to deepinv.org

**Changes**
- [x] Change URLs pointing to deepinv.github.io in the code base
- [x] Get rid of deepinv.github.io in the documentation build

**Absolute to relative URLs**

In ec34fe934b6daa34846b2d4bd60e555db2d57d3d I bypass cache issues resulting in links pointing to the previous domain by switching from absolute (cache-dependent) to relative (always up-to-date) URLs for internal links. I believe it shouldn't mess with anything, which is why I preferred that solution instead of dealing with cache invalidation stuff.

**Plan for Google Search migration**

1. [x] List all relevant Google Search Console properties
    - https://deepinv.github.io
    - https://deepinv.github.io/deepinv
2. [ ] ~~Submit a change of address for each of the top-level ones~~
    - [ ] ~~For https://deepinv.github.io~~
3. [x] Register the sitemap for deepinv.org

**Update - Jun'22, 2026**

For technical reasons related to there being 2 distinct GitHub pages websites at deepinv/deepinv and deepinv/deepinv.github.io we didn't formally migrate the website using the Google Search Console form. The current redirections should suffice for a proper transfer on their end, but if we notice poor indexation here's an alternate plan we can put into place.

1. Find a way to deal with the deepinv/ prefix for proper redirections & put the solution in place
2. Change CI so it builds the docs into `deepinv/deepinv.github.io:main` instead of `deepinv/deepinv:gh-pages`
3. Get rid of the GitHub Pages website at deepinv/deepinv
4. Setup the GitHub pages at deepinv/deepinv.github.io to point to deepinv.org

**SEO**

- [How to move a site - Google Search](https://developers.google.com/search/docs/crawling-indexing/site-move-with-url-changes)
- [Change of Address tool - Google Search](https://support.google.com/webmasters/answer/9370220)

**Subdomains / subdirectories**

Instead of moving the docs from https://deepinv.github.io to https://deepinv.org, we could instead move it to a subdomain https://docs.deepinv.org or a subdirectory https://deepinv.org/docs. Upon consideration, I believe we should directly migrate to the top-level URL.

Below pros & cons of moving to the top-level URL.

Pros
- Easier and better for SEO
- Neat homepage URL without awkward redirections

Cons
- We might eventually have to migrate stuff to have a non-technical landing page at https://deepinv.org for media, funding agencies, and so on.
- It's a bit more tedious to migrate from a generic URL to a specific URL than doing the converse.

**TODO**
- [x] Setup a Google Search Console account for deepinv.org
- [x] Plan out the Google Search migration
- [x] List pros and cons between https://deepinv.org/ and https://deepinv.org/docs
- [x] Check how to do the DNS change through Cloudflare
- [x] Point DNS to GitHub pages for deepinv.org
- [x] Merge this PR
- [x] Setup redirects from deepinv.github.io to deepinv.org
  - [x] A GitHub Pages redirect in https://github.com/deepinv/deepinv
  - [x] A GitHub Pages (ideally) or client-side redirect in https://github.com/deepinv/deepinv.github.io
- [x] Setup deepinv.org with GitHub pages
- [x] Apply the migration plan for Google Search