### PR TITLE
enable centering the psf option for diffraction psf 2D generator , i.e the barycenter of generated psf at origin

### DIFF
--- a/deepinv/physics/generator/blur.py
+++ b/deepinv/physics/generator/blur.py
@@ -405,7 +405,6 @@ class DiffractionBlurGenerator(PSFGenerator):
     ) -> dict:
         r"""
         Generate a batch of PFS with a batch of Zernike coefficients
-
         :param int batch_size: batch_size.
         :param torch.Tensor coeff: `batch_size x len(zernike_index)` coefficients of the Zernike decomposition (default is `None`)
         :param torch.Tensor angle: `batch_size` angles in degree to rotate the PSF (defaults is `None`)

--- a/deepinv/physics/generator/blur.py
+++ b/deepinv/physics/generator/blur.py
@@ -10,6 +10,7 @@ from deepinv.utils.decorators import _deprecated_alias
 from deepinv.transform.rotate import rotate_via_shear
 from deepinv.utils.mixins import TiledMixin2d
 from .zernike import Zernike
+from tqdm import tqdm
 
 
 class PSFGenerator(PhysicsGenerator):
@@ -281,6 +282,7 @@ class DiffractionBlurGenerator(PSFGenerator):
         pupil_size: tuple[int, ...] = (256, 256),
         apodize: bool = False,
         random_rotate: bool = False,
+        center: bool = False,        
         index_convention: str = "noll",
         device: str | torch.device = "cpu",
         dtype: torch.dtype = torch.float32,
@@ -309,6 +311,7 @@ class DiffractionBlurGenerator(PSFGenerator):
         self.apodize = apodize
         self.random_rotate = random_rotate
         self.index_convention = index_convention
+        self.center = center
 
         if self.apodize:
             lin_0 = torch.linspace(
@@ -339,6 +342,8 @@ class DiffractionBlurGenerator(PSFGenerator):
 
         # Fourier plane is discretized on [-0.5,0.5]x[-0.5,0.5]
         XX, YY = torch.meshgrid(lin_x / self.fc, lin_y / self.fc, indexing="ij")
+        self.register_buffer("XX", XX)
+        self.register_buffer("YY", YY)
         self.register_buffer(
             "rho", cart2pol(XX, YY)
         )  # Cartesian coordinates to polar coordinates
@@ -352,7 +357,7 @@ class DiffractionBlurGenerator(PSFGenerator):
         self.pad_pre = (
             ceil((self.pupil_size[0] - self.psf_size[0]) / 2),
             ceil((self.pupil_size[1] - self.psf_size[1]) / 2),
-        )
+        ) 
         self.pad_post = (
             floor((self.pupil_size[0] - self.psf_size[0]) / 2),
             floor((self.pupil_size[1] - self.psf_size[1]) / 2),
@@ -369,6 +374,7 @@ class DiffractionBlurGenerator(PSFGenerator):
                 **self.factory_kwargs,
             ),
         )
+        self.nontilt_indices = []
         for k, index in enumerate(self.zernike_index):
             if isinstance(index, int):
                 n, m = Zernike.index_conversion(index, convention=index_convention)
@@ -378,6 +384,8 @@ class DiffractionBlurGenerator(PSFGenerator):
                 raise ValueError(
                     f"Zernike index must be either int or tuple of (n,m), got {index!r}"
                 )
+            if (m != 1) and (m != -1):
+                self.nontilt_indices.append(k)
             self.Z[:, :, k] = Zernike.cartesian_evaluate(
                 n, m, XX, YY
             )  # defining the k-th Zernike polynomial
@@ -390,6 +398,7 @@ class DiffractionBlurGenerator(PSFGenerator):
         coeff: torch.Tensor = None,
         angle: torch.Tensor = None,
         seed: int = None,
+        center: bool = None,
         **kwargs,
     ) -> dict:
         r"""
@@ -406,22 +415,56 @@ class DiffractionBlurGenerator(PSFGenerator):
             - `coeff`: list of sampled Zernike coefficients in this realization,
             - `pupil`: the pupil function,
             - `angle`: the random rotation angle in degrees if `random_rotate` is `True`, nothing otherwise.
