### PR TITLE
Minor fix to HDF5Dataset.unsupervised warnings in CI

### DIFF
--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -381,7 +381,14 @@ def test_hdf5dataset(
         ), "Transform should be called if and only if it is supervised."
 
     # Test HDF5Dataset.unsupervised
-    assert dataset.unsupervised == unsupervised, "Dataset supervision label mismatch."
+    # Verify that it is deprecated properly
+    with pytest.warns(
+        DeprecationWarning, match="The attribute 'unsupervised' is deprecated"
+    ) as record:
+        # Verify that it gives the right value
+        assert (
+            dataset.unsupervised == unsupervised
+        ), "Dataset supervision label mismatch."
 
     # Test HDF5Dataset.close
     if close:


### PR DESCRIPTION
In #764 the attribute HDF5Dataset.unsupervised was deprecated and substituted for a property. A new check was added in the tests for the value of this property to ensure the change was not breaking, but the deprecation warning hasn't been filtered properly resulting in deprecation warnings in CI, see for instance [1].

Notably, it accounts for 7680 out of the 7756 failures preventing #1007 to be merged.

[1] https://github.com/deepinv/deepinv/actions/runs/25254844525/job/74052443871