### PR TITLE
Remove/defer torchvision imports

### DIFF
--- a/.github/workflows/import_time.yml
+++ b/.github/workflows/import_time.yml
@@ -60,10 +60,10 @@ jobs:
             uv sync $EXTRAS
           fi
 
-      - name: "Benchmark torch+torchvision"
+      - name: "Benchmark torch"
         run: |
           echo "Benchmarking torch..."
-          hyperfine --warmup 3 --show-output --export-json torch.json 'uv run python -c "import torch, torchvision"'
+          hyperfine --warmup 3 --show-output --export-json torch.json 'uv run python -c "import torch"'
 
       - name: "Benchmark PR"
         run: |

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -186,10 +186,10 @@ jobs:
       - name: Pre-install pytorch from conda-forge (git source)
         if: matrix.source == 'git'
         shell: bash -el {0}
-        # Install torch from conda-forge first so that the pip install
+        # Install torch/torchvision from conda-forge first so that the pip install
         # below finds them already satisfied and does not pull in a PyPI-built torch
         # that bundles conflicting native libraries (e.g. libprotobuf on macOS).
-        run: conda install -c conda-forge pytorch -y
+        run: conda install -c conda-forge pytorch torchvision -y
 
       - name: Install deepinv (core) from git
         if: matrix.source == 'git' && matrix.deps == 'core'

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -186,10 +186,10 @@ jobs:
       - name: Pre-install pytorch from conda-forge (git source)
         if: matrix.source == 'git'
         shell: bash -el {0}
-        # Install torch/torchvision from conda-forge first so that the pip install
+        # Install torch from conda-forge first so that the pip install
         # below finds them already satisfied and does not pull in a PyPI-built torch
         # that bundles conflicting native libraries (e.g. libprotobuf on macOS).
-        run: conda install -c conda-forge pytorch torchvision -y
+        run: conda install -c conda-forge pytorch -y
 
       - name: Install deepinv (core) from git
         if: matrix.source == 'git' && matrix.deps == 'core'

--- a/deepinv/__init__.py
+++ b/deepinv/__init__.py
@@ -1,6 +1,5 @@
 from .__about__ import *
 import torch
