### PR TITLE
Improve the robots.txt and sitemap files for SEO

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,9 +102,7 @@ html_copy_source = True
 # https://sphinx-sitemap.readthedocs.io/en/v2.5.0/advanced-configuration.html
 sitemap_url_scheme = "{link}"
 # Filter out /_modules/* paths from the sitemap so they are not attempted to be crawled
-sitemap_excludes = [
-    "_modules/*"
-]
+sitemap_excludes = ["_modules/*"]
 
 ####  userguide directive ###
 default_role = "code"  # default role for single backticks

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,8 +101,8 @@ html_copy_source = True
 # For more details, see:
 # https://sphinx-sitemap.readthedocs.io/en/v2.5.0/advanced-configuration.html
 sitemap_url_scheme = "{link}"
-# Filter out /_modules/* paths from the sitemap so they are not attempted to be crawled
-sitemap_excludes = ["_modules/*"]
+# Filter out irrelevant pages from the sitemap so they are not attempted to be crawled
+sitemap_excludes = ["_modules/*", "search.html", "genindex.html"]
 
 ####  userguide directive ###
 default_role = "code"  # default role for single backticks

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,7 @@ html_copy_source = True
 # https://sphinx-sitemap.readthedocs.io/en/v2.5.0/advanced-configuration.html
 sitemap_url_scheme = "{link}"
 # Filter out /_modules/* paths from the sitemap so they are not attempted to be crawled
-sitemap_excludes = ["_modules/*"]
+sitemap_excludes = ["*/_modules/*"]
 
 ####  userguide directive ###
 default_role = "code"  # default role for single backticks

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,7 @@ html_copy_source = True
 # https://sphinx-sitemap.readthedocs.io/en/v2.5.0/advanced-configuration.html
 sitemap_url_scheme = "{link}"
 # Filter out /_modules/* paths from the sitemap so they are not attempted to be crawled
-sitemap_excludes = ["*/_modules/*"]
+sitemap_excludes = ["_modules/*"]
 
 ####  userguide directive ###
 default_role = "code"  # default role for single backticks

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,6 +101,10 @@ html_copy_source = True
 # For more details, see:
 # https://sphinx-sitemap.readthedocs.io/en/v2.5.0/advanced-configuration.html
 sitemap_url_scheme = "{link}"
+# Filter out /_modules/* paths from the sitemap so they are not attempted to be crawled
+sitemap_excludes = [
+    "_modules/*"
+]
 
 ####  userguide directive ###
 default_role = "code"  # default role for single backticks

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,5 +1,8 @@
 # Adapted from https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt
 User-agent: *
 Allow: /
+Disallow: /_modules/
+Disallow: /_sources/
+Disallow: /_downloads/
 
 Sitemap: https://deepinv.org/sitemap.xml

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -4,5 +4,7 @@ Allow: /
 Disallow: /_modules/
 Disallow: /_sources/
 Disallow: /_downloads/
+Disallow: /search.html$
+Disallow: /genindex.html$
 
 Sitemap: https://deepinv.org/sitemap.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ doc = [
     "sphinx_copybutton",
     "sphinx_autoapi",
     "sphinx-design",
-    "sphinx_sitemap<2.7.0",
+    "sphinx_sitemap >= 2.6.0, != 2.7.0",
     "sphinxcontrib.bibtex",
     "nbformat",
 ]


### PR DESCRIPTION
Looking at the crawling logs from Google Search it seems that they're spending a lot of our crawling budget on irrelevant pages (source code pages, Jupyter notebooks, zip files). In this PR, I prevent those files from being crawled by updating the robots.txt file.

I also:
- Get rid of the irrelevant files listed in the sitemap for the sake of consistency.
- Filter out https://deepinv.org/genindex.html and https://deepinv.org/search.html as it doesn't make much sense to access them from a search engine
- Add a minimum version requirement for sphinx-sitemap. Note that v2.6.0 introduces the `sitemap_excludes` feature that I'm using in this PR and v2.7.0 breaks our workflow (see #559) so I end up using the constraint `>= 2.6.0, != 2.7.0"

**Checks**
- I checked that the targeted URLs are gone from the sitemap in the documentation build
- I checked that the robots.txt in the docs build is the same as the source one

**Remark**
- The current sitemap can be accessed at https://deepinv.org/sitemap.xml
- And the robots.txt file at https://deepinv.org/robots.txt