### PR TITLE
Ignore NaN pixels in SpectralAngleMapper reduction (fixes #1047)

### DIFF
--- a/deepinv/loss/metric/distortion.py
+++ b/deepinv/loss/metric/distortion.py
@@ -589,7 +589,11 @@ class SpectralAngleMapper(Metric):
     def metric(self, x_net: Tensor, x: Tensor, *args, **kwargs) -> Tensor:
         from torchmetrics.functional.image import spectral_angle_mapper
 
-        return spectral_angle_mapper(x_net, x, reduction="none").mean(
+        # Pixels whose spectral vector is all-zero produce NaN angles
+        # (division by a zero norm in torchmetrics). Since we perform the
+        # spatial reduction ourselves, use ``nanmean`` so these pixels are
+        # ignored rather than poisoning the whole image score with NaN.
+        return spectral_angle_mapper(x_net, x, reduction="none").nanmean(
             dim=tuple(range(1, x.ndim - 1)), keepdim=False
         )
 

--- a/deepinv/tests/test_metric.py
+++ b/deepinv/tests/test_metric.py
@@ -591,3 +591,25 @@ def test_gmsd():
     x[:, :, :4] = 2
     out = gmsd(x_net, x)
     assert torch.isclose(out, torch.tensor((0.33,)), atol=3e-4)
+
+
+def test_spectral_angle_mapper_ignores_zero_pixels():
+    # Regression test for #1047: a pixel whose spectral vector is all-zero
+    # yields a NaN angle in torchmetrics. Because SAM reduces spatially
+    # itself, that NaN must not poison the whole image score.
+    a, b = torch.ones(2, 1, 3, 8, 8)
+    a[:, :, 5, 3] = 0  # one all-zero spectral pixel
+
+    out = metric.SpectralAngleMapper()(a, b)
+    assert not torch.isnan(out).any()
+    # The remaining pixels are identical, so the angle is 0 everywhere kept.
+    assert torch.allclose(out, torch.zeros_like(out), atol=1e-6)
+
+    # Without any degenerate pixel the result is unchanged (matches a plain
+    # spatial mean of the per-pixel angles).
+    from torchmetrics.functional.image import spectral_angle_mapper
+
+    x_net = torch.rand(3, 4, 8, 8)
+    x = torch.rand(3, 4, 8, 8)
+    reference = spectral_angle_mapper(x_net, x, reduction="none").mean(dim=(1, 2))
+    assert torch.allclose(metric.SpectralAngleMapper()(x_net, x), reference)


### PR DESCRIPTION
## Summary

Fixes #1047. `deepinv.metric.SpectralAngleMapper` returns `NaN` for the whole image whenever a single pixel has an all-zero spectral vector:

```python
import torch
import deepinv as dinv

a, b = torch.ones(2, 1, 3, 8, 8)
a[:, :, 5, 3] = 0
dinv.metric.SpectralAngleMapper()(a, b)   # -> tensor([nan])
```

### Root cause

`torchmetrics`'s `spectral_angle_mapper(..., reduction="none")` computes a per-pixel angle `arccos(<x̂,x> / (‖x̂‖‖x‖))`. A pixel whose spectral vector is all-zero has a zero norm, so that pixel's angle is `NaN` (this is the upstream behaviour tracked in [torchmetrics#3322](https://github.com/Lightning-AI/torchmetrics/issues/3322)).

`SpectralAngleMapper` performs its **own** spatial reduction:

```python
return spectral_angle_mapper(x_net, x, reduction="none").mean(
    dim=tuple(range(1, x.ndim - 1)), keepdim=False
)
```

so a single `NaN` pixel poisons the entire image score.

### Fix

Since the reduction is done here, use `nanmean` instead of `mean` so degenerate pixels are ignored rather than propagating `NaN`, as suggested in the issue. When no `NaN` is present the result is identical to the previous `mean` behaviour.

## Verification

Added `test_spectral_angle_mapper_ignores_zero_pixels` in `deepinv/tests/test_metric.py`, which:
- reproduces the issue (all-zero spectral pixel) and asserts the score is no longer `NaN` (fails on the current code with `tensor([nan])`, passes with this change);
- asserts the result is unchanged from a plain spatial mean of the per-pixel angles when no degenerate pixel is present (success path preserved).

The existing SAM cases in `test_full_reference_metrics` continue to pass.