-import torchvision as _torchvision  # early loading
 
 __all__ = [
     "__title__",

--- a/deepinv/datasets/base.py
+++ b/deepinv/datasets/base.py
@@ -7,7 +7,6 @@ from numpy import ndarray
 import torch
 from torch.utils.data import Dataset
 from torch import Tensor
-from torchvision.datasets.folder import IMG_EXTENSIONS
 from PIL import Image
 from PIL.Image import Image as PIL_Image
 from deepinv.utils.tensorlist import TensorList
@@ -325,6 +324,8 @@ class ImageFolder(ImageDataset):
 
     """
 
+    IMG_EXTENSIONS = (".jpg", ".jpeg", ".png", ".ppm", ".bmp", ".pgm", ".tif", ".tiff", ".webp")
+
     def __init__(
         self,
         root: str | Path,
@@ -354,7 +355,7 @@ class ImageFolder(ImageDataset):
             raise ValueError("Mismatch in number of GT and LR images.")
         elif self.x_paths is None and self.y_paths is None:
             self.x_paths = sum(
-                (list(self.root.glob(f"**/*{ext}")) for ext in IMG_EXTENSIONS), []
+                (list(self.root.glob(f"**/*{ext}")) for ext in self.IMG_EXTENSIONS), []
             )
 
         if transform is None:

--- a/deepinv/datasets/base.py
+++ b/deepinv/datasets/base.py
@@ -324,7 +324,17 @@ class ImageFolder(ImageDataset):
 
     """
 
-    IMG_EXTENSIONS = (".jpg", ".jpeg", ".png", ".ppm", ".bmp", ".pgm", ".tif", ".tiff", ".webp")
+    IMG_EXTENSIONS = (
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".ppm",
+        ".bmp",
+        ".pgm",
+        ".tif",
+        ".tiff",
+        ".webp",
+    )
 
     def __init__(
         self,

--- a/deepinv/datasets/base.py
+++ b/deepinv/datasets/base.py
@@ -7,8 +7,6 @@ from numpy import ndarray
 import torch
 from torch.utils.data import Dataset
 from torch import Tensor
-from PIL import Image
-from PIL.Image import Image as PIL_Image
 from deepinv.utils.tensorlist import TensorList
 from natsort import natsorted
 
@@ -27,6 +25,8 @@ def check_dataset(dataset: Dataset, allow_non_tensor=True) -> None:
     :param bool allow_non_tensor: allow image types that are not tensors (i.e. numpy ndarrays and PIL Images). Default `False`, which
         is recommended so that the dataset is asserted to return tensors to be compatible with deepinv.
     """
+
+    from PIL.Image import Image as PIL_Image
 
     image_types = CORE_TYPES + ((PIL_Image, ndarray, float) if allow_non_tensor else ())
 
@@ -380,6 +380,9 @@ class ImageFolder(ImageDataset):
             self.transform_x = self.transform_y = transform
 
         self.estimate_params = estimate_params
+
+        from PIL import Image
+
         self.loader = (
             loader if loader is not None else lambda fn: Image.open(fn).convert("RGB")
         )

--- a/deepinv/datasets/bsds500.py
+++ b/deepinv/datasets/bsds500.py
@@ -1,6 +1,5 @@
 import os
 import os.path
-from PIL import Image
 from pathlib import Path
 from deepinv.datasets.utils import calculate_md5, download_archive, extract_zipfile
 from deepinv.datasets.base import ImageDataset
@@ -98,6 +97,8 @@ class BSDS500(ImageDataset):
         return len(self.file_list)
 
     def __getitem__(self, idx):
+        from PIL import Image
+
         img = Image.open(self.file_list[idx]).convert("RGB")
         if self.rotate:
             width, height = img.size

--- a/deepinv/datasets/cbsd68.py
+++ b/deepinv/datasets/cbsd68.py
@@ -1,6 +1,5 @@
 from typing import Any, Callable
 import os
-from PIL import Image
 
 from deepinv.datasets.utils import calculate_md5
 from deepinv.datasets.base import ImageDataset
@@ -107,12 +106,13 @@ class CBSD68(ImageDataset):
         return len(self.hf_dataset)
 
     def __getitem__(self, idx: int) -> Any:
-        # PIL Image
         img = self.hf_dataset[idx]["png"]
 
         if self.rotate:
             width, height = img.size
             if width > height:
+                from PIL import Image
+
                 img = img.transpose(Image.ROTATE_90)
 
         if self.transform is not None:

--- a/deepinv/datasets/fastmri.py
+++ b/deepinv/datasets/fastmri.py
@@ -36,7 +36,6 @@ except ImportError:  # pragma: no cover
 
 from tqdm import tqdm
 import torch
-from torchvision.transforms import Compose, CenterCrop
 
 from deepinv.datasets.utils import ToComplex, Rescale, download_archive
 from deepinv.datasets.base import ImageDataset
@@ -130,6 +129,8 @@ class SimpleFastMRISliceDataset(ImageDataset):
                 raise FileNotFoundError(
                     "Local dataset not downloaded. Download by setting download=True."
                 )
+
+        from torchvision.transforms import Compose  # lazy import
 
         self.transform = Compose(
             [ToComplex()] + ([transform] if transform is not None else [])
@@ -527,6 +528,8 @@ class FastMRISliceDataset(ImageDataset, MRIMixin):
         :return: loaded SimpleFastMRISliceDataset
         :rtype: SimpleFastMRISliceDataset
         """
+        from torchvision.transforms import Compose, CenterCrop  # lazy import
+
         transform = [Rescale()]
         if pad_to_size is not None:
             transform += [CenterCrop(pad_to_size)]

--- a/deepinv/datasets/fastmri.py
+++ b/deepinv/datasets/fastmri.py
@@ -27,13 +27,6 @@ import pickle
 import warnings
 import os
 
-try:
-    import h5py
-except ImportError:  # pragma: no cover
-    h5py = ImportError(
-        "The h5py package is not installed. Please install it with `pip install h5py`."
-    )  # pragma: no cover
-
 from tqdm import tqdm
 import torch
 
@@ -357,9 +350,6 @@ class FastMRISliceDataset(ImageDataset, MRIMixin):
         self.metadata_cache_file = metadata_cache_file
         self.target_root = Path(target_root) if target_root is not None else None
 
-        if isinstance(h5py, ImportError):
-            raise h5py
-
         if not os.path.isdir(root):
             raise ValueError(
                 f"The `root` folder doesn't exist. Please set `root` properly. Current value `{root}`."
@@ -420,6 +410,8 @@ class FastMRISliceDataset(ImageDataset, MRIMixin):
         :param Union[str, pathlib.Path, os.PathLike] fname: filename to open
         :return: metadata dict of key-value pairs.
         """
+        import h5py
+
         with h5py.File(fname, "r") as hf:
             shape = hf["kspace"].shape
             metadata = (
@@ -459,6 +451,8 @@ class FastMRISliceDataset(ImageDataset, MRIMixin):
         Outputs may be modifed by transform if specified, in which case may also return params dict,
         containing optionally mask and coil maps.
         """
+        import h5py
+
         fname, slice_ind, metadata = self.samples[idx]
         params = {}
 

--- a/deepinv/datasets/fmd.py
+++ b/deepinv/datasets/fmd.py
@@ -4,7 +4,6 @@ import os
 import re
 
 from PIL import Image
-import requests
 
 from deepinv.datasets.utils import (
     download_archive,
@@ -172,6 +171,7 @@ class FMD(ImageDataset):
                 ## Which will be needed to download the archive ------------------------
 
                 # URL to fetch the initial HTML content
+                import requests # lazy import
                 url_initial = (
                     f"https://docs.google.com/uc?export=download&id={gdrive_id}"
                 )

--- a/deepinv/datasets/fmd.py
+++ b/deepinv/datasets/fmd.py
@@ -3,8 +3,6 @@ from types import MappingProxyType
 import os
 import re
 
-from PIL import Image
-
 from deepinv.datasets.utils import (
     download_archive,
     extract_tarball,
@@ -171,7 +169,8 @@ class FMD(ImageDataset):
                 ## Which will be needed to download the archive ------------------------
 
                 # URL to fetch the initial HTML content
-                import requests # lazy import
+                import requests  # lazy import
+
                 url_initial = (
                     f"https://docs.google.com/uc?export=download&id={gdrive_id}"
                 )
@@ -238,7 +237,9 @@ class FMD(ImageDataset):
             self.root, img_type, noise_dirname, str(fov), fname
         )
         clean_img_path = os.path.join(self.root, img_type, "gt", str(fov), "avg50.png")
-        # PIL Image
+
+        from PIL import Image
+
         noisy_img = Image.open(noisy_img_path)
         clean_img = Image.open(clean_img_path)
 

--- a/deepinv/datasets/kohler.py
+++ b/deepinv/datasets/kohler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import torch
-from torchvision.datasets.utils import download_and_extract_archive
 from PIL import Image
 
 from urllib.parse import urlparse
@@ -154,6 +153,8 @@ class Kohler(ImageDataset):
                 from deepinv.datasets import Kohler
                 Kohler.download("datasets/Kohler")
         """
+        from torchvision.datasets.utils import download_and_extract_archive
+
         root = resolve_root(root, "Kohler")
         for url in cls._archive_urls:
             archive_name = url_basename(url)

--- a/deepinv/datasets/kohler.py
+++ b/deepinv/datasets/kohler.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 import torch
-from PIL import Image
 
 from urllib.parse import urlparse
 from os.path import basename, join
-from typing import Callable
+from typing import Callable, TYPE_CHECKING
 from types import MappingProxyType
 from pathlib import Path
 
 from deepinv.datasets.base import ImageDataset
 from .utils import resolve_root
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 
 def url_basename(url: str) -> str:
@@ -260,6 +262,8 @@ class Kohler(ImageDataset):
     def get_sharp_frame(
         self, printout_index: int, trajectory_index: int, frame_index: int
     ) -> torch.Tensor | Image.Image | any:
+        from PIL import Image
+
         path = join(
             self.root,
             f"Image{printout_index}",
@@ -274,6 +278,8 @@ class Kohler(ImageDataset):
     def get_blurry_shot(
         self, printout_index: int, trajectory_index: int
     ) -> torch.Tensor | Image.Image | any:
+        from PIL import Image
+
         path = join(self.root, f"Blurry{printout_index}_{trajectory_index}.png")
         blurry_shot = Image.open(path)
         if self.transform is not None:

--- a/deepinv/datasets/satellite.py
+++ b/deepinv/datasets/satellite.py
@@ -8,8 +8,6 @@ from natsort import natsorted
 
 import numpy as np
 
-from torchvision.transforms import ToTensor, Compose
-
 from deepinv.datasets.utils import (
     download_archive,
     extract_zipfile,
@@ -131,6 +129,11 @@ class NBUDataset(ImageDataset):
         for _ms, _pan in self.image_paths:
             assert _ms.name == _pan.name, "MS and PAN filenames do not match."
 
+        # lazy import torchvision
+        from torchvision.transforms import Compose, ToTensor
+
+        self.compose, self.totensor = Compose, ToTensor()
+
     def check_dataset_exists(self):
         """Verify that the image folders exist and contain all the images.
 
@@ -161,12 +164,12 @@ class NBUDataset(ImageDataset):
         paths = self.image_paths[idx]
         ms, pan = load_mat(paths[0])["imgMS"], load_mat(paths[1])["imgPAN"]
 
-        transform_ms = Compose(
-            [self.normalize, ToTensor()]
+        transform_ms = self.compose(
+            [self.normalize, self.totensor]
             + ([self.transform_ms] if self.transform_ms is not None else [])
         )
-        transform_pan = Compose(
-            [self.normalize, ToTensor()]
+        transform_pan = self.compose(
+            [self.normalize, self.totensor]
             + ([self.transform_pan] if self.transform_pan is not None else [])
         )
 

--- a/deepinv/datasets/skmtea.py
+++ b/deepinv/datasets/skmtea.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from typing import Sequence, Callable
 from pathlib import Path
 from tqdm import tqdm
-import h5py
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -109,6 +108,8 @@ class SKMTEASliceDataset(FastMRISliceDataset, MRIMixin):
 
     @staticmethod
     def _retrieve_metadata(fname):
+        import h5py
+
         with h5py.File(fname, "r") as hf:
             shape = hf["kspace"].shape
             metadata = {
@@ -167,6 +168,8 @@ class SKMTEASliceDataset(FastMRISliceDataset, MRIMixin):
         * `maps`: `(N, H, W)` complex
 
         """
+        import h5py
+
         fname, slice_ind, metadata = self.samples[idx]
 
         with h5py.File(fname, "r") as f:

--- a/deepinv/datasets/utils.py
+++ b/deepinv/datasets/utils.py
@@ -9,10 +9,10 @@ from pathlib import Path
 
 import requests
 from tqdm.auto import tqdm
+from PIL import Image
 
 from torch import randn, Tensor, stack, zeros_like
 from torch.nn import Module
-from torchvision.transforms.functional import crop as torchvision_crop
 
 from deepinv.datasets.base import ImageDataset
 from deepinv.utils import normalize_signal, get_cache_home
@@ -215,5 +215,12 @@ class Crop(Module):
             else:
                 raise ValueError("size must be int or tuple of ints of size 2 or 4.")
 
-    def forward(self, x: Tensor):
-        return torchvision_crop(x, *self.size)
+    def forward(self, x: Tensor | Image.Image) -> Tensor | Image.Image:
+        top, left, height, width = self.size
+
+        if isinstance(x, Image.Image):    
+            return x.crop((left, top, left + width, top + height))
+        elif isinstance(x, Tensor):
+            return x[..., top:top + height, left:left + width]
+        else:
+            raise ValueError(f"Crop expected input type torch.Tensor or PIL.Image.Image, but got type {type(x)}.")

--- a/deepinv/datasets/utils.py
+++ b/deepinv/datasets/utils.py
@@ -224,3 +224,44 @@ class Crop(Module):
             return x[..., top:top + height, left:left + width]
         else:
             raise ValueError(f"Crop expected input type torch.Tensor or PIL.Image.Image, but got type {type(x)}.")
+        
+# TODO make Crop also allow padding (like original torchvision crop function) and then CenterCrop overrides it
+
+def center_crop(img: Tensor, output_size: List[int]) -> Tensor:
+    """Crops the given image at the center.
+    If the image is torch Tensor, it is expected
+    to have [..., H, W] shape, where ... means an arbitrary number of leading dimensions.
+    If image size is smaller than output size along any edge, image is padded with 0 and then center cropped.
+
+    Args:
+        img (PIL Image or Tensor): Image to be cropped.
+        output_size (sequence or int): (height, width) of the crop box. If int or sequence with single int,
+            it is used for both directions.
+
+    Returns:
+        PIL Image or Tensor: Cropped image.
+    """
+
+    if isinstance(output_size, numbers.Number):
+        output_size = (int(output_size), int(output_size))
+    elif isinstance(output_size, (tuple, list)) and len(output_size) == 1:
+        output_size = (output_size[0], output_size[0])
+
+    _, image_height, image_width = get_dimensions(img)
+    crop_height, crop_width = output_size
+
+    if crop_width > image_width or crop_height > image_height:
+        padding_ltrb = [
+            (crop_width - image_width) // 2 if crop_width > image_width else 0,
+            (crop_height - image_height) // 2 if crop_height > image_height else 0,
+            (crop_width - image_width + 1) // 2 if crop_width > image_width else 0,
+            (crop_height - image_height + 1) // 2 if crop_height > image_height else 0,
+        ]
+        img = pad(img, padding_ltrb, fill=0)  # PIL uses fill value 0
+        _, image_height, image_width = get_dimensions(img)
+        if crop_width == image_width and crop_height == image_height:
+            return img
+
+    crop_top = int(round((image_height - crop_height) / 2.0))
+    crop_left = int(round((image_width - crop_width) / 2.0))
+    return crop(img, crop_top, crop_left, crop_height, crop_width)

--- a/deepinv/datasets/utils.py
+++ b/deepinv/datasets/utils.py
@@ -8,7 +8,6 @@ import sys
 from pathlib import Path
 
 from tqdm.auto import tqdm
-from PIL import Image
 
 from torch import randn, Tensor, stack, zeros_like
 from torch.nn import Module
@@ -62,7 +61,7 @@ def download_archive(
     :param bool force_download: if ``True``, download the archive even if it already exists.
     :raises DownloadError: if the archive cannot be downloaded.
     """
-    import requests # lazy import
+    import requests  # lazy import
 
     save_path = Path(save_path)
     if not force_download and save_path.exists() and save_path.stat().st_size > 0:
@@ -216,7 +215,9 @@ class Crop(Module):
             else:
                 raise ValueError("size must be int or tuple of ints of size 2 or 4.")
 
-    def forward(self, x: Tensor | Image.Image) -> Tensor | Image.Image:
+    def forward(self, x: Tensor) -> Tensor:
+        from PIL import Image
+
         top, left, height, width = self.size
 
         if isinstance(x, Image.Image):

--- a/deepinv/datasets/utils.py
+++ b/deepinv/datasets/utils.py
@@ -7,7 +7,6 @@ import tarfile
 import sys
 from pathlib import Path
 
-import requests
 from tqdm.auto import tqdm
 from PIL import Image
 
@@ -63,6 +62,8 @@ def download_archive(
     :param bool force_download: if ``True``, download the archive even if it already exists.
     :raises DownloadError: if the archive cannot be downloaded.
     """
+    import requests # lazy import
+
     save_path = Path(save_path)
     if not force_download and save_path.exists() and save_path.stat().st_size > 0:
         print(f"File already downloaded: {save_path}. Skipping...", file=sys.stderr)
@@ -218,50 +219,11 @@ class Crop(Module):
     def forward(self, x: Tensor | Image.Image) -> Tensor | Image.Image:
         top, left, height, width = self.size
 
-        if isinstance(x, Image.Image):    
+        if isinstance(x, Image.Image):
             return x.crop((left, top, left + width, top + height))
         elif isinstance(x, Tensor):
-            return x[..., top:top + height, left:left + width]
+            return x[..., top : top + height, left : left + width]
         else:
-            raise ValueError(f"Crop expected input type torch.Tensor or PIL.Image.Image, but got type {type(x)}.")
-        
-# TODO make Crop also allow padding (like original torchvision crop function) and then CenterCrop overrides it
-
-def center_crop(img: Tensor, output_size: List[int]) -> Tensor:
-    """Crops the given image at the center.
-    If the image is torch Tensor, it is expected
-    to have [..., H, W] shape, where ... means an arbitrary number of leading dimensions.
-    If image size is smaller than output size along any edge, image is padded with 0 and then center cropped.
-
-    Args:
-        img (PIL Image or Tensor): Image to be cropped.
-        output_size (sequence or int): (height, width) of the crop box. If int or sequence with single int,
-            it is used for both directions.
-
-    Returns:
-        PIL Image or Tensor: Cropped image.
-    """
-
-    if isinstance(output_size, numbers.Number):
-        output_size = (int(output_size), int(output_size))
-    elif isinstance(output_size, (tuple, list)) and len(output_size) == 1:
-        output_size = (output_size[0], output_size[0])
-
-    _, image_height, image_width = get_dimensions(img)
-    crop_height, crop_width = output_size
-
-    if crop_width > image_width or crop_height > image_height:
-        padding_ltrb = [
-            (crop_width - image_width) // 2 if crop_width > image_width else 0,
-            (crop_height - image_height) // 2 if crop_height > image_height else 0,
-            (crop_width - image_width + 1) // 2 if crop_width > image_width else 0,
-            (crop_height - image_height + 1) // 2 if crop_height > image_height else 0,
-        ]
-        img = pad(img, padding_ltrb, fill=0)  # PIL uses fill value 0
-        _, image_height, image_width = get_dimensions(img)
-        if crop_width == image_width and crop_height == image_height:
-            return img
-
-    crop_top = int(round((image_height - crop_height) / 2.0))
-    crop_left = int(round((image_width - crop_width) / 2.0))
-    return crop(img, crop_top, crop_left, crop_height, crop_width)
+            raise ValueError(
+                f"Crop expected input type torch.Tensor or PIL.Image.Image, but got type {type(x)}."
+            )

--- a/deepinv/loss/adversarial/uair.py
+++ b/deepinv/loss/adversarial/uair.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 import torch.nn as nn
 from torch import Tensor
 from .base import GeneratorLoss
-from deepinv.physics import Physics
+
+if TYPE_CHECKING:
+    from deepinv.physics import Physics
 
 
 class UAIRGeneratorLoss(GeneratorLoss):

--- a/deepinv/loss/augmentation.py
+++ b/deepinv/loss/augmentation.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -7,10 +7,12 @@ from torch import Tensor
 
 from deepinv.loss.loss import Loss
 from deepinv.loss.metric.metric import Metric
-from deepinv.physics.mri import MRI
 from deepinv.transform.base import Transform, Identity
 from deepinv.transform.rotate import Rotate
 from deepinv.transform.shift import Shift
+
+if TYPE_CHECKING:
+    from deepinv.physics.mri import MRI
 
 
 class AugmentConsistencyLoss(Loss):

--- a/deepinv/loss/es.py
+++ b/deepinv/loss/es.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 import deepinv as dinv
 
 from deepinv.loss.loss import Loss
 from deepinv.loss.measplit import SplittingLoss
-from deepinv.physics.generator.base import PhysicsGenerator
 from deepinv.transform.base import Transform
 
 import torch
 
 import weakref
 import warnings
+
+if TYPE_CHECKING:
+    from deepinv.physics.generator.base import PhysicsGenerator
 
 
 class EquivariantSplittingLoss(Loss):

--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 from warnings import warn
 import torch
-from deepinv.physics import Inpainting, Physics
 from deepinv.loss.loss import Loss
 from deepinv.loss.metric.metric import Metric
-from deepinv.physics.generator import BernoulliSplittingMaskGenerator
 from deepinv.models.base import Reconstructor
+
+if TYPE_CHECKING:
+    from deepinv.physics import Physics
+    from deepinv.physics.generator import BernoulliSplittingMaskGenerator
 
 
 class SplittingLoss(Loss):
@@ -125,6 +128,8 @@ class SplittingLoss(Loss):
         :param torch.Tensor y: input data of shape (B,C,...,H,W)
         :param deepinv.physics.Physics physics: physics to split, retaining its original noise model. If ``None``, only :math:`y` is split.
         """
+        from deepinv.physics import Inpainting
+
         if y.shape[-2:] != mask.shape[-2:]:
             raise ValueError(
                 f"y and mask must have same shape in last 2 dimensions, but y has {y.shape} and mask has {mask.shape}"
@@ -275,6 +280,8 @@ class SplittingLoss(Loss):
                 warn(
                     f"Mask generator not defined. Using new Bernoulli mask generator with shape {y.shape[-2:]}."
                 )
+                from deepinv.physics.generator import BernoulliSplittingMaskGenerator
+
                 self.mask_generator = BernoulliSplittingMaskGenerator(
                     img_size=(
                         y.shape[1],

--- a/deepinv/loss/metric/distortion.py
+++ b/deepinv/loss/metric/distortion.py
@@ -13,8 +13,6 @@ from deepinv.loss.metric.functional import (
     signal_noise_ratio,
 )
 
-from deepinv.physics.functional import conv2d
-
 if TYPE_CHECKING:
     from deepinv.physics.remote_sensing import Pansharpen
     from deepinv.utils.tensorlist import TensorList
@@ -1043,6 +1041,10 @@ class GMSD(Metric):
         super().__init__(**kwargs)
         self.c = c
 
+        from deepinv.physics.functional import conv2d
+
+        self.conv2d = conv2d  # lazy import
+
     def _build_hx_hy(self, device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
         hx = torch.tensor(
             [[1 / 3, 0, -1 / 3], [1 / 3, 0, -1 / 3], [1 / 3, 0, -1 / 3]],
@@ -1076,12 +1078,12 @@ class GMSD(Metric):
         x_net_bc = x_net.reshape(B * C, 1, H, W)
 
         grad_mag_x = torch.hypot(
-            conv2d(x_bc, hx, padding="replicate"),
-            conv2d(x_bc, hy, padding="replicate"),
+            self.conv2d(x_bc, hx, padding="replicate"),
+            self.conv2d(x_bc, hy, padding="replicate"),
         )
         grad_mag_x_net = torch.hypot(
-            conv2d(x_net_bc, hx, padding="replicate"),
-            conv2d(x_net_bc, hy, padding="replicate"),
+            self.conv2d(x_net_bc, hx, padding="replicate"),
+            self.conv2d(x_net_bc, hy, padding="replicate"),
         )
 
         gms = (2 * grad_mag_x * grad_mag_x_net + self.c) / (

--- a/deepinv/loss/metric/perceptual.py
+++ b/deepinv/loss/metric/perceptual.py
@@ -5,8 +5,6 @@ import torch
 import torch.nn.functional as F
 
 from deepinv.loss.metric.metric import Metric
-from deepinv.physics.functional.convolution import conv2d
-from deepinv.physics.functional.imresize import imresize_matlab
 from deepinv.models.utils import load_state_dict_from_url, get_weights_url
 
 
@@ -199,6 +197,12 @@ class NIQE(Metric):
 
             self.cov_p = cov.to(dtype=dtype, device=device)
 
+        from deepinv.physics.functional.convolution import conv2d
+        from deepinv.physics.functional.imresize import imresize_matlab
+
+        self.conv2d = conv2d  # lazy import to break import chain
+        self.imresize_matlab = imresize_matlab
+
     def estimate_aggd_param(self, vecs: torch.Tensor, eps: float = 1e-12):
         v = vecs
         neg = v < 0
@@ -287,10 +291,10 @@ class NIQE(Metric):
         all_feats = []
 
         for scale in range(1, self.n_scales + 1):
-            mu = conv2d(x_net, kernel, "replicate")
+            mu = self.conv2d(x_net, kernel, "replicate")
             mu_sq = mu * mu
             sigma = torch.sqrt(
-                torch.abs(conv2d(x_net * x_net, kernel, "replicate") - mu_sq)
+                torch.abs(self.conv2d(x_net * x_net, kernel, "replicate") - mu_sq)
             )
             structdis = (x_net - mu) / (sigma + self.denominator)
             k = max(1, self.patch_size // scale)
@@ -301,7 +305,7 @@ class NIQE(Metric):
             all_feats.append(feats)
 
             if scale < self.n_scales:
-                x_net = imresize_matlab(
+                x_net = self.imresize_matlab(
                     x_net,
                     scale=0.5,
                     kernel="cubic",
@@ -483,11 +487,11 @@ class NIQE(Metric):
 
                 x_scale = x
                 for scale in range(1, self.n_scales + 1):
-                    mu = conv2d(x_scale, kernel, "replicate")
+                    mu = self.conv2d(x_scale, kernel, "replicate")
                     mu_sq = mu * mu
                     sigma = torch.sqrt(
                         torch.abs(
-                            conv2d(x_scale * x_scale, kernel, "replicate") - mu_sq
+                            self.conv2d(x_scale * x_scale, kernel, "replicate") - mu_sq
                         )
                     )
                     structdis = (x_scale - mu) / (sigma + self.denominator)
@@ -505,7 +509,7 @@ class NIQE(Metric):
                         sharpness = U.mean(dim=1).squeeze(0)  # (L,)
 
                     if scale < self.n_scales:
-                        x_scale = imresize_matlab(
+                        x_scale = self.imresize_matlab(
                             x_scale,
                             scale=0.5,
                             kernel="cubic",

--- a/deepinv/loss/metric/perceptual.py
+++ b/deepinv/loss/metric/perceptual.py
@@ -25,6 +25,9 @@ class LPIPS(Metric):
 
         By default, no reduction is performed in the batch dimension.
 
+    Note that `torchmetrics` is required to use this metric. `torchvision` is also required to download the pretrained weights. Install them with
+    `pip install torchvision torchmetrics`.
+
     :Example:
 
     ::

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 from warnings import warn
 import torch
-from deepinv.physics.forward import Physics
-from deepinv.physics.noise import GaussianNoise
+
 from deepinv.loss.metric.metric import Metric
-from deepinv.physics.generator import (
-    BaseMaskGenerator,
-    BernoulliSplittingMaskGenerator,
-    Phase2PhaseSplittingMaskGenerator,
-    Artifact2ArtifactSplittingMaskGenerator,
-)
 from deepinv.models.dynamic import TimeAveragingNet
 from deepinv.utils.mixins import TimeMixin
 from deepinv.models.base import Reconstructor
 from deepinv.loss.measplit import SplittingLoss
+
+if TYPE_CHECKING:
+    from deepinv.physics.noise import GaussianNoise
+    from deepinv.physics.forward import Physics
+    from deepinv.physics.generator import (
+        BaseMaskGenerator,
+        BernoulliSplittingMaskGenerator,
+    )
 
 
 class WeightedSplittingLoss(SplittingLoss):
@@ -230,6 +232,8 @@ class RobustSplittingLoss(WeightedSplittingLoss):
         metric: Metric | torch.nn.Module | None = None,
     ):
         if noise_model is None:
+            from deepinv.physics.noise import GaussianNoise
+
             noise_model = GaussianNoise(sigma=0.1)
         if metric is None:
             metric = torch.nn.MSELoss()
@@ -396,6 +400,9 @@ class Phase2PhaseLoss(SplittingLoss):
         self.dynamic_model = dynamic_model
         self.metric = metric
         self.device = device
+
+        from deepinv.physics.generator import Phase2PhaseSplittingMaskGenerator
+
         self.mask_generator = Phase2PhaseSplittingMaskGenerator(
             img_size=self.img_size, device=self.device
         )
@@ -585,6 +592,9 @@ class Artifact2ArtifactLoss(Phase2PhaseLoss):
             device=device,
         )
         self._name = "artifact2artifact"
+
+        from deepinv.physics.generator import Artifact2ArtifactSplittingMaskGenerator
+
         self.mask_generator = Artifact2ArtifactSplittingMaskGenerator(
             img_size=self.img_size, split_size=split_size, device=self.device
         )

--- a/deepinv/loss/mri/sure.py
+++ b/deepinv/loss/mri/sure.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 from torch import Tensor
 import torch
 
-from deepinv.physics.mri import MRI, MRIMixin
-from deepinv.physics.inpainting import Inpainting
 from deepinv.loss.sure import SureGaussianLoss, mc_div
 
 if TYPE_CHECKING:
@@ -85,6 +83,9 @@ class ENSURELoss(SureGaussianLoss):
     def forward(
         self, y: Tensor, x_net: Tensor, physics: Physics, model: Reconstructor, **kwargs
     ) -> Tensor:
+        from deepinv.physics.inpainting import Inpainting
+        from deepinv.physics.mri import MRI, MRIMixin
+
         if isinstance(physics, MRI):
             metric = lambda y: MRIMixin().kspace_to_im(y * self.dsqrti)
         elif isinstance(physics, Inpainting):

--- a/deepinv/loss/r2r.py
+++ b/deepinv/loss/r2r.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 import torch
 import math
 from deepinv.loss.loss import Loss
 from deepinv.loss.metric.metric import Metric
-from deepinv.physics.noise import NoiseModel, GaussianNoise, PoissonNoise, GammaNoise
+
+if TYPE_CHECKING:
+    from deepinv.physics.noise import NoiseModel
 
 
 class R2RLoss(Loss):
@@ -195,6 +198,8 @@ class R2RModel(torch.nn.Module):
         self.alpha = alpha
 
     def forward(self, y, physics, update_parameters=False):
+        from deepinv.physics.noise import NoiseModel
+
         if self.noise_model is None:
             if isinstance(physics.noise_model, NoiseModel):
                 self.curr_noise_model = physics.noise_model
@@ -227,6 +232,8 @@ class R2RModel(torch.nn.Module):
         return out
 
     def get_corruptor(self, y):
+        from deepinv.physics.noise import GaussianNoise, PoissonNoise, GammaNoise
+
         alpha = self.alpha
 
         if isinstance(self.curr_noise_model, GaussianNoise):

--- a/deepinv/loss/scheduler.py
+++ b/deepinv/loss/scheduler.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from torch import Generator, randint, Tensor, tensor
 from torch.nn import Module
 from deepinv.loss.loss import Loss
-from deepinv.physics.forward import Physics
+
+if TYPE_CHECKING:
+    from deepinv.physics.forward import Physics
 
 
 class BaseLossScheduler(Loss):

--- a/deepinv/loss/sup.py
+++ b/deepinv/loss/sup.py
@@ -6,7 +6,6 @@ from torch import Tensor
 from deepinv.loss.loss import Loss
 from deepinv.loss.metric.metric import Metric
 from deepinv.models.base import Reconstructor
-from deepinv.physics.forward import Physics
 
 if TYPE_CHECKING:
     from deepinv.physics.forward import Physics

--- a/deepinv/models/bm3d.py
+++ b/deepinv/models/bm3d.py
@@ -3,7 +3,6 @@ import torch
 from torch import Tensor
 from .base import Denoiser
 from .utils import array2tensor, tensor2array
-from deepinv.physics.functional import dct
 from deepinv.utils import image_to_patches
 
 
@@ -168,6 +167,8 @@ class BM3D(Denoiser):
     def _get_dct_matrix(
         self, n: int, norm: str = "ortho", device: torch.device | None = None
     ) -> tuple[Tensor, Tensor]:
+        from deepinv.physics.functional import dct  # lazy import at init
+
         matrix = dct(torch.eye(n, dtype=torch.float32, device=device), norm=norm).T
         inverse = matrix.T if norm == "ortho" else torch.linalg.inv(matrix)
         return matrix, inverse

--- a/deepinv/models/client.py
+++ b/deepinv/models/client.py
@@ -159,8 +159,9 @@ class Client(Reconstructor, Denoiser):
         self.endpoint = endpoint
         self.training = False
         self.return_metadata = return_metadata
-        
-        import requests # lazy import
+
+        import requests  # lazy import
+
         self.requests_post = requests.post
 
     @staticmethod

--- a/deepinv/models/client.py
+++ b/deepinv/models/client.py
@@ -1,4 +1,3 @@
-import requests
 import io
 import base64
 import json
@@ -160,6 +159,9 @@ class Client(Reconstructor, Denoiser):
         self.endpoint = endpoint
         self.training = False
         self.return_metadata = return_metadata
+        
+        import requests # lazy import
+        self.requests_post = requests.post
 
     @staticmethod
     def serialize(tensor: torch.Tensor) -> str:
@@ -248,7 +250,7 @@ class Client(Reconstructor, Denoiser):
         if self.api_key != "":
             headers |= {"Authorization": f"Bearer {self.api_key}"}
 
-        response = requests.post(
+        response = self.requests_post(
             self.endpoint, headers=headers, data=json.dumps(payload)
         )
         if response.status_code != 200:

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -5,11 +5,13 @@ import torch.nn.functional as F
 import torch.nn.utils.parametrize as P
 from torch import Tensor, nn
 
-from deepinv.physics import Denoising, LinearPhysics
 from deepinv.optim.linear import conjugate_gradient
 from .base import Reconstructor
 from .utils import load_state_dict_from_url
-from typing import Any, Callable
+from typing import Any, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deepinv.physics import LinearPhysics
 
 
 class DEAL(Reconstructor):
@@ -174,6 +176,11 @@ class DEAL(Reconstructor):
         # DeepInverse denoisers are commonly called as model(y, sigma).
         # In that case, the second positional argument arrives here as
         # `physics`, so we reinterpret scalar/tensor physics as sigma.
+        from deepinv.physics import (
+            Denoising,
+            LinearPhysics,
+        )  # lazy import to break import chain
+
         if (
             sigma is None
             and physics is not None

--- a/deepinv/models/dynamic.py
+++ b/deepinv/models/dynamic.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
 from torch import Tensor
 import torch.nn as nn
-from deepinv.physics import Physics
 from deepinv.models.base import Reconstructor
 from deepinv.utils.mixins import TimeMixin
+
+if TYPE_CHECKING:
+    from deepinv.physics import Physics
 
 
 class TimeAgnosticNet(Reconstructor, TimeMixin):

--- a/deepinv/models/epll.py
+++ b/deepinv/models/epll.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 import torch
 from deepinv.optim.epll import EPLL
-from deepinv.physics import Denoising, GaussianNoise
-from .base import Denoiser
+from deepinv.models.base import Denoiser
 from deepinv.optim.utils import GaussianMixtureModel
 
 
@@ -45,6 +44,9 @@ class EPLLDenoiser(Denoiser):
         self.PatchGMM = EPLL(
             GMM, n_components, pretrained, patch_size, channels, device
         )
+
+        from deepinv.physics import Denoising, GaussianNoise  # lazy import
+
         self.denoising_operator = Denoising(GaussianNoise(0))
 
     def forward(

--- a/deepinv/models/equivariant.py
+++ b/deepinv/models/equivariant.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from torch import Tensor
 from deepinv.transform import Transform, Rotate, Reflect
 from .base import Denoiser, Reconstructor
-from deepinv.physics.virtual import VirtualLinearPhysics
 import torch
 
 
@@ -141,6 +140,12 @@ class EquivariantReconstructor(Reconstructor):
         self.transform = transform
         self.eval_transform = eval_transform
 
+        from deepinv.physics.virtual import VirtualLinearPhysics
+
+        self.virtual_linear_physics = (
+            VirtualLinearPhysics  # lazy import to break import chains
+        )
+
     def forward(
         self, y: torch.Tensor, physics, *reconstructor_args, **reconstructor_kwargs
     ) -> torch.Tensor:
@@ -170,7 +175,7 @@ class EquivariantReconstructor(Reconstructor):
         # Compute the terms in the sum, i.e., T_g(R(y, AT_g)) for each g
         terms = []
         for g_params in transform.iterate_params(G_params):
-            ATg = VirtualLinearPhysics(
+            ATg = self.virtual_linear_physics(
                 physics=physics, transform=transform, g_params=g_params
             )
 

--- a/deepinv/models/gan.py
+++ b/deepinv/models/gan.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 import numpy as np
 from tqdm import tqdm
 
@@ -7,10 +8,11 @@ from torch import Tensor
 from torch import rand
 import torch
 from torch.optim import Adam
-from deepinv.physics import Physics
-from deepinv.loss import MCLoss
-from .base import Reconstructor
-from .utils import fix_dim, conv_nd, batchnorm_nd, conv_transpose_nd
+from deepinv.models.base import Reconstructor
+from deepinv.models.utils import fix_dim, conv_nd, batchnorm_nd, conv_transpose_nd
+
+if TYPE_CHECKING:
+    from deepinv.physics.forward import Physics
 
 
 class PatchGANDiscriminator(nn.Module):
@@ -326,6 +328,8 @@ class CSGMGenerator(Reconstructor):
         inf_lr: float = 1e-2,
         inf_progress_bar: bool = False,
     ):
+        from deepinv.loss.mc import MCLoss
+
         if backbone_generator is None:
             backbone_generator = DCGANGenerator()
         super().__init__()

--- a/deepinv/models/multispectral.py
+++ b/deepinv/models/multispectral.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
 import torch
 import torch.nn as nn
 
 from deepinv.utils.tensorlist import TensorList
-from deepinv.physics.forward import Physics
-from deepinv.physics.noise import PoissonNoise
-from deepinv.physics.blur import Downsampling, Blur
-from deepinv.physics.remote_sensing import Pansharpen
+
+if TYPE_CHECKING:
+    from deepinv.physics.forward import Physics
+    from deepinv.physics.remote_sensing import Pansharpen
 
 
 class ResNet(nn.Module):
@@ -94,6 +96,8 @@ class PanNet(nn.Module):
 
         self.upsampler = self.create_sampler("up", self.hrms_shape)
 
+        from deepinv.physics.blur import Blur
+
         self.boxblur = Blur(
             filter=torch.tensor(1.0 / highpass_kernel_size**2, device=device).expand(
                 1, 1, highpass_kernel_size, highpass_kernel_size
@@ -134,6 +138,9 @@ class PanNet(nn.Module):
         :param float noise_gain: noise applied to downsampling ONLY, defaults to 0.
         :return dinv.physics.Physics: deepinv sampler
         """
+        from deepinv.physics.noise import PoissonNoise
+        from deepinv.physics.blur import Downsampling
+
         sampler = Downsampling(
             img_size=hr_shape,
             factor=self.scale_factor,

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -8,7 +8,6 @@ import torch.nn as nn
 from torch import Tensor
 
 import deepinv as dinv
-from deepinv.physics import LinearPhysicsMultiScaler, PhysicsCropper
 from deepinv.utils.tensorlist import TensorList
 from deepinv.models.base import Reconstructor, Denoiser
 from .utils import load_state_dict_from_url
@@ -249,6 +248,10 @@ class RAM(Reconstructor, Denoiser):
         :param deepinv.physics.Physics physics: physics measurement operator
         :param torch.Tensor y: measurements
         """
+        from deepinv.physics import (
+            LinearPhysicsMultiScaler,
+        )  # lazy import to break import chain
+
         img_channels = x0.shape[1]
         physics = LinearPhysicsMultiScaler(physics, x0.shape[-3:], device=x0.device)
 
@@ -413,6 +416,8 @@ class RAM(Reconstructor, Denoiser):
 
         use_pad = False
         if any(p != 0 for p in pad):
+            from deepinv.physics import PhysicsCropper  # lazy import
+
             physics = PhysicsCropper(physics, pad, device=y.device)
             use_pad = True
 

--- a/deepinv/models/swinir.py
+++ b/deepinv/models/swinir.py
@@ -517,9 +517,10 @@ class BasicLayer(nn.Module):
             )
         else:
             self.downsample = None
-        
+
         from torch.utils.checkpoint import checkpoint as torch_checkpoint
-        self.torch_checkpoint = torch_checkpoint # lazy import
+
+        self.torch_checkpoint = torch_checkpoint  # lazy import
 
     def forward(self, x, x_size):
         for blk in self.blocks:

--- a/deepinv/models/swinir.py
+++ b/deepinv/models/swinir.py
@@ -9,7 +9,6 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.utils.checkpoint as checkpoint
 from .base import Denoiser
 from .utils import load_state_dict_from_url
 import warnings
@@ -518,11 +517,14 @@ class BasicLayer(nn.Module):
             )
         else:
             self.downsample = None
+        
+        from torch.utils.checkpoint import checkpoint as torch_checkpoint
+        self.torch_checkpoint = torch_checkpoint # lazy import
 
     def forward(self, x, x_size):
         for blk in self.blocks:
             if self.use_checkpoint:
-                x = checkpoint.checkpoint(blk, x, x_size)
+                x = self.torch_checkpoint(blk, x, x_size)
             else:
                 x = blk(x, x_size)
         if self.downsample is not None:

--- a/deepinv/models/third_party/promptir.py
+++ b/deepinv/models/third_party/promptir.py
@@ -6,7 +6,7 @@ See deepinv/models/third_party/LICENSE for license details.
 """
 
 from __future__ import annotations
-
+from typing import TYPE_CHECKING
 import warnings
 
 import torch
@@ -22,7 +22,8 @@ from deepinv.models.restormer import (
     OverlapPatchEmbed,
 )
 
-from deepinv.physics import Physics
+if TYPE_CHECKING:
+    from deepinv.physics import Physics
 
 
 class PromptGenBlock(nn.Module):

--- a/deepinv/models/varnet.py
+++ b/deepinv/models/varnet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from warnings import warn
+from typing import TYPE_CHECKING
 
 import torch
 from torch import Tensor
@@ -7,9 +8,11 @@ import torch.nn as nn
 
 from deepinv.models.base import Denoiser
 from deepinv.models.artifactremoval import ArtifactRemoval
-from deepinv.models import DnCNN
-from deepinv.physics.mri import MRI, MultiCoilMRI
+from deepinv.models.dncnn import DnCNN
 from deepinv.utils.mixins import MRIMixin
+
+if TYPE_CHECKING:
+    from deepinv.physics.mri import MRI, MultiCoilMRI
 
 
 class VarNet(ArtifactRemoval, MRIMixin):

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -15,7 +15,6 @@ from deepinv.optim.distance import (
 )
 
 from deepinv.optim.potential import Potential
-from deepinv.physics.functional import dct_2d, idct_2d
 
 if TYPE_CHECKING:
     from deepinv.physics import Physics, StackedPhysics
@@ -350,6 +349,10 @@ class ItohFidelity(L2):
         self.norm = 1 / (sigma**2)
         self.modulo_round = lambda x: x - threshold * torch.round(x / threshold)
 
+        from deepinv.physics.functional import dct_2d, idct_2d
+
+        self.dct_2d, self.idct_2d = dct_2d, idct_2d  # lazy import
+
     def fn(self, x: torch.Tensor, y: torch.Tensor, physics: Physics, *args, **kwargs):
         r"""
         Computes the data fidelity term :math:`\datafid{x}{y} = \distance{Dx}{w_{t}(Dy)}`.
@@ -539,14 +542,14 @@ class ItohFidelity(L2):
                 - (torch.cos(torch.pi * I / MX) + torch.cos(torch.pi * J / NX))
             )
 
-        dct_psi = dct_2d(psi, norm="ortho")
+        dct_psi = self.dct_2d(psi, norm="ortho")
 
         denom = denom.to(psi.device)
         denom[..., 0, 0] = 1  # avoid division by zero
 
         dct_phi = dct_psi / denom
 
-        phi = idct_2d(dct_phi, norm="ortho")
+        phi = self.idct_2d(dct_phi, norm="ortho")
 
         return phi
 

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -11,7 +11,6 @@ import torch.nn as nn
 from deepinv.physics.noise import NoiseModel, GaussianNoise, ZeroNoise
 from deepinv.utils.tensorlist import randn_like, TensorList
 from deepinv.optim.utils import least_squares, lsqr, least_squares_implicit_backward
-
 from deepinv.physics.functional import power_method
 import warnings
 

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -17,7 +17,6 @@ from deepinv.utils.tensorlist import TensorList
 from deepinv.datasets.base import check_dataset
 from deepinv.models.base import Reconstructor
 from torchvision.utils import save_image
-import torchvision.transforms.functional as TF
 import inspect
 
 
@@ -1141,8 +1140,9 @@ class Trainer:
 
             if self.mlflow_vis:
                 import mlflow
+                from torchvision.transforms.functional import to_pil_image
 
-                image = TF.to_pil_image(grid_image, mode="RGB")
+                image = to_pil_image(grid_image, mode="RGB")
                 mlflow.log_metrics({"step": epoch}, step=epoch)
                 mlflow.log_image(image, key=f"{post_str} samples", step=epoch)
 

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -16,7 +16,6 @@ from deepinv.utils.plotting import prepare_images
 from deepinv.utils.tensorlist import TensorList
 from deepinv.datasets.base import check_dataset
 from deepinv.models.base import Reconstructor
-from torchvision.utils import save_image
 import inspect
 
 
@@ -1147,6 +1146,8 @@ class Trainer:
                 mlflow.log_image(image, key=f"{post_str} samples", step=epoch)
 
         if save_images:
+            from torchvision.utils import save_image  # lazy import
+
             for k, img in enumerate(imgs):  # ground truths, reconstructions, etc.
                 img_name = f"{self.save_folder_im}/{titles[k]}/"
                 Path(img_name).mkdir(parents=True, exist_ok=True)

--- a/deepinv/transform/augmentation.py
+++ b/deepinv/transform/augmentation.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 
 import torch
 from torch import Tensor
 
 from deepinv.transform.base import Transform, TransformParam
 from deepinv.utils.mixins import MRIMixin
-from deepinv.physics.noise import GaussianNoise, NoiseModel
+
+if TYPE_CHECKING:
+    from deepinv.physics.noise import NoiseModel
 
 
 class RandomNoise(Transform):
@@ -33,7 +35,9 @@ class RandomNoise(Transform):
         super().__init__(*args, **kwargs)
         self.sigma = sigma
         if noise_type == "gaussian":
-            self.noise_class = GaussianNoise
+            from deepinv.physics.noise import GaussianNoise
+
+            self.noise_class = GaussianNoise  # lazy import
         else:
             raise ValueError(f"Noise type {noise_type} not supported.")
 

--- a/deepinv/transform/projective.py
+++ b/deepinv/transform/projective.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 from dataclasses import dataclass
 
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 
 import numpy as np
 import torch
-from PIL import Image
 
 from deepinv.transform.base import Transform, TransformParam
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 
 def rotation_matrix(tx: float, ty: float, tz: float) -> np.ndarray:
@@ -142,6 +144,8 @@ def apply_homography(
             padding_mode=padding,
         )
     else:
+        from PIL import Image
+
         if interpolation == "bilinear":
             pil_interp = Image.Resampling.BILINEAR
         elif interpolation == "bicubic":

--- a/deepinv/transform/rotate.py
+++ b/deepinv/transform/rotate.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 import torch
-from torchvision.transforms.functional import rotate
-from torchvision.transforms import InterpolationMode
 from deepinv.transform.base import Transform, TransformParam
 from warnings import warn
+
+if TYPE_CHECKING:
+    from torchvision.transforms import InterpolationMode
 
 
 class Rotate(Transform):
@@ -43,6 +44,9 @@ class Rotate(Transform):
         self.limits = limits
         self.multiples = multiples
         self.positive = positive
+
+        from torchvision.transforms import InterpolationMode
+
         if interpolation_mode is None:
             interpolation_mode = InterpolationMode.NEAREST
             if multiples % 90 != 0:
@@ -56,6 +60,10 @@ class Rotate(Transform):
             if isinstance(interpolation_mode, str)
             else interpolation_mode
         )
+
+        from torchvision.transforms.functional import rotate as torchvision_rotate
+
+        self.torchvision_rotate = torchvision_rotate  # lazy import
 
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate rotation parameters.
@@ -86,7 +94,7 @@ class Rotate(Transform):
         """
         return torch.cat(
             [
-                rotate(
+                self.torchvision_rotate(
                     x,
                     float(_theta),
                     interpolation=self.interpolation_mode,

--- a/deepinv/utils/__init__.py
+++ b/deepinv/utils/__init__.py
@@ -7,7 +7,6 @@ from .plotting import (
     plot_inset,
     plot_videos,
     save_videos,
-    make_grid,
     resize_pad_square_tensor,
     scatter_plot,
     plot_ortho3D,

--- a/deepinv/utils/demo.py
+++ b/deepinv/utils/demo.py
@@ -10,7 +10,6 @@ from PIL import Image
 
 import numpy as np
 import torch
-from torchvision import transforms
 from deepinv.utils.io import (
     DownloadError,
     get_cache_home,
@@ -205,21 +204,23 @@ def load_image(
     :param str device: Device on which to load the image (gpu or cpu).
     :return: :class:`torch.Tensor` containing the image with an added batch dimension.
     """
+    from torchvision.transforms import CenterCrop, Resize, Grayscale, ToTensor, Compose
+
     img = Image.open(path)
     transform_list = []
     if img_size is not None:
         if resize_mode == "crop":
-            transform_list.append(transforms.CenterCrop(img_size))
+            transform_list.append(CenterCrop(img_size))
         elif resize_mode == "resize":
-            transform_list.append(transforms.Resize(img_size))
+            transform_list.append(Resize(img_size))
         else:
             raise ValueError(
                 f"resize_mode must be either 'crop' or 'resize', got {resize_mode}"
             )
     if grayscale:
-        transform_list.append(transforms.Grayscale())
-    transform_list.append(transforms.ToTensor())
-    transform = transforms.Compose(transform_list)
+        transform_list.append(Grayscale())
+    transform_list.append(ToTensor())
+    transform = Compose(transform_list)
     x = transform(img).unsqueeze(0).to(device=device, dtype=dtype)
     return x
 

--- a/deepinv/utils/demo.py
+++ b/deepinv/utils/demo.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 from warnings import warn
 from typing import Callable, TYPE_CHECKING
-import os, shutil, zipfile, requests
+import os, shutil, zipfile
 from io import BytesIO
 
 from pathlib import Path
 from tqdm import tqdm
-from PIL import Image
 
 import numpy as np
 import torch
@@ -111,6 +110,8 @@ def load_dataset(
     dataset_dir = data_dir / dataset_name
 
     if download and not dataset_dir.exists():
+        import requests  # lazy import
+
         dataset_dir.mkdir(parents=True, exist_ok=True)
 
         if url is None:
@@ -167,6 +168,8 @@ def load_degradation(
     path = data_dir / name
 
     if download and not path.exists():
+        import requests  # lazy import
+
         data_dir.mkdir(parents=True, exist_ok=True)
         url = get_degradation_url(name)
         try:
@@ -205,6 +208,7 @@ def load_image(
     :return: :class:`torch.Tensor` containing the image with an added batch dimension.
     """
     from torchvision.transforms import CenterCrop, Resize, Grayscale, ToTensor, Compose
+    from PIL import Image
 
     img = Image.open(path)
     transform_list = []

--- a/deepinv/utils/io.py
+++ b/deepinv/utils/io.py
@@ -7,7 +7,6 @@ import os
 import numpy as np
 from numpy.lib.format import open_memmap
 import torch
-from deepinv.utils.mixins import MRIMixin
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -69,21 +68,24 @@ def get_cache_home() -> Path:
     path.mkdir(parents=True, exist_ok=True)
     return path
 
-import requests
-class DownloadError(requests.exceptions.RequestException):
-    r"""Raised when a network download initiated by deepinv fails.
 
-    Wraps any underlying network error (HTTP status, connection failure,
-    SSL error, DNS failure, timeout, …) so that callers — and the test
-    suite in particular — can detect download failures with a single
-    ``except DownloadError:`` rather than enumerating every exception
-    type that the network stack may raise. The original exception is
-    chained via ``__cause__``.
+class DownloadError(IOError):
+    r"""Raised when a deepinv download fails.
 
-    Inherits from :class:`requests.exceptions.RequestException` (and
-    transitively from `IOError`) so existing handlers that catch
-    those broader types keep working.
+    Lets callers catch any download failure with ``except DownloadError``.
+    The underlying error is chained via ``__cause__``.
+
+    Code copied from :class:`requests.exception.RequestException`.
     """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize DownloadError with `request` and `response` objects."""
+        response = kwargs.pop("response", None)
+        self.response = response
+        self.request = kwargs.pop("request", None)
+        if response is not None and not self.request and hasattr(response, "request"):
+            self.request = self.response.request
+        super().__init__(*args, **kwargs)
 
 
 def load_url(url: str, **kwargs) -> BytesIO:
@@ -110,7 +112,7 @@ def load_url(url: str, **kwargs) -> BytesIO:
     :return: `BytesIO` buffer.
     :raises deepinv.utils.DownloadError: if the file cannot be downloaded.
     """
-    import requests # lazy import
+    import requests  # lazy import
 
     cache_home = get_cache_home()
     cache_dir = cache_home / "url_cache"
@@ -241,6 +243,7 @@ def load_ismrmd(
         raise ImportError(
             "The h5py package is not installed. Please install it with `pip install h5py`."
         )
+    from deepinv.utils.mixins import MRIMixin
 
     with h5py.File(fname, "r") as hf:
         data = hf[data_name]
@@ -348,6 +351,8 @@ def load_raster(
         )  # Remove single-band dimension if exists
         if arr.ndim == 2:
             if arr.is_complex():
+                from deepinv.utils.mixins import MRIMixin
+
                 arr = MRIMixin.from_torch_complex(arr.unsqueeze(0)).squeeze(
                     0
                 )  # (2, H, W)

--- a/deepinv/utils/io.py
+++ b/deepinv/utils/io.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from warnings import warn
 from io import BytesIO
 import os
-import requests
 import numpy as np
 from numpy.lib.format import open_memmap
 import torch
@@ -70,7 +69,7 @@ def get_cache_home() -> Path:
     path.mkdir(parents=True, exist_ok=True)
     return path
 
-
+import requests
 class DownloadError(requests.exceptions.RequestException):
     r"""Raised when a network download initiated by deepinv fails.
 
@@ -111,6 +110,8 @@ def load_url(url: str, **kwargs) -> BytesIO:
     :return: `BytesIO` buffer.
     :raises deepinv.utils.DownloadError: if the file cannot be downloaded.
     """
+    import requests # lazy import
+
     cache_home = get_cache_home()
     cache_dir = cache_home / "url_cache"
     cache_path = _get_url_cache_path(url, cache_dir)

--- a/deepinv/utils/mixins.py
+++ b/deepinv/utils/mixins.py
@@ -5,7 +5,6 @@ import numpy as np
 import torch
 from torch import Tensor, zeros_like
 from torch.nn import Module
-from torchvision.transforms import CenterCrop, Resize
 from deepinv.utils.decorators import _deprecated_argument
 from ._tiling import (
     _compute_compatible_img_size,
@@ -224,6 +223,8 @@ class MRIMixin:
         :param bool rescale: whether to rescale instead of cropping. If `True`, `crop` must be `False`.
             Note to be careful here as resizing will change aspect ratio.
         """
+        from torchvision.transforms import CenterCrop, Resize
+
         crop_size = shape[-2:] if shape is not None else self.img_size[-2:]
         odd_h = crop_size[0] % 2 == 1
 

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -10,8 +10,6 @@ from warnings import warn
 import torch
 import numpy as np
 
-from PIL import Image
-
 from deepinv.utils.signals import normalize_signal, complex_abs
 
 _DEFAULT_PLOT_FONTSIZE = 17
@@ -1070,6 +1068,7 @@ def save_videos(
     :param \*\*plot_kwargs: kwargs to pass to :func:`deepinv.utils.plot`
     """
     import matplotlib.pyplot as plt
+    from PIL import Image
 
     if isinstance(vid_list, torch.Tensor):
         vid_list = [vid_list]

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -9,9 +9,6 @@ from warnings import warn
 
 import torch
 import numpy as np
-from torchvision.utils import make_grid
-import torchvision.transforms as T
-import torchvision.transforms.functional as F
 
 from PIL import Image
 
@@ -102,10 +99,15 @@ def resize_pad_square_tensor(tensor, size):
     r"""
     Resize a tensor BxCxWxH to a square tensor BxCxsizexsize with the same aspect ratio thanks to zero-padding.
 
+    Uses torchvision transforms.
+
     :param torch.Tensor tensor: the tensor to resize.
     :param int size: the new size.
     :return torch.Tensor: the resized tensor.
     """
+
+    from torchvision.transforms import Compose, ToPILImage, Resize, ToTensor
+    from torchvision.transforms.functional import pad as torchvision_pad
 
     class SquarePad:
         def __call__(self, image):
@@ -114,9 +116,9 @@ def resize_pad_square_tensor(tensor, size):
             hp = int((max_wh - W) / 2)
             vp = int((max_wh - H) / 2)
             padding = (hp, vp, hp, vp)
-            return F.pad(image, padding, fill=0, padding_mode="constant")
+            return torchvision_pad(image, padding, fill=0, padding_mode="constant")
 
-    transform = T.Compose([T.ToPILImage(), SquarePad(), T.Resize(size), T.ToTensor()])
+    transform = Compose([ToPILImage(), SquarePad(), Resize(size), ToTensor()])
     return torch.stack([transform(el) for el in tensor])
 
 
@@ -139,7 +141,7 @@ def prepare_images(x=None, y=None, x_net=None, x_nl=None, rescale_mode="min_max"
     r"""
     Prepare the images for plotting.
 
-    It prepares the images for plotting by rescaling them and concatenating them in a grid.
+    It prepares the images for plotting by rescaling them and concatenating them in a grid (using torchvision).
 
     :param torch.Tensor x: Ground truth.
     :param torch.Tensor y: Measurement.
@@ -147,6 +149,8 @@ def prepare_images(x=None, y=None, x_net=None, x_nl=None, rescale_mode="min_max"
     :param torch.Tensor x_nl: No-learning reconstruction.
     :returns: The images, the titles, the grid image, and the caption.
     """
+    from torchvision.utils import make_grid
+
     with torch.no_grad():
         imgs = []
         titles = []

--- a/examples/physics/demo_spatial_unwrapping.py
+++ b/examples/physics/demo_spatial_unwrapping.py
@@ -21,7 +21,7 @@ The goal is to recover :math:`x` from the observed wrapped image :math:`y`.
 # -------------------------------------------------------
 import torch
 import deepinv as dinv
-import torchvision.transforms as transforms
+from torchvision import transforms
 import matplotlib.pyplot as plt
 from deepinv.optim import ADMM
 from deepinv.utils import load_example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "matplotlib",
     "tqdm",
     "torch>=2.2.0",
-    "torchvision",
     "torchmetrics",
     "einops",
     "requests",
@@ -129,7 +128,6 @@ platforms = ["linux-64", "win-64"]
 
 [tool.pixi.dependencies]
 python = "<3.13.0"
-torchvision = "*"
 numpy = "*"
 matplotlib = "*"
 tqdm = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "tqdm",
     "torch>=2.2.0",
     "torchmetrics",
+    "torchvision",
     "einops",
     "requests",
     "h5py",
@@ -128,6 +129,7 @@ platforms = ["linux-64", "win-64"]
 
 [tool.pixi.dependencies]
 python = "<3.13.0"
+torchvision = "*"
 numpy = "*"
 matplotlib = "*"
 tqdm = "*"


### PR DESCRIPTION
Closes #936 . See that issue for motivation

This removes all top-level eager torchvision imports from the main library. Now, import deepinv does not import torchvision eagerly anymore.

All torchvision imports in examples and tests are unchanged.

This PR also breaks some long import chains by forcing lazy imports of some external libs like PIL, h5py as well as lazy imports of physics inside models etc.

NOTE for future reference: removing torchvision altogether is also an option, in order to reduce the install dependencies, and remove some layers of abstraction. However, this is out of scope.

TLDR: import time cut in half, with minimal overhead on top of torch!

<img width="3159" height="3716" alt="image" src="https://github.com/user-attachments/assets/131c3418-04eb-449c-9b44-e73b9cf96c07" />


cc @nucli-vicky 

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).