### PR TITLE
Add gradient accumulation option to Trainer

### DIFF
--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -468,6 +468,69 @@ def test_trainer_multidatasets(imsize, rng, device):
     assert torch.isclose(dummy_model.dummy_param, torch.tensor(avg_value), atol=1e-6)
 
 
+def test_trainer_accum_gradients(imsize, rng, device):
+    N = 4
+
+    list_physics = [get_dummy_physics(rng=rng), get_dummy_physics(rng=rng)]
+    list_generators = [
+        get_dummy_physics_generator(rng=rng, device=device),
+        get_dummy_physics_generator(rng=rng, device=device),
+    ]
+    list_dataloaders = [
+        DataLoader(get_dummy_dataset(imsize=imsize, N=N, value=-0.4), batch_size=1),
+        DataLoader(get_dummy_dataset(imsize=imsize, N=N, value=1.9), batch_size=1),
+    ]
+
+    class DummyModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dummy_param = torch.nn.Parameter(torch.zeros(1), requires_grad=True)
+
+        def forward(self, y=0.0, physics=None, **kwargs):
+            return self.dummy_param * torch.ones_like(y)
+
+    dummy_model = DummyModel().to(device)
+    optimizer = torch.optim.SGD(dummy_model.parameters(), lr=1e-2)
+
+    step_calls = []
+    zero_grad_calls = []
+    original_step = optimizer.step
+    original_zero_grad = optimizer.zero_grad
+
+    def counted_step(*args, **kwargs):
+        step_calls.append(1)
+        return original_step(*args, **kwargs)
+
+    def counted_zero_grad(*args, **kwargs):
+        zero_grad_calls.append(1)
+        return original_zero_grad(*args, **kwargs)
+
+    optimizer.step = counted_step
+    optimizer.zero_grad = counted_zero_grad
+
+    trainer = Trainer(
+        model=dummy_model,
+        physics=list_physics,
+        optimizer=optimizer,
+        train_dataloader=list_dataloaders,
+        online_measurements=True,
+        physics_generator=list_generators,
+        loop_random_online_physics=True,
+        optimizer_step_multi_dataset=True,
+        accum_gradients=2,
+        epochs=1,
+        device=device,
+        save_path=None,
+        verbose=False,
+        show_progress_bar=False,
+    )
+
+    trainer.train()
+
+    assert len(step_calls) == 2
+    assert len(zero_grad_calls) == 2
+
+
 def test_trainer_load_model(tmp_path):
     class TempModel(torch.nn.Module):
         def __init__(self, *args, **kwargs):

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -86,6 +86,9 @@ class Trainer:
         using :class:`deepinv.utils.AverageMeter` to deal with uneven batch sizes. Default is :class:`supervised loss <deepinv.loss.SupLoss>`.
     :param float grad_clip: Gradient clipping value for the optimizer. If None, no gradient clipping is performed. Default is None.
     :param bool optimizer_step_multi_dataset: If ``True``, the optimizer step is performed once on all datasets. If ``False``, the optimizer step is performed on each dataset separately.
+    :param int accum_gradients: Number of training steps to accumulate gradients before calling ``optimizer.step()``.
+        A single training step already accumulates gradients from the ``G`` operators when ``optimizer_step_multi_dataset=True``,
+        so ``accum_gradients=1`` preserves the current behavior.
 
     .. note::
 
@@ -285,6 +288,7 @@ class Trainer:
     no_learning_method: str | Reconstructor = "A_adjoint"
     grad_clip: float = None
     check_grad: bool = False
+    accum_gradients: int = 1
     wandb_vis: bool = False
     mlflow_vis: bool = False
     wandb_setup: dict = field(default_factory=dict)
@@ -323,6 +327,9 @@ class Trainer:
                 DeprecationWarning,
                 stacklevel=2,
             )
+        assert (
+            isinstance(self.accum_gradients, int) and self.accum_gradients > 0
+        ), "accum_gradients should be a positive integer."
         # Cache flag for whether model.forward accepts 'update_parameters'
         self._model_accepts_update_parameters = False
 
@@ -1014,7 +1021,9 @@ class Trainer:
         :param bool last_batch: If ``True``, the last batch of the epoch is being processed.
         :returns: The current physics operator, the ground truth, the measurement, and the network reconstruction.
         """
-        if train and self.optimizer_step_multi_dataset:
+        if train and self.optimizer_step_multi_dataset and (
+            train_ite is None or train_ite % self.accum_gradients == 0
+        ):
             self.optimizer.zero_grad(set_to_none=True)  # Clear stored gradients
 
         # random permutation of the dataloaders
@@ -1057,7 +1066,11 @@ class Trainer:
         if self.log_train_batch and train:
             self.log_metrics_mlops(logs, step=train_ite, train=train)
 
-        if train and self.optimizer_step_multi_dataset:
+        if train and self.optimizer_step_multi_dataset and (
+            train_ite is None
+            or (train_ite + 1) % self.accum_gradients == 0
+            or last_batch
+        ):
             self.optimizer.step()  # Optimizer step
 
         if last_batch:
@@ -1466,9 +1479,9 @@ class Trainer:
                 self.scheduler.step()
 
             if (
-                epoch > 0 and epoch % self.ckp_interval == 0
+                epoch + 1 > 0 and (epoch + 1) % self.ckp_interval == 0
             ) or epoch + 1 == self.epochs:
-                self.save_model(f"ckp_{epoch}.pth.tar", epoch)
+                self.save_model(f"ckp_{epoch + 1}.pth.tar", epoch + 1)
 
             if stop_flag:
                 break

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -1021,8 +1021,10 @@ class Trainer:
         :param bool last_batch: If ``True``, the last batch of the epoch is being processed.
         :returns: The current physics operator, the ground truth, the measurement, and the network reconstruction.
         """
-        if train and self.optimizer_step_multi_dataset and (
-            train_ite is None or train_ite % self.accum_gradients == 0
+        if (
+            train
+            and self.optimizer_step_multi_dataset
+            and (train_ite is None or train_ite % self.accum_gradients == 0)
         ):
             self.optimizer.zero_grad(set_to_none=True)  # Clear stored gradients
 
@@ -1066,10 +1068,14 @@ class Trainer:
         if self.log_train_batch and train:
             self.log_metrics_mlops(logs, step=train_ite, train=train)
 
-        if train and self.optimizer_step_multi_dataset and (
-            train_ite is None
-            or (train_ite + 1) % self.accum_gradients == 0
-            or last_batch
+        if (
+            train
+            and self.optimizer_step_multi_dataset
+            and (
+                train_ite is None
+                or (train_ite + 1) % self.accum_gradients == 0
+                or last_batch
+            )
         ):
             self.optimizer.step()  # Optimizer step
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,12 +8,14 @@ Current
 
 New Features
 ^^^^^^^^^^^^
+- Add multi-step optimizer (:gh:`1235` by `Julian Tachella`_)
 
 Changed
 ^^^^^^^
 
 Fixed
 ^^^^^
+- Allow saving first checkpoint in Trainer (:gh:`1235` by `Julian Tachella`_)
 
 
 v0.4.1


### PR DESCRIPTION
- adds the possibility of using gradient accumulation across batches to `Trainer`
- fixes a small ckp saving bug that didn't allow saving the ckp after the first completed epoch

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
