### PR TITLE
Fix BM3D silently breaks for multi-channel images when number of channels is not 3

### DIFF
--- a/deepinv/models/utils.py
+++ b/deepinv/models/utils.py
@@ -15,30 +15,20 @@ import io
 import contextlib
 
 
-def tensor2array(img):
-    img = img.cpu().detach().numpy()
-    img = np.transpose(img, (1, 2, 0))
-    return img
-
-
-def array2tensor(img):
-    return torch.from_numpy(img).permute(2, 0, 1)
-
-
 def tensor2array(img: Tensor) -> np.ndarray:
     img = img.cpu().detach().numpy()
-    if img.shape[0] == 3:  # Color case: cast to numpy format (W,H,C)
-        img = np.transpose(img, (1, 2, 0))
-    else:  # Grayscale case: cast to numpy format (W,H)
+    if img.shape[0] == 1:  # Grayscale case: cast to numpy format (W,H)
         img = img[0]
+    else:  # All other cases: cast to numpy format (W,H,C)
+        img = np.transpose(img, (1, 2, 0))
     return img
 
 
 def array2tensor(img: np.ndarray) -> Tensor:
-    if len(img.shape) == 3:  # Color case: back to (C,W,H)
-        out = torch.from_numpy(img).permute(2, 0, 1)
-    else:  # Grayscale case: back to (1,W,H)
+    if len(img.shape) == 1:  # Grayscale case: back to (1,W,H)
         out = torch.from_numpy(img).unsqueeze(0)
+    else:  # All other cases: back to (C,W,H)
+        out = torch.from_numpy(img).permute(2, 0, 1)
     return out
 
 

--- a/deepinv/models/utils.py
+++ b/deepinv/models/utils.py
@@ -25,7 +25,7 @@ def tensor2array(img: Tensor) -> np.ndarray:
 
 
 def array2tensor(img: np.ndarray) -> Tensor:
-    if len(img.shape) == 1:  # Grayscale case: back to (1,W,H)
+    if len(img.shape) == 2:  # Grayscale case: back to (1,W,H)
         out = torch.from_numpy(img).unsqueeze(0)
     else:  # All other cases: back to (C,W,H)
         out = torch.from_numpy(img).permute(2, 0, 1)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,6 +35,7 @@ Fixed
 - Fix dimensions mismatch in :class:`deepinv.physics.TomographyWithAstra` with 3D phantoms (:gh:`1137` by `Baptiste Legouix`_)
 - Add warning and error handling for negative inputs in BlurFFT and Poisson noise (:gh:`1155` by `Thibaut Modrzyk`_)
 - Fix a bug in the custom backward of the least-squares solvers for non-leaf tensors (:gh:`1146` by `Minh Hai Nguyen`_)
+- Fix a bug that caused :class:`deepinv.models.BM3D` to silently break for multi-channel images when the number of channels is not 3 (:gh:`1192` by `Kaibo Tang`_)
 
 
 v0.4.0
@@ -619,3 +620,4 @@ Changed
 .. _Laura C. Diaz-Delgado: https://github.com/LauraCD2
 .. _Paul Bernard: https://github.com/PAUL-BERNARD
 .. _Baptiste Legouix: https://github.com/blegouix
+.. _Kaibo Tang: https://github.com/kvttt


### PR DESCRIPTION
Fix #1191.

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
