### PR TITLE
add srresnet to pretrained models user guide

### DIFF
--- a/docs/source/user_guide/reconstruction/pretrained-models.rst
+++ b/docs/source/user_guide/reconstruction/pretrained-models.rst
@@ -56,7 +56,7 @@ These models can be set-up in one line and perform inference in another line:
      - :ref:`Diffusion <diffusion>` w/ pretrained denoiser
      - General
      - Slow
-   * - :class:`SRResNet <deepinv.sampling.SRResNet>`
+   * - :class:`SRResNet <deepinv.models.SRResNet>`
      - Feedforward
      - :class:`Super-resolution <deepinv.physics.Downsampling>`
      - Fast

--- a/docs/source/user_guide/reconstruction/pretrained-models.rst
+++ b/docs/source/user_guide/reconstruction/pretrained-models.rst
@@ -56,6 +56,10 @@ These models can be set-up in one line and perform inference in another line:
      - :ref:`Diffusion <diffusion>` w/ pretrained denoiser
      - General
      - Slow
+   * - :class:`SRResNet <deepinv.sampling.SRResNet>`
+     - Feedforward
+     - :class:`Super-resolution <deepinv.physics.Downsampling>`
+     - Fast
    * - :ref:`Pretrained denoisers <pretrained-weights>`
      - Feedforward
      - Denoising


### PR DESCRIPTION
SRResNet was missing from pretrained models user guide section

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).
