### PR TITLE
Allow passing sigma as a dimensionless nn.Parameter

### DIFF
--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -237,12 +237,9 @@ class DRUNet(Denoiser):
                         f"Incorrect shape, sigma should be of shape (1,), (batch_size,) or (batch_size, 1, height, width, (depth)), got {tuple(sigma.shape)}"
                     )
             else:
-                noise_level_map = torch.full(
-                    (x.size(0), 1, *x.shape[2:]),
-                    sigma,
-                    device=x.device,
-                    dtype=x.dtype,
-                )
+                noise_level_map = torch.ones(
+                    (x.size(0), 1, *x.shape[2:]), device=x.device
+                ) * sigma.to(x.device)
         else:
             noise_level_map = torch.full(
                 (x.size(0), 1, *x.shape[2:]),

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -747,7 +747,16 @@ def test_drunet_inputs(dim, spatial_size, device):
     sigma_tensor = torch.tensor(sigma).to(device)
     x_hat = f(y, sigma_tensor)
     assert x_hat.shape == x.shape
+    
+    # Case 5: sigma is a nn.Parameter with no dimension
+    sigma_param = torch.nn.Parameter(torch.tensor(sigma, requires_grad=True, device=device))
+    x_hat = f(y, sigma_param)
+    assert x_hat.shape == x.shape
 
+    loss = x_hat.pow(2).mean()
+    loss.backward()
+    assert sigma_param.grad is not None
+    
 
 @pytest.mark.parametrize(
     "drunet_args",

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -747,16 +747,18 @@ def test_drunet_inputs(dim, spatial_size, device):
     sigma_tensor = torch.tensor(sigma).to(device)
     x_hat = f(y, sigma_tensor)
     assert x_hat.shape == x.shape
-    
+
     # Case 5: sigma is a nn.Parameter with no dimension
-    sigma_param = torch.nn.Parameter(torch.tensor(sigma, requires_grad=True, device=device))
+    sigma_param = torch.nn.Parameter(
+        torch.tensor(sigma, requires_grad=True, device=device)
+    )
     x_hat = f(y, sigma_param)
     assert x_hat.shape == x.shape
 
     loss = x_hat.pow(2).mean()
     loss.backward()
     assert sigma_param.grad is not None
-    
+
 
 @pytest.mark.parametrize(
     "drunet_args",


### PR DESCRIPTION
In #1174, we inadvertently removed an untested feature of the `DRUNet`, which allowed passing `sigma` as an `nn.Parameter`. This feature is used in #1088 (I pushed a temporary fix there). I am opening a separate PR to avoid cluttering the discussion there.

- I am adding back the feature and adding a small test in `test_drunet_inputs`.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
