### PR TITLE
fix(transform): fix Reflect.inverse and Shift axis swap

### DIFF
--- a/deepinv/transform/reflect.py
+++ b/deepinv/transform/reflect.py
@@ -28,6 +28,10 @@ class Reflect(Transform):
         super().__init__(*args, **kwargs)
         self.dim = dim
 
+    def invert_params(self, params: dict) -> dict:
+        """Inverse of a reflection is itself (flipping twice returns the original)."""
+        return params
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate sets of reflection axes without replacement.
 

--- a/deepinv/transform/shift.py
+++ b/deepinv/transform/shift.py
@@ -66,7 +66,7 @@ class Shift(Transform):
         """
         return torch.cat(
             [
-                torch.roll(x, [sx, sy], [-2, -1])
+                torch.roll(x, [sy, sx], [-2, -1])
                 for sx, sy in zip_longest(x_shift, y_shift, fillvalue=0)
             ],
             dim=0,


### PR DESCRIPTION
Closes #1197

## Bug 1: Reflect.inverse

The base class `invert_params` negates all parameters (`{k: -v}`), which incorrectly transforms `dims=[-1]` to `dims=[1]`. Since reflecting (flipping) twice along the same axis is the identity operation, the inverse of a reflection is itself. Fixed by overriding `invert_params` in `Reflect` to return params unchanged.

## Bug 2: Shift axis swap

`x_shift` was generated from the height range (`H_max`) and applied to dim `-2` (height), while `y_shift` was generated from the width range (`W_max`) and applied to dim `-1` (width). In image convention, x=horizontal=width, y=vertical=height. Fixed by swapping the roll arguments so `x_shift` maps to width and `y_shift` maps to height.