### PR TITLE
Unpin pixi version

### DIFF
--- a/.github/workflows/docs_cpu.yml
+++ b/.github/workflows/docs_cpu.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: v0.70.2
+          pixi-version: latest
           environments: docs-cpu doctest-cpu
 
       - name: Fetch base branch

--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: v0.70.2
+          pixi-version: latest
           post-cleanup: true
           pixi-bin-path: /local/jtachell/pixi/bin/pixi
           environments: docs doctest

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: v0.70.2
+          pixi-version: latest
           environments: full-cpu test-cpu
 
       - name: Restore .testmondata

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -74,14 +74,14 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          echo "pixi install -e ${{ matrix.environment }} --locked"
+          set -x
           if ! pixi install -e ${{ matrix.environment }} --locked --manifest-path pyproject.toml --color always; then
             echo "pixi install with --locked option failed, run install without lock"
             pixi install -e ${{ matrix.environment }} --manifest-path pyproject.toml --color always
           fi
 
-          echo "pixi list -e ${{ matrix.environment }}"
           pixi list -e ${{ matrix.environment }} --manifest-path pyproject.toml --color always
+          set +x
 
       - name: Restore deepinv URL cache # shared across matrix environments
         uses: actions/cache/restore@v4

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -67,7 +67,6 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
-          environments: ${{ matrix.environment }}
           run-install: false  # we drive installation manually below
 
       # Install dependencies with pixi, using the restored lock if available. If the

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -52,12 +52,11 @@ jobs:
       # full re-run). Restored *before* Setup Pixi so the action installs from
       # this lock. Not restored on push to main: main solves fresh to track
       # latest deps (and re-runs the full suite anyway).
-      - name: Restore pixi.lock + .testmondata
+      - name: Restore .testmondata
         if: github.event_name == 'pull_request'
         uses: actions/cache/restore@v4
         with:
           path: |
-            pixi.lock
             .testmondata
           key: testmon-cpu-main-${{ matrix.environment }}-${{ matrix.os }}-${{ github.run_id }}
           restore-keys: |
@@ -83,12 +82,11 @@ jobs:
 
       # Save the freshly-solved lock + .testmondata as a single (atomic) cache
       # entry so PRs always restore a matching pair. Only on push to main.
-      - name: Save pixi.lock + .testmondata # only when pushed to main, not for PRs
+      - name: Save  .testmondata # only when pushed to main, not for PRs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
           path: |
-            pixi.lock
             .testmondata
           key: testmon-cpu-main-${{ matrix.environment }}-${{ matrix.os }}-${{ github.run_id }}
 

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -72,6 +72,7 @@ jobs:
       # Install dependencies with pixi, using the restored lock if available. If the
       # lock is unavailable or fails to solve, fall back to a fresh solve. 
       - name: Install dependencies
+        shell: bash
         run: |
           echo "pixi install -e ${{ matrix.environment }} --locked"
           if ! pixi install -e ${{ matrix.environment }} --locked --manifest-path pyproject.toml --color always; then

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -67,15 +67,17 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
-          environments: ${{ matrix.env_name }}
+          environments: ${{ matrix.environment }}
           run-install: false  # we drive installation manually below
 
+      # Install dependencies with pixi, using the restored lock if available. If the
+      # lock is unavailable or fails to solve, fall back to a fresh solve. 
       - name: Install dependencies
         run: |
           echo "pixi install -e ${{ matrix.environment }} --locked"
           if ! pixi install -e ${{ matrix.environment }} --locked --manifest-path pyproject.toml --color always; then
             echo "pixi install with --locked option failed, run install without lock"
-                pixi install -e ${{ matrix.environment }} --manifest-path pyproject.toml --color always
+            pixi install -e ${{ matrix.environment }} --manifest-path pyproject.toml --color always
           fi
 
           echo "pixi list -e ${{ matrix.environment }}"

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -52,11 +52,12 @@ jobs:
       # full re-run). Restored *before* Setup Pixi so the action installs from
       # this lock. Not restored on push to main: main solves fresh to track
       # latest deps (and re-runs the full suite anyway).
