### PR TITLE
Add NEMA IEC body phantom

### DIFF
--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -419,7 +419,7 @@ def test_deprecated_alias():
 @pytest.mark.parametrize("n_data", [1, 2, 3])
 @pytest.mark.parametrize("transform", [None, lambda x: x])
 @pytest.mark.parametrize("length", [1, 10])
-@pytest.mark.parametrize("dataset_name", ["random", "shepplogan"])
+@pytest.mark.parametrize("dataset_name", ["random", "shepplogan", "nemaiec"])
 def test_phantom_datasets(size, n_data, transform, length, dataset_name):
     if dataset_name == "random":
         dataset = deepinv.utils.RandomPhantomDataset(
@@ -429,12 +429,29 @@ def test_phantom_datasets(size, n_data, transform, length, dataset_name):
         dataset = deepinv.utils.SheppLoganDataset(
             size=size, n_data=n_data, transform=transform
         )
+    elif dataset_name == "nemaiec":
+        dataset = deepinv.utils.NEMAIECPhantomDataset(
+            size=size, n_data=n_data, transform=transform
+        )
     check_dataset_format(
         dataset,
-        length=length if dataset_name != "shepplogan" else 1,
+        length=length if dataset_name in ("random",) else 1,
         dtype=torch.Tensor,
         shape=(n_data, size, size),
     )
+
+
+def test_nema_iec_phantom_activities():
+    # the six requested activity levels should appear as distinct values
+    activities = [0.1, 0.2, 0.3, 0.4, 0.5, 1.0]
+    x = deepinv.utils.generate_nema_iec_phantom(
+        size=256, activities=activities, background=0.05, lung=0.0, normalize=False
+    )
+    for a in activities:
+        assert torch.isclose(x, torch.tensor(a)).any(), f"activity {a} missing"
+    # invalid number of activities should raise
+    with pytest.raises(ValueError):
+        deepinv.utils.generate_nema_iec_phantom(size=64, activities=[1.0, 2.0])
 
 
 @pytest.mark.parametrize("input_shape", [(1, 3, 32, 64)])

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -424,7 +424,7 @@ def test_deprecated_alias():
 @pytest.mark.parametrize("n_data", [1, 2, 3])
 @pytest.mark.parametrize("transform", [None, lambda x: x])
 @pytest.mark.parametrize("length", [1, 10])
-@pytest.mark.parametrize("dataset_name", ["random", "shepplogan"])
+@pytest.mark.parametrize("dataset_name", ["random", "shepplogan", "nemaiec"])
 def test_phantom_datasets(size, n_data, transform, length, dataset_name):
     if dataset_name == "random":
         dataset = deepinv.utils.RandomPhantomDataset(
@@ -438,12 +438,29 @@ def test_phantom_datasets(size, n_data, transform, length, dataset_name):
         dataset = deepinv.utils.SheppLoganDataset(
             size=size, n_data=n_data, transform=transform, use_dict_output=True
         )
+    elif dataset_name == "nemaiec":
+        dataset = deepinv.utils.NEMAIECPhantomDataset(
+            size=size, n_data=n_data, transform=transform, use_dict_output=True
+        )
     check_dataset_format(
         dataset,
-        length=length if dataset_name != "shepplogan" else 1,
+        length=length if dataset_name in ("random",) else 1,
         dtype=dict,
         shape=(n_data, size, size),
     )
+
+
+def test_nema_iec_phantom_activities():
+    # the six requested activity levels should appear as distinct values
+    activities = [0.1, 0.2, 0.3, 0.4, 0.5, 1.0]
+    x = deepinv.utils.generate_nema_iec_phantom(
+        size=256, activities=activities, background=0.05, lung=0.0, normalize=False
+    )
+    for a in activities:
+        assert torch.isclose(x, torch.tensor(a)).any(), f"activity {a} missing"
+    # invalid number of activities should raise
+    with pytest.raises(ValueError):
+        deepinv.utils.generate_nema_iec_phantom(size=64, activities=[1.0, 2.0])
 
 
 @pytest.mark.parametrize("input_shape", [(1, 3, 32, 64)])

--- a/deepinv/utils/__init__.py
+++ b/deepinv/utils/__init__.py
@@ -41,7 +41,12 @@ from .tensorlist import (
     dirac_like,
     dirac_comb_like,
 )
-from .phantoms import RandomPhantomDataset, SheppLoganDataset
+from .phantoms import (
+    RandomPhantomDataset,
+    SheppLoganDataset,
+    NEMAIECPhantomDataset,
+    generate_nema_iec_phantom,
+)
 from .patch_extractor import (
     patch_extractor,
     image_to_patches,

--- a/deepinv/utils/__init__.py
+++ b/deepinv/utils/__init__.py
@@ -40,7 +40,12 @@ from .tensorlist import (
     dirac_like,
     dirac_comb_like,
 )
-from .phantoms import RandomPhantomDataset, SheppLoganDataset
+from .phantoms import (
+    RandomPhantomDataset,
+    SheppLoganDataset,
+    NEMAIECPhantomDataset,
+    generate_nema_iec_phantom,
+)
 from .patch_extractor import (
     patch_extractor,
     image_to_patches,

--- a/deepinv/utils/phantoms.py
+++ b/deepinv/utils/phantoms.py
@@ -128,3 +128,161 @@ class SheppLoganDataset(Dataset):
             x = self.transform(x)
 
         return x
+
+
+# NEMA IEC body phantom geometry, in millimetres, following the specification
+# used by OpenGATE (opengate/contrib/phantoms/nemaiec.py).
+NEMA_IEC_SPHERE_DIAMETERS_MM = (10.0, 13.0, 17.0, 22.0, 28.0, 37.0)
+NEMA_IEC_RING_RADIUS_MM = 57.27  # radius of the circle the sphere centres sit on
+NEMA_IEC_LUNG_RADIUS_MM = 25.0  # central cold cylindrical insert
+NEMA_IEC_START_ANGLE_DEG = 180.0  # angular position of the first (smallest) sphere
+NEMA_IEC_BOX_HALF_X_MM = 100.0  # half-width of the surrounding box
+NEMA_IEC_BOX_HALF_Y_MM = 90.0  # half-height of the surrounding box
+NEMA_IEC_FOV_HALF_MM = 110.0  # physical half-extent mapped to the [-1, 1] grid
+
+
+def generate_nema_iec_phantom(
+    size: int,
+    activities: list[float] | None = None,
+    background: float = 0.25,
+    lung: float = 0.0,
+    normalize: bool = True,
+) -> torch.Tensor:
+    r"""
+    Generate a 2D NEMA IEC body phantom.
+
+    The NEMA IEC body phantom is a standard image-quality phantom commonly used
+    in PET and SPECT. It consists of six spheres of increasing diameter
+    (10, 13, 17, 22, 28 and 37 mm) arranged on a circle inside a uniform
+    background, with a central cold cylindrical "lung" insert. This function
+    returns the 2D transverse cross-section through the centre of the six
+    spheres, with the body approximated by a rectangular box.
+
+    The activity level of each sphere can be set individually via ``activities``.
+
+    .. note::
+
+        This is a synthetic phantom intended for demonstrations and testing of
+        reconstruction algorithms (e.g. with :class:`deepinv.physics.Tomography`),
+        not a physically accurate simulation of a PET/SPECT acquisition.
+
+    |sep|
+
+    :Example:
+
+    >>> import deepinv as dinv
+    >>> x = dinv.utils.phantoms.generate_nema_iec_phantom(64)
+    >>> x.shape
+    torch.Size([64, 64])
+
+    :param int size: size of the (square) phantom image.
+    :param list[float] activities: list of 6 activity levels, one per sphere ordered
+        by increasing diameter. Defaults to ``[1.0] * 6`` (all spheres equally active).
+    :param float background: activity level of the uniform background inside the box.
+    :param float lung: activity level of the central cold cylindrical insert.
+    :param bool normalize: if ``True``, the phantom is rescaled so that its maximum
+        value is 1.
+    :return: (:class:`torch.Tensor`) a phantom of shape ``(size, size)``.
+    """
+    n_spheres = len(NEMA_IEC_SPHERE_DIAMETERS_MM)
+    if activities is None:
+        activities = [1.0] * n_spheres
+    if len(activities) != n_spheres:
+        raise ValueError(
+            f"activities must have length {n_spheres}, got {len(activities)}."
+        )
+
+    scale = 1.0 / NEMA_IEC_FOV_HALF_MM
+    x, y = torch.meshgrid(
+        torch.linspace(-1, 1, size), torch.linspace(-1, 1, size), indexing="ij"
+    )
+
+    phantom = torch.zeros(size, size)
+
+    # body box filled with uniform background activity
+    box = (x.abs() <= NEMA_IEC_BOX_HALF_X_MM * scale) & (
+        y.abs() <= NEMA_IEC_BOX_HALF_Y_MM * scale
+    )
+    phantom[box] = background
+
+    # six spheres arranged on a circle, ordered by increasing diameter
+    ring_radius = NEMA_IEC_RING_RADIUS_MM * scale
+    for i, diameter in enumerate(NEMA_IEC_SPHERE_DIAMETERS_MM):
+        angle = np.deg2rad(NEMA_IEC_START_ANGLE_DEG + i * 360 / n_spheres)
+        x_0 = ring_radius * np.cos(angle)
+        y_0 = ring_radius * np.sin(angle)
+        radius = (diameter / 2) * scale
+        mask = ((x - x_0) ** 2 + (y - y_0) ** 2) <= radius**2
+        phantom[mask] = activities[i]
+
+    # central cold cylindrical "lung" insert
+    lung_mask = (x**2 + y**2) <= (NEMA_IEC_LUNG_RADIUS_MM * scale) ** 2
+    phantom[lung_mask] = lung
+
+    if normalize:
+        max_val = phantom.max()
+        if max_val > 0:
+            phantom = phantom / max_val
+
+    return phantom
+
+
+class NEMAIECPhantomDataset(Dataset):
+    r"""
+    Dataset for the NEMA IEC body phantom. The dataset has length 1.
+
+    See :func:`deepinv.utils.phantoms.generate_nema_iec_phantom` for details on
+    the phantom and its parameters.
+
+    :param int size: Size of the phantom (square) image.
+    :param int n_data: Number of phantoms to generate per sample.
+    :param list[float] activities: list of 6 sphere activity levels, ordered by
+        increasing diameter. Defaults to ``[1.0] * 6``.
+    :param float background: activity level of the uniform background.
+    :param float lung: activity level of the central cold insert.
+    :param bool normalize: if ``True``, rescale so that the maximum value is 1.
+    :param Callable transform: Transformation to apply to the output image.
+    """
+
+    def __init__(
+        self,
+        size: int = 128,
+        n_data: int = 1,
+        activities: list[float] | None = None,
+        background: float = 0.25,
+        lung: float = 0.0,
+        normalize: bool = True,
+        transform=None,
+    ):
+        self.size = size
+        self.n_data = n_data
+        self.activities = activities
+        self.background = background
+        self.lung = lung
+        self.normalize = normalize
+        self.transform = transform
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        """
+        :return: A torch.Tensor of shape (n_data, size, size).
+        """
+        x = torch.stack(
+            [
+                generate_nema_iec_phantom(
+                    self.size,
+                    activities=self.activities,
+                    background=self.background,
+                    lung=self.lung,
+                    normalize=self.normalize,
+                )
+                for _ in range(self.n_data)
+            ]
+        )
+
+        if self.transform is not None:
+            x = self.transform(x)
+
+        return x

--- a/deepinv/utils/phantoms.py
+++ b/deepinv/utils/phantoms.py
@@ -349,3 +349,173 @@ def generate_pet_phantom(
     x_att = x_att.unsqueeze(0).unsqueeze(0)
 
     return x_em, x_att
+
+
+# NEMA IEC body phantom geometry, in millimetres, following the specification
+# used by OpenGATE (opengate/contrib/phantoms/nemaiec.py).
+NEMA_IEC_SPHERE_DIAMETERS_MM = (10.0, 13.0, 17.0, 22.0, 28.0, 37.0)
+NEMA_IEC_RING_RADIUS_MM = 57.27  # radius of the circle the sphere centres sit on
+NEMA_IEC_LUNG_RADIUS_MM = 25.0  # central cold cylindrical insert
+NEMA_IEC_START_ANGLE_DEG = 180.0  # angular position of the first (smallest) sphere
+NEMA_IEC_BOX_HALF_X_MM = 100.0  # half-width of the surrounding box
+NEMA_IEC_BOX_HALF_Y_MM = 90.0  # half-height of the surrounding box
+NEMA_IEC_FOV_HALF_MM = 110.0  # physical half-extent mapped to the [-1, 1] grid
+
+
+def generate_nema_iec_phantom(
+    size: int,
+    activities: list[float] | None = None,
+    background: float = 0.25,
+    lung: float = 0.0,
+    normalize: bool = True,
+) -> torch.Tensor:
+    r"""
+    Generate a 2D NEMA IEC body phantom.
+
+    The NEMA IEC body phantom is a standard image-quality phantom commonly used
+    in PET and SPECT. It consists of six spheres of increasing diameter
+    (10, 13, 17, 22, 28 and 37 mm) arranged on a circle inside a uniform
+    background, with a central cold cylindrical "lung" insert. This function
+    returns the 2D transverse cross-section through the centre of the six
+    spheres, with the body approximated by a rectangular box.
+
+    The activity level of each sphere can be set individually via ``activities``.
+
+    .. note::
+
+        This is a synthetic phantom intended for demonstrations and testing of
+        reconstruction algorithms (e.g. with :class:`deepinv.physics.Tomography`),
+        not a physically accurate simulation of a PET/SPECT acquisition.
+
+    |sep|
+
+    :Example:
+
+    >>> import deepinv as dinv
+    >>> x = dinv.utils.phantoms.generate_nema_iec_phantom(64)
+    >>> x.shape
+    torch.Size([64, 64])
+
+    :param int size: size of the (square) phantom image.
+    :param list[float] activities: list of 6 activity levels, one per sphere ordered
+        by increasing diameter. Defaults to ``[1.0] * 6`` (all spheres equally active).
+    :param float background: activity level of the uniform background inside the box.
+    :param float lung: activity level of the central cold cylindrical insert.
+    :param bool normalize: if ``True``, the phantom is rescaled so that its maximum
+        value is 1.
+    :return: (:class:`torch.Tensor`) a phantom of shape ``(size, size)``.
+    """
+    n_spheres = len(NEMA_IEC_SPHERE_DIAMETERS_MM)
+    if activities is None:
+        activities = [1.0] * n_spheres
+    if len(activities) != n_spheres:
+        raise ValueError(
+            f"activities must have length {n_spheres}, got {len(activities)}."
+        )
+
+    scale = 1.0 / NEMA_IEC_FOV_HALF_MM
+    x, y = torch.meshgrid(
+        torch.linspace(-1, 1, size), torch.linspace(-1, 1, size), indexing="ij"
+    )
+
+    phantom = torch.zeros(size, size)
+
+    # body box filled with uniform background activity
+    box = (x.abs() <= NEMA_IEC_BOX_HALF_X_MM * scale) & (
+        y.abs() <= NEMA_IEC_BOX_HALF_Y_MM * scale
+    )
+    phantom[box] = background
+
+    # six spheres arranged on a circle, ordered by increasing diameter
+    ring_radius = NEMA_IEC_RING_RADIUS_MM * scale
+    for i, diameter in enumerate(NEMA_IEC_SPHERE_DIAMETERS_MM):
+        angle = np.deg2rad(NEMA_IEC_START_ANGLE_DEG + i * 360 / n_spheres)
+        x_0 = ring_radius * np.cos(angle)
+        y_0 = ring_radius * np.sin(angle)
+        radius = (diameter / 2) * scale
+        mask = ((x - x_0) ** 2 + (y - y_0) ** 2) <= radius**2
+        phantom[mask] = activities[i]
+
+    # central cold cylindrical "lung" insert
+    lung_mask = (x**2 + y**2) <= (NEMA_IEC_LUNG_RADIUS_MM * scale) ** 2
+    phantom[lung_mask] = lung
+
+    if normalize:
+        max_val = phantom.max()
+        if max_val > 0:
+            phantom = phantom / max_val
+
+    return phantom
+
+
+class NEMAIECPhantomDataset(Dataset):
+    r"""
+    Dataset for the NEMA IEC body phantom. The dataset has length 1.
+
+    See :func:`deepinv.utils.phantoms.generate_nema_iec_phantom` for details on
+    the phantom and its parameters.
+
+    :param int size: Size of the phantom (square) image.
+    :param int n_data: Number of phantoms to generate per sample.
+    :param list[float] activities: list of 6 sphere activity levels, ordered by
+        increasing diameter. Defaults to ``[1.0] * 6``.
+    :param float background: activity level of the uniform background.
+    :param float lung: activity level of the central cold insert.
+    :param bool normalize: if ``True``, rescale so that the maximum value is 1.
+    :param Callable transform: Transformation to apply to the output image.
+    :param bool use_dict_output: Whether to return output as dict with key "x" or a bare Tensor (default: ``False``).
+    """
+
+    def __init__(
+        self,
+        size: int = 128,
+        n_data: int = 1,
+        activities: list[float] | None = None,
+        background: float = 0.25,
+        lung: float = 0.0,
+        normalize: bool = True,
+        transform=None,
+        use_dict_output: bool = False,
+    ):
+        self.size = size
+        self.n_data = n_data
+        self.activities = activities
+        self.background = background
+        self.lung = lung
+        self.normalize = normalize
+        self.transform = transform
+        self.use_dict_output = use_dict_output
+
+        if not self.use_dict_output:
+            warn(
+                "The tuple format for dataset outputs is deprecated and will be removed in a future version."
+                "It is recommended to set `use_dict_output=True` for better readability and flexibility in returned outputs."
+                "The default is currently `False` for backward compatibility, but will be switched to `True` in a future version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        """
+        :return: A torch.Tensor of shape (n_data, size, size).
+        """
+        x = torch.stack(
+            [
+                generate_nema_iec_phantom(
+                    self.size,
+                    activities=self.activities,
+                    background=self.background,
+                    lung=self.lung,
+                    normalize=self.normalize,
+                )
+                for _ in range(self.n_data)
+            ]
+        )
+
+        if self.transform is not None:
+            x = self.transform(x)
+
+        return {"x": x} if self.use_dict_output else x

--- a/docs/source/api/deepinv.utils.rst
+++ b/docs/source/api/deepinv.utils.rst
@@ -123,6 +123,7 @@ Phantoms
 
     deepinv.utils.phantoms.generate_shepp_logan
     deepinv.utils.phantoms.generate_random_phantom
+    deepinv.utils.phantoms.generate_nema_iec_phantom
 
 
 .. autosummary::
@@ -132,6 +133,7 @@ Phantoms
 
     deepinv.utils.phantoms.SheppLoganDataset
     deepinv.utils.phantoms.RandomPhantomDataset
+    deepinv.utils.phantoms.NEMAIECPhantomDataset
 
 Tiling / Untiling (Patching and Unpatching)
 -------------------------------------------

--- a/docs/source/api/deepinv.utils.rst
+++ b/docs/source/api/deepinv.utils.rst
@@ -133,6 +133,7 @@ Phantoms
     deepinv.utils.phantoms.generate_shepp_logan
     deepinv.utils.phantoms.generate_random_phantom
     deepinv.utils.phantoms.generate_pet_phantom
+    deepinv.utils.phantoms.generate_nema_iec_phantom
 
 
 .. autosummary::
@@ -142,6 +143,7 @@ Phantoms
 
     deepinv.utils.phantoms.SheppLoganDataset
     deepinv.utils.phantoms.RandomPhantomDataset
+    deepinv.utils.phantoms.NEMAIECPhantomDataset
 
 Tiling / Untiling (Patching and Unpatching)
 -------------------------------------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,7 +8,7 @@ Current
 
 New Features
 ^^^^^^^^^^^^
-- Add the NEMA IEC body phantom :func:`deepinv.utils.phantoms.generate_nema_iec_phantom` and :class:`deepinv.utils.phantoms.NEMAIECPhantomDataset`, with per-sphere activity levels (:gh:`XXXX` by `Smriti Pradhan`_)
+- Add the NEMA IEC body phantom :func:`deepinv.utils.phantoms.generate_nema_iec_phantom` and :class:`deepinv.utils.phantoms.NEMAIECPhantomDataset`, with per-sphere activity levels (:gh:`1237` by `Smriti Pradhan`_)
 
 Changed
 ^^^^^^^

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Current
 
 New Features
 ^^^^^^^^^^^^
+- Add the NEMA IEC body phantom :func:`deepinv.utils.phantoms.generate_nema_iec_phantom` and :class:`deepinv.utils.phantoms.NEMAIECPhantomDataset`, with per-sphere activity levels (:gh:`XXXX` by `Smriti Pradhan`_)
 
 Changed
 ^^^^^^^
@@ -655,3 +656,4 @@ Changed
 .. _Baptiste Legouix: https://github.com/blegouix
 .. _Kaibo Tang: https://github.com/kvttt
 .. _Irène Waldspurger: https://github.com/IWalds
+.. _Smriti Pradhan: https://github.com/pradhansmriti

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Current
 
 New Features
 ^^^^^^^^^^^^
+- Add the NEMA IEC body phantom :func:`deepinv.utils.phantoms.generate_nema_iec_phantom` and :class:`deepinv.utils.phantoms.NEMAIECPhantomDataset`, with per-sphere activity levels (:gh:`XXXX` by `Smriti Pradhan`_)
 
 Changed
 ^^^^^^^
@@ -705,3 +706,4 @@ Changed
 .. _Irène Waldspurger: https://github.com/IWalds
 .. _Kushagra Shukla: https://github.com/Kushagra481
 .. _Sarra Amiri: https://github.com/amirisarra18-jpg
+.. _Smriti Pradhan: https://github.com/pradhansmriti

--- a/docs/source/user_guide/training/datasets.rst
+++ b/docs/source/user_guide/training/datasets.rst
@@ -62,6 +62,19 @@ We provide dataset classes for you to easily load in your own data:
    * - :class:`deepinv.datasets.RandomPatchSampler`
      - Dataset that randomly samples a patch from a larger nD image at each iteration, accepts a ground-truth directory or measurement directory. If both are provided, filenames and shapes must match for each pair.
 
+Phantom Datasets
+----------------
+
+Synthetic phantom datasets return `x` only, generated on the fly rather than loaded from disk.
+
+.. list-table:: Phantom Datasets Overview
+   :header-rows: 1
+
+   * - **Dataset**
+     - **Description**
+   * - :class:`deepinv.utils.phantoms.NEMAIECPhantomDataset`
+     - Single NEMA IEC body phantom (six spheres of increasing diameter on a ring, with a uniform background and a central cold "lung" insert), commonly used as an image-quality phantom in PET and SPECT. See :func:`deepinv.utils.phantoms.generate_nema_iec_phantom` for details.
+
 .. _generating-datasets:
 
 Generating Datasets


### PR DESCRIPTION
Adds feature for issue number #1179 

### Changes made

- `deepinv.utils.phantoms.generate_nema_iec_phantom(size, activities=None, background=0.25, lung=0.0, normalize=True)` — returns the 2D transverse cross-section: six spheres (10/13/17/22/28/37 mm) on a ring, a uniform background box, and a central cold "lung" insert.
- `deepinv.utils.phantoms.NEMAIECPhantomDataset` — a length-1 dataset wrapper mirroring `SheppLoganDataset`.
- Per-sphere **activity levels** are configurable via `activities` (a list of 6 values), per the issue request.

## Tests added
- Added `"nemaiec"` to the parametrized `test_phantom_datasets` (shape/format contract).
- Added `test_nema_iec_phantom_activities` (verifies all 6 activity levels render; invalid list length raises).

## Docs
- Added entries to `docs/source/api/deepinv.utils.rst` and a changelog line.



### Checks to be done before submitting your PR

- [] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