+            - `tip`: the added tip zernike if `center` is `True`, nothing otherwise.
+            - `tilt`: the added tilt zernike if `center` is `True`, nothing otherwise.
         """
-
+        if center is None:
+            center = self.center
         self.rng_manual_seed(seed)
         if coeff is None:
             coeff = self.generate_coeff(batch_size)
 
-        pupil = (self.Z @ coeff[:, : self.n_zernike].T).transpose(2, 0)
-        pupil = torch.exp(-2.0j * torch.pi * pupil)
-        pupil = pupil * self.indicator_circ
-        psf = torch.fft.ifftshift(torch.fft.fft2(torch.fft.fftshift(pupil)))
+        pupil = (self.Z @ coeff[:, : self.n_zernike].T).permute(2, 0, 1)
+        pupil = torch.exp( -2.0j * torch.pi * pupil)
+        pupil = pupil * self.indicator_circ[None, :, :]
+        psf = torch.fft.ifftshift(torch.fft.fft2(torch.fft.fftshift(pupil, dim=(-2, -1))),dim=(-2, -1))
         psf = psf.abs().pow(2)
         psf = psf[
             :,
             self.pad_pre[0] : self.pupil_size[0] - self.pad_post[0],
             self.pad_pre[1] : self.pupil_size[1] - self.pad_post[1],
         ].unsqueeze(1)
+
+        if center:
+            x = torch.arange(-(psf.shape[-2]//2), psf.shape[-2]//2 + 1).to(self.device)
+            y = torch.arange(-(psf.shape[-1]//2), psf.shape[-1]//2 + 1).to(self.device)
+            x, y = torch.meshgrid(x, y, indexing='ij')
+            normalization = psf.sum(dim=(-3,-2,-1))
+            shift_x = (x.unsqueeze(0).unsqueeze(0) * psf).sum(dim=(1,2,3))/normalization
+            shift_y = (y.unsqueeze(0).unsqueeze(0) * psf).sum(dim=(1,2,3))/normalization
+
+            Z2 = Zernike.cartesian_evaluate(1, 1, self.XX, self.YY)
+            tangential_coeff_Z2 = (Z2[pupil.shape[-2]//2, pupil.shape[-1]//2]
+                                   - Z2[pupil.shape[-2]//2 -1, pupil.shape[-1]//2])
+            coeff_Z2 = shift_x / (pupil.shape[-2] * tangential_coeff_Z2)
+            pupil = pupil * torch.exp(-2.0j * torch.pi * coeff_Z2[:,None, None] * Z2[None, :, :]) 
+
+            Z3 = Zernike.cartesian_evaluate(1, -1, self.XX, self.YY)
+            tangential_coeff_Z3 = (Z3[pupil.shape[-2]//2, pupil.shape[-1]//2]
+                                   - Z3[pupil.shape[-2]//2, pupil.shape[-1]//2-1])
+            coeff_Z3 = shift_y / (pupil.shape[-1] * tangential_coeff_Z3)
+            pupil = pupil * torch.exp(-2.0j * torch.pi * coeff_Z3[:,None, None] * Z3[None, :, :]) 
+            
+            psf = torch.fft.ifftshift(torch.fft.fft2(torch.fft.fftshift(pupil, dim =(-2, -1))), dim=(-2, -1))
+            psf = psf.abs().pow(2)
+            psf = psf[
+                :,
+                self.pad_pre[0] : self.pupil_size[0] - self.pad_post[0],
+                self.pad_pre[1] : self.pupil_size[1] - self.pad_post[1],
+            ].unsqueeze(1)
+
+
+
 
         # random rotate the PSF if angle is given
         if self.random_rotate:
@@ -433,6 +476,8 @@ class DiffractionBlurGenerator(PSFGenerator):
             psf = self.apodize_mask * psf
 
         psf = psf / torch.sum(psf, dim=(-1, -2), keepdim=True)
+
+
         params = {
             "filter": psf.expand(-1, self.shape[0], -1, -1),
             "coeff": coeff,
@@ -440,6 +485,10 @@ class DiffractionBlurGenerator(PSFGenerator):
         }
         if self.random_rotate:
             params["angle"] = angle
+        
+        if center:
+            params["tip"] = coeff_Z2
+            params["tilt"] = coeff_Z3
         return params
 
     @property

--- a/deepinv/physics/generator/blur.py
+++ b/deepinv/physics/generator/blur.py
@@ -10,7 +10,6 @@ from deepinv.utils.decorators import _deprecated_alias
 from deepinv.transform.rotate import rotate_via_shear
 from deepinv.utils.mixins import TiledMixin2d
 from .zernike import Zernike
-from tqdm import tqdm
 
 
 class PSFGenerator(PhysicsGenerator):
@@ -242,6 +241,9 @@ class DiffractionBlurGenerator(PSFGenerator):
         If a single ``int`` is given, a square pupil is considered.
     :param bool apodize: whether to apodize the PSF to reduce ringing artifacts, defaults to ``False``.
     :param bool random_rotate: whether to randomly rotate the PSF, defaults to ``False``.
+    :param bool center: whether to add tip and tilt Zernike polynomials to center the the barycenter of the PSF, defaults to ``False``.
+        Having effect only when the psf size is large enough.
+        Less effective when the PSF is apodize=True or random_rotate=True.
     :param str index_convention: the convention for the Zernike polynomials indexing. Can be either ``'noll'`` (default) or ``'ansi'``.
     :param str, torch.device device: device where the tensors are allocated and processed, defaults to ``'cpu'``.
     :param torch.dtype dtype: data type of the tensors, defaults to ``torch.float32``.
@@ -282,7 +284,7 @@ class DiffractionBlurGenerator(PSFGenerator):
         pupil_size: tuple[int, ...] = (256, 256),
         apodize: bool = False,
         random_rotate: bool = False,
-        center: bool = False,        
+        center: bool = False,
         index_convention: str = "noll",
         device: str | torch.device = "cpu",
         dtype: torch.dtype = torch.float32,
@@ -341,7 +343,7 @@ class DiffractionBlurGenerator(PSFGenerator):
         self.step_rho = lin_x[1] - lin_x[0]
 
         # Fourier plane is discretized on [-0.5,0.5]x[-0.5,0.5]
-        XX, YY = torch.meshgrid(lin_x / self.fc, lin_y / self.fc, indexing="ij")
+        XX, YY = torch.meshgrid(lin_x / self.fc, lin_y / self.fc, indexing="xy")
         self.register_buffer("XX", XX)
         self.register_buffer("YY", YY)
         self.register_buffer(
@@ -357,7 +359,7 @@ class DiffractionBlurGenerator(PSFGenerator):
         self.pad_pre = (
             ceil((self.pupil_size[0] - self.psf_size[0]) / 2),
             ceil((self.pupil_size[1] - self.psf_size[1]) / 2),
-        ) 
+        )
         self.pad_post = (
             floor((self.pupil_size[0] - self.psf_size[0]) / 2),
             floor((self.pupil_size[1] - self.psf_size[1]) / 2),
@@ -397,8 +399,8 @@ class DiffractionBlurGenerator(PSFGenerator):
         batch_size: int = 1,
         coeff: torch.Tensor = None,
         angle: torch.Tensor = None,
-        seed: int = None,
         center: bool = None,
+        seed: int = None,
         **kwargs,
     ) -> dict:
         r"""
