### PR TITLE
Fix small typo in the docs of DecomposablePhysics

### DIFF
--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -996,7 +996,7 @@ class DecomposablePhysics(LinearPhysics):
         A = U\text{diag}(s)V^{\top} \in \mathbb{R}^{m\times n}
 
     where :math:`U\in\mathbb{C}^{m\times m}` and :math:`V\in\mathbb{C}^{n\times n}`
-    are orthonormal linear transformations and :math:`s\in\mathbb{R}_{+}^{n}` are the singular values.
+    are orthonormal linear transformations and :math:`\text{diag}(s)\in\mathbb{R}_{+}^{m \times n}` is the possibly rectangular singular value matrix.
 
     :param None | Callable U: orthonormal transformation. If `None` (default), it is set to the identity function.
     :param None | Callable V_adjoint: transpose of V. If `None` (default), it is set to the identity function.

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -996,7 +996,7 @@ class DecomposablePhysics(LinearPhysics):
         A = U\text{diag}(s)V^{\top} \in \mathbb{R}^{m\times n}
 
     where :math:`U\in\mathbb{C}^{m\times m}` and :math:`V\in\mathbb{C}^{n\times n}`
-    are orthonormal linear transformations and :math:`\text{diag}(s)\in\mathbb{R}_{+}^{m \times n}` is the possibly rectangular singular value matrix.
+    are orthonormal linear transformations and :math:`\text{diag}(s)\in\mathbb{R}_{+}^{m \times n}` is the possibly rectangular singular values matrix.
 
     :param None | Callable U: orthonormal transformation. If `None` (default), it is set to the identity function.
     :param None | Callable V_adjoint: transpose of V. If `None` (default), it is set to the identity function.

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -995,7 +995,7 @@ class DecomposablePhysics(LinearPhysics):
 
         A = U\text{diag}(s)V^{\top} \in \mathbb{R}^{m\times n}
 
-    where :math:`U\in\mathbb{C}^{n\times n}` and :math:`V\in\mathbb{C}^{m\times m}`
+    where :math:`U\in\mathbb{C}^{m\times m}` and :math:`V\in\mathbb{C}^{n\times n}`
     are orthonormal linear transformations and :math:`s\in\mathbb{R}_{+}^{n}` are the singular values.
 
     :param None | Callable U: orthonormal transformation. If `None` (default), it is set to the identity function.


### PR DESCRIPTION
If A is in R^(m times n), U should be in R^(m times m) and V in R^(n times n) while currently it's the opposite