-      - name: Restore .testmondata
+      - name: Restore pixi.lock + .testmondata
         if: github.event_name == 'pull_request'
         uses: actions/cache/restore@v4
         with:
           path: |
+            pixi.lock
             .testmondata
           key: testmon-cpu-main-${{ matrix.environment }}-${{ matrix.os }}-${{ github.run_id }}
           restore-keys: |
@@ -66,7 +67,19 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
-          environments: full-cpu test-cpu
+          environments: ${{ matrix.env_name }}
+          run-install: false  # we drive installation manually below
+
+      - name: Install dependencies
+        run: |
+          echo "pixi install -e ${{ matrix.environment }} --locked"
+          if ! pixi install -e ${{ matrix.environment }} --locked --manifest-path pyproject.toml --color always; then
+            echo "pixi install with --locked option failed, run install without lock"
+                pixi install -e ${{ matrix.environment }} --manifest-path pyproject.toml --color always
+          fi
+
+          echo "pixi list -e ${{ matrix.environment }}"
+          pixi list -e ${{ matrix.environment }} --manifest-path pyproject.toml --color always
 
       - name: Restore deepinv URL cache # shared across matrix environments
         uses: actions/cache/restore@v4
@@ -82,11 +95,12 @@ jobs:
 
       # Save the freshly-solved lock + .testmondata as a single (atomic) cache
       # entry so PRs always restore a matching pair. Only on push to main.
-      - name: Save  .testmondata # only when pushed to main, not for PRs
+      - name: Save pixi.lock + .testmondata # only when pushed to main, not for PRs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
           path: |
+            pixi.lock
             .testmondata
           key: testmon-cpu-main-${{ matrix.environment }}-${{ matrix.os }}-${{ github.run_id }}
 

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           pixi-version: latest
           post-cleanup: true
-          environments: full
           pixi-bin-path: /local/jtachell/pixi/bin/pixi
           run-install: false  # we drive installation manually below
 

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -40,12 +40,13 @@ jobs:
       # testmon's environment fingerprint stable. Restored *before* Setup Pixi
       # so the action installs from this lock. Baseline runs (schedule / push
       # to main) restore nothing and solve fresh to track latest deps.
-      - name: Restore .testmondata
+      - name: Restore pixi.lock + .testmondata
         if: inputs.pr_number != ''
         uses: actions/cache/restore@v4
         id: restore-cache
         with:
           path: |
+            pixi.lock
             .testmondata
           key: testmon-gpu-main-${{ github.run_id }}
           restore-keys: |
@@ -58,7 +59,23 @@ jobs:
           post-cleanup: true
           environments: full
           pixi-bin-path: /local/jtachell/pixi/bin/pixi
+          run-install: false  # we drive installation manually below
 
+      # Install dependencies with pixi, using the restored lock if available. If the
+      # lock is unavailable or fails to solve, fall back to a fresh solve. 
+      - name: Install dependencies
+        run: |
+          echo "pixi install -e full --locked"
+          if ! pixi install -e full --locked --manifest-path pyproject.toml --color always; then
+            echo "pixi install with --locked option failed, run install without lock"
+            pixi install -e full --manifest-path pyproject.toml --color always
+          fi
+
+          echo "pixi list -e full"
+          pixi list -e full --manifest-path pyproject.toml --color always
+
+          pixi clean cache --yes
+            
       - name: Check import
         run: |
           pixi run -e full python -c "import deepinv"
@@ -84,11 +101,12 @@ jobs:
       # Save the freshly-solved lock + .testmondata as a single (atomic) matched
       # baseline pair. Only on main and only for baseline runs (not PR-dispatch),
       # so a PR's env/results never overwrite the main baseline.
