### PR TITLE
Fix noise model not updating int param

### DIFF
--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -119,7 +119,7 @@ class NoiseModel(nn.Module):
                 if (
                     value is not None
                     and hasattr(self, key)
-                    and isinstance(value, (torch.Tensor, float))
+                    and isinstance(value, (torch.Tensor, float, int))
                 ):
                     self.register_buffer(key, self._float_to_tensor(value))
 


### PR DESCRIPTION
Fix a very minor silent bug:

```python
>>> _p = dinv.physics.Denoising(dinv.physics.GaussianNoise(0.1))
>>> _p.update(sigma=3)
>>> _p.noise_model.sigma
tensor(0.1000)
```

Now that `int` is included in the `isinstance`, this should not happen anymore.