### PR TITLE
Fix coverage not uploaded to codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,17 @@
 # Coverage configuration from https://gist.github.com/doaa-altarawy/9e324f2486e53d38de817e0e38e58175
 # ----------------------
+
+# Compute coverage for the the CPU and GPU tests separately
+flags:
+  full-cpu:
+    paths:
+      - deepinv/
+    carryforward: true # For iterative testing with testmon: https://docs.codecov.com/docs/carryforward-flags
+  full:
+    paths:
+      - deepinv/
+    carryforward: true 
+
 coverage:
   status:
     patch: false

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -114,7 +114,7 @@ jobs:
           key: deepinv-url-cache-${{ matrix.os }}-${{ github.run_id }}
 
       - name: Upload coverage to Codecov
-        if: runner.os == 'Linux' && matrix.environment == 'full'
+        if: runner.os == 'Linux' && matrix.environment == 'full-cpu'
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -96,6 +96,7 @@ jobs:
       # (pytest-cov does not take into account skipped tests by testmon)
       # If .coverage exists, testmon skips the non-related tests and --cov-append updates coverage with respect to related changes.
       - name: Test with pytest
+        shell: bash
         run: |
           TESTMON_FLAG=""
           if [ -f .coverage ]; then

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # On PRs, restore the pixi.lock + .testmondata pair solved on main as a
+      # On PRs, restore the pixi.lock + .testmondata + .coverage triple solved on main as a
       # SINGLE cache entry, so it is restored atomically (no lock/testmondata
       # mismatch). pixi then installs the exact same package set that produced
       # .testmondata, keeping testmon's environment fingerprint stable
@@ -102,9 +102,9 @@ jobs:
           if [ -f .coverage ]; then
             TESTMON_FLAG="--testmon"
           fi
-          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml --cov-append $TESTMON_FLAG
+          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append $TESTMON_FLAG
 
-      # Save the freshly-solved lock + .testmondata as a single (atomic) cache
+      # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) cache
       # entry so PRs always restore a matching pair. Only on push to main.
       - name: Save pixi.lock + .testmondata + .coverage # only when pushed to main, not for PRs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -129,4 +129,6 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
+          files: ./coverage-${{ matrix.environment }}.xml
+          flags: ${{ matrix.environment }}
+          name: ${{ matrix.environment }}-coverage

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -52,13 +52,14 @@ jobs:
       # full re-run). Restored *before* Setup Pixi so the action installs from
       # this lock. Not restored on push to main: main solves fresh to track
       # latest deps (and re-runs the full suite anyway).
-      - name: Restore pixi.lock + .testmondata
+      - name: Restore pixi.lock + .testmondata + .coverage
         if: github.event_name == 'pull_request'
         uses: actions/cache/restore@v4
         with:
           path: |
             pixi.lock
             .testmondata
+            .coverage
           key: testmon-cpu-main-${{ matrix.environment }}-${{ matrix.os }}-${{ github.run_id }}
           restore-keys: |
             testmon-cpu-main-${{ matrix.environment }}-${{ matrix.os }}-
@@ -91,19 +92,27 @@ jobs:
           restore-keys: |
             deepinv-url-cache-${{ matrix.os }}-
 
+      # If no .coverage is cached, run pytest without testmon to compute full coverage results
+      # (pytest-cov does not take into account skipped tests by testmon)
+      # If .coverage exists, testmon skips the non-related tests and --cov-append updates coverage with respect to related changes.
       - name: Test with pytest
         run: |
-          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml --testmon
+          TESTMON_FLAG=""
+          if [ -f .coverage ]; then
+            TESTMON_FLAG="--testmon"
+          fi
+          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml --cov-append $TESTMON_FLAG
 
       # Save the freshly-solved lock + .testmondata as a single (atomic) cache
       # entry so PRs always restore a matching pair. Only on push to main.
-      - name: Save pixi.lock + .testmondata # only when pushed to main, not for PRs
+      - name: Save pixi.lock + .testmondata + .coverage # only when pushed to main, not for PRs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v4
         with:
           path: |
             pixi.lock
             .testmondata
+            .coverage
           key: testmon-cpu-main-${{ matrix.environment }}-${{ matrix.os }}-${{ github.run_id }}
 
       - name: Save deepinv URL cache # only on push to main, mirrors testmondata

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -34,13 +34,13 @@ jobs:
                   || (inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number))
                   || github.sha }}
 
-      # When testing a PR, restore the pixi.lock + .testmondata pair solved on
+      # When testing a PR, restore the pixi.lock + .testmondata + .coverage triple solved on
       # main as a SINGLE cache entry (atomic, no lock/testmondata mismatch) so
       # pixi installs the exact package set that produced .testmondata, keeping
       # testmon's environment fingerprint stable. Restored *before* Setup Pixi
       # so the action installs from this lock. Baseline runs (schedule / push
       # to main) restore nothing and solve fresh to track latest deps.
-      - name: Restore pixi.lock + .testmondata
+      - name: Restore pixi.lock + .testmondata + .coverage
         if: inputs.pr_number != ''
         uses: actions/cache/restore@v4
         id: restore-cache
@@ -48,6 +48,7 @@ jobs:
           path: |
             pixi.lock
             .testmondata
+            .coverage
           key: testmon-gpu-main-${{ github.run_id }}
           restore-keys: |
             testmon-gpu-main-
@@ -94,19 +95,25 @@ jobs:
           "
 
       - name: Test with pytest
+        shell: bash
         run: |
-          pixi run -e full pytest -n 2 --dist=loadgroup --testmon
+          TESTMON_FLAG=""
+          if [ -f .coverage ]; then
+            TESTMON_FLAG="--testmon"
+          fi
+          pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append $TESTMON_FLAG
 
-      # Save the freshly-solved lock + .testmondata as a single (atomic) matched
+      # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) matched
       # baseline pair. Only on main and only for baseline runs (not PR-dispatch),
       # so a PR's env/results never overwrite the main baseline.
-      - name: Save pixi.lock + .testmondata
+      - name: Save pixi.lock + .testmondata + .coverage
         uses: actions/cache/save@v4
         if: github.ref == 'refs/heads/main' && inputs.pr_number == '' # Only save baseline cache on main
         with:
           path: |
             pixi.lock
             .testmondata
+            .coverage
           key: testmon-gpu-main-${{ github.run_id }}
 
       - name: Post result to PR
@@ -128,6 +135,15 @@ jobs:
               issue_number: pr,
               body,
             });
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-full.xml
+          flags: full
+          name: full-coverage
 
       - name: Cleanup Pixi
         if: always()


### PR DESCRIPTION
Small fix to `test_cpu.yml`to bring back codecoverage upload.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.