-      - name: Save .testmondata
+      - name: Save pixi.lock + .testmondata
         uses: actions/cache/save@v4
         if: github.ref == 'refs/heads/main' && inputs.pr_number == '' # Only save baseline cache on main
         with:
           path: |
+            pixi.lock
             .testmondata
           key: testmon-gpu-main-${{ github.run_id }}
 

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -40,13 +40,12 @@ jobs:
       # testmon's environment fingerprint stable. Restored *before* Setup Pixi
       # so the action installs from this lock. Baseline runs (schedule / push
       # to main) restore nothing and solve fresh to track latest deps.
-      - name: Restore pixi.lock + .testmondata
+      - name: Restore .testmondata
         if: inputs.pr_number != ''
         uses: actions/cache/restore@v4
         id: restore-cache
         with:
           path: |
-            pixi.lock
             .testmondata
           key: testmon-gpu-main-${{ github.run_id }}
           restore-keys: |
@@ -85,12 +84,11 @@ jobs:
       # Save the freshly-solved lock + .testmondata as a single (atomic) matched
       # baseline pair. Only on main and only for baseline runs (not PR-dispatch),
       # so a PR's env/results never overwrite the main baseline.
-      - name: Save pixi.lock + .testmondata
+      - name: Save .testmondata
         uses: actions/cache/save@v4
         if: github.ref == 'refs/heads/main' && inputs.pr_number == '' # Only save baseline cache on main
         with:
           path: |
-            pixi.lock
             .testmondata
           key: testmon-gpu-main-${{ github.run_id }}
 

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: v0.70.2
+          pixi-version: latest
           post-cleanup: true
           environments: full
           pixi-bin-path: /local/jtachell/pixi/bin/pixi

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -64,17 +64,17 @@ jobs:
       # lock is unavailable or fails to solve, fall back to a fresh solve. 
       - name: Install dependencies
         run: |
-          echo "pixi install -e full --locked"
+          set -x
           if ! pixi install -e full --locked --manifest-path pyproject.toml --color always; then
             echo "pixi install with --locked option failed, run install without lock"
             pixi install -e full --manifest-path pyproject.toml --color always
           fi
 
-          echo "pixi list -e full"
           pixi list -e full --manifest-path pyproject.toml --color always
 
           pixi clean cache --yes
-            
+          set +x
+
       - name: Check import
         run: |
           pixi run -e full python -c "import deepinv"

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -98,7 +98,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.9.3
         with:
-          pixi-version: v0.70.2
+          pixi-version: latest
           run-install: false  # we drive installation manually below
 
       # --- PyPI source: spin up a temporary project and pull from PyPI ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ Homepage = "https://deepinv.org/"
 Source = "https://github.com/deepinv/deepinv"
 Tracker = "https://github.com/deepinv/deepinv/issues"
 