@@ -407,6 +409,7 @@ class DiffractionBlurGenerator(PSFGenerator):
         :param int batch_size: batch_size.
         :param torch.Tensor coeff: `batch_size x len(zernike_index)` coefficients of the Zernike decomposition (default is `None`)
         :param torch.Tensor angle: `batch_size` angles in degree to rotate the PSF (defaults is `None`)
+        :param bool center: whether to add tip and tilt Zernike polynomials to center the the barycenter of the PSF (defaults to self.center).
         :param int seed: the seed for the random number generator.
 
         :return: dictionary with keys
@@ -425,9 +428,11 @@ class DiffractionBlurGenerator(PSFGenerator):
             coeff = self.generate_coeff(batch_size)
 
         pupil = (self.Z @ coeff[:, : self.n_zernike].T).permute(2, 0, 1)
-        pupil = torch.exp( -2.0j * torch.pi * pupil)
+        pupil = torch.exp(-2.0j * torch.pi * pupil)
         pupil = pupil * self.indicator_circ[None, :, :]
-        psf = torch.fft.ifftshift(torch.fft.fft2(torch.fft.fftshift(pupil, dim=(-2, -1))),dim=(-2, -1))
+        psf = torch.fft.ifftshift(
+            torch.fft.fft2(torch.fft.fftshift(pupil, dim=(-2, -1))), dim=(-2, -1)
+        )
         psf = psf.abs().pow(2)
         psf = psf[
             :,
@@ -436,35 +441,52 @@ class DiffractionBlurGenerator(PSFGenerator):
         ].unsqueeze(1)
 
         if center:
