### PR TITLE
Hotfix pixi

### DIFF
--- a/.github/workflows/docs_cpu.yml
+++ b/.github/workflows/docs_cpu.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: latest
+          pixi-version: v0.70.2
           environments: docs-cpu doctest-cpu
 
       - name: Fetch base branch
@@ -54,7 +54,7 @@ jobs:
             -H "Authorization: Bearer $TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments")
-      
+
           echo "pr_comments<<EOF" >> $GITHUB_OUTPUT
           echo "$COMMENTS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: latest
+          pixi-version: v0.70.2
           post-cleanup: true
           pixi-bin-path: /local/jtachell/pixi/bin/pixi
           environments: docs doctest

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: latest
+          pixi-version: v0.70.2
           environments: full-cpu test-cpu
 
       - name: Restore .testmondata

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: latest
+          pixi-version: v0.70.2
           post-cleanup: true
           environments: full
           pixi-bin-path: /local/jtachell/pixi/bin/pixi
@@ -88,11 +88,11 @@ jobs:
             const pr = context.payload.inputs.pr_number;
             const result = "${{ job.status }}";
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
-      
+
             const body = result === "success"
               ? `✅ GPU tests passed\n\n🔗 [View run details](${runUrl})`
               : `❌ GPU tests failed\n\n🔗 [View run details](${runUrl})`;
-      
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -98,7 +98,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: latest
+          pixi-version: v0.70.2
           run-install: false  # we drive installation manually below
 
       # --- PyPI source: spin up a temporary project and pull from PyPI ---


### PR DESCRIPTION
Pixi just released a new version 2 hours ago which might have broke CI: 536d13d41900bc2e45adb829a34ae5279200bb63 passed 4 hours ago but 536d13d41900bc2e45adb829a34ae5279200bb63 pushed after the release failed

See:
https://github.com/prefix-dev/pixi/releases/tag/v0.71.0

In this PR I pin down the previous version until we figure out a better fix