+# Define groups of optional pypi dependencies. Can be overridden with conda
+# dependencies below using [tool.pixi.feature.*.dependencies] sections.
 [project.optional-dependencies]
 test = [
     "pytest",
@@ -89,13 +91,16 @@ denoisers = [
     "scipy",
     "diffusers",
     "transformers",
-    "numba>=0.60.0",
+    "numba",
 ]
 
 # optional dependencies for advanced forward operators
+physics-gpu = [
+    "astra-toolbox"
+]
+
 physics = [
-    "astra-toolbox>=2.2.0,!=2.3.0; platform_system=='Linux'",
-    "spyrit>=3.0.0; platform_system=='Linux'",
+    "spyrit>=3.0.0",
     "torchkbnufft",
     "array_api_compat",
     "sigpy",
@@ -125,7 +130,12 @@ training = [
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]
-platforms = ["linux-64", "win-64"]
+platforms = [
+  "linux-64",
+  "win-64",
+  { name = "linux-64-cuda", platform = "linux-64", cuda = "12.0" },
+  { name = "win-64-cuda", platform = "win-64", cuda = "12.0" },
+]
 
 [tool.pixi.dependencies]
 python = "<3.13.0"
@@ -139,15 +149,18 @@ requests = "*"
 h5py = "*"
 natsort = "*"
 
-[tool.pixi.feature.gpu.system-requirements]
-cuda = "12.0"
+[tool.pixi.feature.cpu]
+platforms = ["linux-64", "win-64"]
+
+[tool.pixi.feature.cpu.dependencies]
+pytorch-cpu = "*"
+
+[tool.pixi.feature.gpu]
+platforms = ["linux-64-cuda", "win-64-cuda"]
 
 [tool.pixi.feature.gpu.dependencies]
 cuda-version = "*"
 pytorch-gpu = "*"
-
-[tool.pixi.feature.cpu.dependencies]
-pytorch-cpu = "*"
 
 [tool.pixi.feature.py312.dependencies]
 python = "3.12.*"
@@ -171,12 +184,13 @@ diffusers = "*"
 transformers = "*"
 # bm3d, bm4d, libcpab, ptwt are PyPI-only, stay in optional deps
 
-[tool.pixi.feature.physics.dependencies]
+[tool.pixi.feature.physics-gpu.dependencies]
 astra-toolbox = ">=2.2.0,!=2.3.0"
+
+[tool.pixi.feature.physics.dependencies]
 torchkbnufft = "*"
 array-api-compat = "*"
 sigpy = "*"
-# spyrit is PyPI-only, stays in optional deps
 
 [tool.pixi.feature.training.dependencies]
 wandb = "*"
@@ -189,7 +203,7 @@ deepinv = { path = ".", editable = true}
 # gpu environments
 default   = { features = ["gpu"], solve-group = "gpu" }
 test      = { features = ["gpu", "test"], solve-group = "gpu" }
-full      = { features = ["gpu", "doc", "test", "dataset", "denoisers", "physics", "training"], solve-group = "gpu" }
+full      = { features = ["gpu", "doc", "test", "dataset", "denoisers", "physics", "physics-gpu", "training"], solve-group = "gpu" }
 docs      = { features = ["gpu", "doc", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "gpu-docs" }
 doctest   = { features = ["gpu", "doc", "test", "dataset", "denoisers", "physics", "training", "py312"], solve-group = "gpu-docs" }
 # cpu environments (same as gpu but without the gpu dependencies)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ physics = [
 
 # optional dependencies for specific datasets
 dataset = [
-    "datasets",
+    "datasets>=3.5.0",
     "pandas",
     "pydicom",
     "mat73",
@@ -130,10 +130,7 @@ training = [
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]
-platforms = [
-  "linux-64",
-  "win-64"
-]
+platforms = ["linux-64", "win-64"]
 
 [tool.pixi.dependencies]
 python = "<3.13.0"
@@ -147,15 +144,20 @@ requests = "*"
 h5py = "*"
 natsort = "*"
 
-[tool.pixi.feature.cpu.dependencies]
-pytorch-cpu = "*"
+# Force the CPU environment to ignore CUDA-enabled platforms if they exist, .e.g linux-64-cuda-12-0
+[tool.pixi.feature.cpu]
+platforms = ["linux-64", "win-64"]
+
+[tool.pixi.feature.cpu.pypi-dependencies]
+torch = { version = "*", index = "https://download.pytorch.org/whl/cpu" }
+torchvision = { version = "*", index = "https://download.pytorch.org/whl/cpu" }
 
 [tool.pixi.feature.gpu.system-requirements]
 cuda = "12.0"
 
-[tool.pixi.feature.gpu.dependencies]
-cuda-version = "*"
-pytorch-gpu = "*"
+[tool.pixi.feature.gpu.pypi-dependencies]
+torch = { version = "*", index = "https://download.pytorch.org/whl/cu124" }
+torchvision = { version = "*", index = "https://download.pytorch.org/whl/cu124" }
 
 [tool.pixi.feature.py312.dependencies]
 python = "3.12.*"
@@ -179,13 +181,12 @@ diffusers = "*"
 transformers = "*"
 # bm3d, bm4d, libcpab, ptwt are PyPI-only, stay in optional deps
 
-[tool.pixi.feature.physics-gpu.dependencies]
-astra-toolbox = ">=2.2.0,!=2.3.0"
-
 [tool.pixi.feature.physics.dependencies]
+astra-toolbox = ">=2.2.0,!=2.3.0"
 torchkbnufft = "*"
 array-api-compat = "*"
 sigpy = "*"
+# spyrit is PyPI-only, stays in optional deps
 
 [tool.pixi.feature.training.dependencies]
 wandb = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ Homepage = "https://deepinv.org/"
 Source = "https://github.com/deepinv/deepinv"
 Tracker = "https://github.com/deepinv/deepinv/issues"
 
-# Define groups of optional pypi dependencies. Can be overridden with conda
-# dependencies below using [tool.pixi.feature.*.dependencies] sections.
+# Define groups of optional pypi dependencies. This is use by pip, uv, and pixi. 
+# It can be overridden with conda dependencies below using [tool.pixi.feature.*.dependencies] sections.
 [project.optional-dependencies]
 test = [
     "pytest",
@@ -134,7 +134,6 @@ platforms = ["linux-64", "win-64"]
 
 [tool.pixi.dependencies]
 python = "<3.13.0"
-torchvision = "*"
 numpy = "*"
 matplotlib = "*"
 tqdm = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,12 +91,12 @@ denoisers = [
     "scipy",
     "diffusers",
     "transformers",
-    "numba",
+    "numba>=0.60.0",
 ]
 
 # optional dependencies for advanced forward operators
 physics-gpu = [
-    "astra-toolbox"
+    "astra-toolbox>=2.2.0,!=2.3.0; platform_system=='Linux'"
 ]
 
 physics = [
@@ -132,9 +132,7 @@ training = [
 channels = ["conda-forge"]
 platforms = [
   "linux-64",
-  "win-64",
-  { name = "linux-64-cuda", platform = "linux-64", cuda = "12.0" },
-  { name = "win-64-cuda", platform = "win-64", cuda = "12.0" },
+  "win-64"
 ]
 
 [tool.pixi.dependencies]
@@ -149,14 +147,11 @@ requests = "*"
 h5py = "*"
 natsort = "*"
 
-[tool.pixi.feature.cpu]
-platforms = ["linux-64", "win-64"]
-
 [tool.pixi.feature.cpu.dependencies]
 pytorch-cpu = "*"
 
-[tool.pixi.feature.gpu]
-platforms = ["linux-64-cuda", "win-64-cuda"]
+[tool.pixi.feature.gpu.system-requirements]
+cuda = "12.0"
 
 [tool.pixi.feature.gpu.dependencies]
 cuda-version = "*"


### PR DESCRIPTION
I'm reverting the hotfix in #1243, which pinned the Pixi version due to a breaking update on Pixi's side:
- I'm adding a new dependency group: `physics-gpu` with only `astra-toolbox` in it for the moment.
- I'm also adding wheels specific to the cpu/gpu dependency group for `torchvision` (switching for pypi dependency instead of conda as it was easier to find the wheels)

The 0.71.1 pixi version seems to break some of the legacy `system-requirements`  syntax (https://github.com/prefix-dev/pixi/issues/6462). Specifically mentioning the supported platform for the `cpu` group seems to solve this problem, i.e.
```
[tool.pixi.feature.cpu]
platforms = ["linux-64", "win-64"]
```

I'm not using any of the new pixi syntax so it should be compatible with old pixi versions (works locally at least for me)

---

I'm also adding a fallback mechanism to a "not locked" pixi install in case a PR modifies `pyproject.toml` or if pixi can no longer resolve some environments. If `pixi install -e <env> --locked` fails it retries without `--locked` which automatically updates the lock file.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