-            x = torch.arange(-(psf.shape[-2]//2), psf.shape[-2]//2 + 1).to(self.device)
-            y = torch.arange(-(psf.shape[-1]//2), psf.shape[-1]//2 + 1).to(self.device)
-            x, y = torch.meshgrid(x, y, indexing='ij')
-            normalization = psf.sum(dim=(-3,-2,-1))
-            shift_x = (x.unsqueeze(0).unsqueeze(0) * psf).sum(dim=(1,2,3))/normalization
-            shift_y = (y.unsqueeze(0).unsqueeze(0) * psf).sum(dim=(1,2,3))/normalization
+            Ny, Nx = psf.shape[-2:]
+            centerx = (Nx / 2.0) - 0.5
+            centery = (Ny / 2.0) - 0.5
+            x = torch.arange(0, psf.shape[-1]).to(self.device)
+            y = torch.arange(0, psf.shape[-2]).to(self.device)
+            x, y = torch.meshgrid(x, y, indexing="xy")
+            normalization = psf.sum(dim=(-3, -2, -1))
 
-            Z2 = Zernike.cartesian_evaluate(1, 1, self.XX, self.YY)
-            tangential_coeff_Z2 = (Z2[pupil.shape[-2]//2, pupil.shape[-1]//2]
-                                   - Z2[pupil.shape[-2]//2 -1, pupil.shape[-1]//2])
-            coeff_Z2 = shift_x / (pupil.shape[-2] * tangential_coeff_Z2)
-            pupil = pupil * torch.exp(-2.0j * torch.pi * coeff_Z2[:,None, None] * Z2[None, :, :]) 
+            shift_x = (x.unsqueeze(0).unsqueeze(0) * psf).sum(
+                dim=(-3, -2, -1)
+            ) / normalization
+            shift_x = shift_x - centerx
 
-            Z3 = Zernike.cartesian_evaluate(1, -1, self.XX, self.YY)
-            tangential_coeff_Z3 = (Z3[pupil.shape[-2]//2, pupil.shape[-1]//2]
-                                   - Z3[pupil.shape[-2]//2, pupil.shape[-1]//2-1])
-            coeff_Z3 = shift_y / (pupil.shape[-1] * tangential_coeff_Z3)
-            pupil = pupil * torch.exp(-2.0j * torch.pi * coeff_Z3[:,None, None] * Z3[None, :, :]) 
-            
-            psf = torch.fft.ifftshift(torch.fft.fft2(torch.fft.fftshift(pupil, dim =(-2, -1))), dim=(-2, -1))
+            shift_y = (y.unsqueeze(0).unsqueeze(0) * psf).sum(
+                dim=(-3, -2, -1)
+            ) / normalization
+            shift_y = shift_y - centery
+            Z3 = Zernike.cartesian_evaluate(1, 1, self.XX, self.YY)
+            tangential_coeff_Z3 = (
+                Z3[pupil.shape[-2] // 2, pupil.shape[-1] // 2]
+                - Z3[pupil.shape[-2] // 2, (pupil.shape[-1] // 2) - 1]
+            )
+            coeff_Z3 = shift_x / (pupil.shape[-1] * tangential_coeff_Z3)
+            pupil = pupil * torch.exp(
+                -2.0j * torch.pi * coeff_Z3[:, None, None] * Z3[None, :, :]
+            )
+
+            Z2 = Zernike.cartesian_evaluate(1, -1, self.XX, self.YY)
+            tangential_coeff_Z2 = (
+                Z2[pupil.shape[-2] // 2, pupil.shape[-1] // 2]
+                - Z2[(pupil.shape[-2] // 2) - 1, pupil.shape[-1] // 2]
+            )
+            coeff_Z2 = shift_y / (pupil.shape[-2] * tangential_coeff_Z2)
+            pupil = pupil * torch.exp(
+                -2.0j * torch.pi * coeff_Z2[:, None, None] * Z2[None, :, :]
+            )
+
+            psf = torch.fft.ifftshift(
+                torch.fft.fft2(torch.fft.fftshift(pupil, dim=(-2, -1))), dim=(-2, -1)
+            )
             psf = psf.abs().pow(2)
             psf = psf[
                 :,
                 self.pad_pre[0] : self.pupil_size[0] - self.pad_post[0],
                 self.pad_pre[1] : self.pupil_size[1] - self.pad_post[1],
             ].unsqueeze(1)
-
-
-
 
         # random rotate the PSF if angle is given
         if self.random_rotate:
@@ -477,7 +499,6 @@ class DiffractionBlurGenerator(PSFGenerator):
 
         psf = psf / torch.sum(psf, dim=(-1, -2), keepdim=True)
 
-
         params = {
             "filter": psf.expand(-1, self.shape[0], -1, -1),
             "coeff": coeff,
@@ -485,10 +506,10 @@ class DiffractionBlurGenerator(PSFGenerator):
         }
         if self.random_rotate:
             params["angle"] = angle
-        
+
         if center:
-            params["tip"] = coeff_Z2
-            params["tilt"] = coeff_Z3
+            params["tilt_x"] = coeff_Z3
+            params["tilt_y"] = coeff_Z2
         return params
 
     @property

--- a/deepinv/tests/test_generators.py
+++ b/deepinv/tests/test_generators.py
@@ -723,12 +723,11 @@ def test_diffraction_generator(
         for key in params.keys():
             assert not torch.allclose(params[key], params3[key])
 
-
     # Test centering effect if center is True and psf size is large enough
     # Test only for 2D case as centering in 3D case is still under development
     if (not is_3d) and center and (not apodize) and (not random_rotate):
         batch_sizes = (1, 2)
-        size = (71,71)
+        size = (71, 71)
         pupil_size = (256, 256)
         generator = dinv.physics.generator.DiffractionBlurGenerator(
             psf_size=size,
@@ -745,13 +744,13 @@ def test_diffraction_generator(
         )
         for batch_size in batch_sizes:
             generated_psf = generator.step(
-                                batch_size=batch_size,
-                                seed=0,
-                                focal_length=0.004,
-                                aperture_diameter=0.002,
-                                apodize=apodize,
-                                random_rotate=random_rotate,
-                            )["filter"]
+                batch_size=batch_size,
+                seed=0,
+                focal_length=0.004,
+                aperture_diameter=0.002,
+                apodize=apodize,
+                random_rotate=random_rotate,
+            )["filter"]
             com_x, com_y = barycenter(generated_psf)
             assert torch.all(torch.round(com_x.abs(), decimals=1) <= 0.1)
             assert torch.all(torch.round(com_y.abs(), decimals=1) <= 0.1)
@@ -760,13 +759,14 @@ def test_diffraction_generator(
 def barycenter(h):
     Ny, Nx = h.shape[-2:]
     centerx = (Nx / 2.0) - 0.5
-    centery = (Ny / 2.0) - 0.5 
+    centery = (Ny / 2.0) - 0.5
     x = torch.arange(0, h.shape[-1]).to(h.device)
     y = torch.arange(0, h.shape[-2]).to(h.device)
-    X, Y = torch.meshgrid(x, y, indexing='xy')
-    com_x = (X[None,None,:,:] * h).sum(dim=(-2,-1)) - centerx
-    com_y = (Y[None,None,:,:] * h).sum(dim=(-2,-1)) - centery
+    X, Y = torch.meshgrid(x, y, indexing="xy")
+    com_x = (X[None, None, :, :] * h).sum(dim=(-2, -1)) - centerx
+    com_y = (Y[None, None, :, :] * h).sum(dim=(-2, -1)) - centery
     return com_x, com_y
+
 
 @pytest.mark.parametrize("generators", MIXTURES)
 @pytest.mark.parametrize("size", SIZES)

--- a/deepinv/tests/test_generators.py
+++ b/deepinv/tests/test_generators.py
@@ -637,11 +637,12 @@ def test_string_seed():
 
 @pytest.mark.parametrize("apodize", [True, False])
 @pytest.mark.parametrize("random_rotate", [True, False])
+@pytest.mark.parametrize("center", [True, False])
 @pytest.mark.parametrize("num_channels", [1, 3])
 @pytest.mark.parametrize("convention", ["noll", "ansi"])
 @pytest.mark.parametrize("is_3d", [True, False])
 def test_diffraction_generator(
-    device, apodize, random_rotate, num_channels, convention, is_3d, rng
+    device, apodize, random_rotate, center, num_channels, convention, is_3d, rng
 ):
     r"""
     Test diffraction generator.
@@ -676,6 +677,7 @@ def test_diffraction_generator(
             index_convention=convention,
             apodize=apodize,
             random_rotate=random_rotate,
+            center=center,
             dtype=dtype,
             pupil_size=pupil_size,
             rng=rng,
@@ -683,7 +685,9 @@ def test_diffraction_generator(
 
     batch_sizes = (1, 2)
     expected_keys = set(
-        ["filter", "coeff", "pupil"] + (["angle"] if random_rotate else [])
+        ["filter", "coeff", "pupil"]
+        + (["angle"] if random_rotate else [])
+        + (["tilt_x", "tilt_y"] if ((not is_3d) and center) else [])
     )
     for batch_size in batch_sizes:
         params = generator.step(
@@ -719,6 +723,50 @@ def test_diffraction_generator(
         for key in params.keys():
             assert not torch.allclose(params[key], params3[key])
 
+
+    # Test centering effect if center is True and psf size is large enough
+    # Test only for 2D case as centering in 3D case is still under development
+    if (not is_3d) and center and (not apodize) and (not random_rotate):
+        batch_sizes = (1, 2)
+        size = (71,71)
+        pupil_size = (256, 256)
+        generator = dinv.physics.generator.DiffractionBlurGenerator(
+            psf_size=size,
+            device=device,
+            num_channels=num_channels,
+            zernike_index=zernike_index,
+            index_convention=convention,
+            apodize=apodize,
+            random_rotate=random_rotate,
+            center=center,
+            dtype=dtype,
+            pupil_size=pupil_size,
+            rng=rng,
+        )
+        for batch_size in batch_sizes:
+            generated_psf = generator.step(
+                                batch_size=batch_size,
+                                seed=0,
+                                focal_length=0.004,
+                                aperture_diameter=0.002,
+                                apodize=apodize,
+                                random_rotate=random_rotate,
+                            )["filter"]
+            com_x, com_y = barycenter(generated_psf)
+            assert torch.all(torch.round(com_x.abs(), decimals=1) <= 0.1)
+            assert torch.all(torch.round(com_y.abs(), decimals=1) <= 0.1)
+
+
+def barycenter(h):
+    Ny, Nx = h.shape[-2:]
+    centerx = (Nx / 2.0) - 0.5
+    centery = (Ny / 2.0) - 0.5 
+    x = torch.arange(0, h.shape[-1]).to(h.device)
+    y = torch.arange(0, h.shape[-2]).to(h.device)
+    X, Y = torch.meshgrid(x, y, indexing='xy')
+    com_x = (X[None,None,:,:] * h).sum(dim=(-2,-1)) - centerx
+    com_y = (Y[None,None,:,:] * h).sum(dim=(-2,-1)) - centery
+    return com_x, com_y
 
 @pytest.mark.parametrize("generators", MIXTURES)
 @pytest.mark.parametrize("size", SIZES)

--- a/examples/physics/demo_mri_tour.py
+++ b/examples/physics/demo_mri_tour.py
@@ -463,11 +463,13 @@ dataset = dinv.datasets.CMRxReconSliceDataset(
 
 x, y, params = next(iter(DataLoader(dataset)))
 
-print(f"""
+print(
+    f"""
     Ground truth: {x.shape} (B, C, T, H, W)
     Measurements: {y.shape}
     Acc. mask: {params["mask"].shape}
-""")
+"""
+)
 
 # %%
 # Dynamic MRI data is directly compatible with existing functionality.

--- a/examples/physics/demo_mri_tour.py
+++ b/examples/physics/demo_mri_tour.py
@@ -463,13 +463,11 @@ dataset = dinv.datasets.CMRxReconSliceDataset(
 
 x, y, params = next(iter(DataLoader(dataset)))
 
-print(
-    f"""
+print(f"""
     Ground truth: {x.shape} (B, C, T, H, W)
     Measurements: {y.shape}
     Acc. mask: {params["mask"].shape}
-"""
-)
+""")
 
 # %%
 # Dynamic MRI data is directly compatible with existing functionality.


### PR DESCRIPTION
enable centering the psf option for diffraction psf 2D generator , i.e the barycenter of generated psf at origin



### Checks to be done before submitting your PR

- [] `python3 -m pytest deepinv/tests` runs successfully.
- [] `black .` and `ruff check .` run successfully.
- [] `make html` runs successfully (in the `docs/` directory).
- [] Updated docstrings related to the changes (as applicable).
- [] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
