### PR TITLE
Move from uv to pixi for import time benchmark

### DIFF
--- a/.github/workflows/import_time.yml
+++ b/.github/workflows/import_time.yml
@@ -91,6 +91,3 @@ jobs:
             } else {
               core.info('✅ No significant performance regression detected.');
             }
-      
-      - name: Minimize uv cache
-        run: uv cache prune --ci

--- a/.github/workflows/import_time.yml
+++ b/.github/workflows/import_time.yml
@@ -13,74 +13,55 @@ jobs:
     name: benchmark
     runs-on: ubuntu-latest
 
-    env:
-      # Configure a constant location for the uv cache
-      UV_CACHE_DIR: /tmp/.uv-cache
-
     strategy:
       matrix:
         include:
           # Ubuntu tests
-          - extra: dataset,denoisers,test,training
+          - environment: "full-cpu"
             name: "all optional dependencies"
-          - extra: ""
+          - environment: "test-cpu"
             name: "no optional dependencies"
 
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
+      - name: Setup Pixi
+        uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          pixi-version: latest
+          environments: full-cpu test-cpu
 
       - name: "Set up Hyperfine"
         run: |
           sudo apt-get update && sudo apt-get install -y hyperfine
 
-      - name: Restore uv cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.uv-cache
-          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
-            uv-${{ runner.os }}
-
       - name: Install deepinv and its dependencies
         shell: bash
         run: |
-          uv venv --python 3.11
-          # if the extra is empty, install without optional dependencies
-          if [ "${{ matrix.extra }}" = "" ]; then
-            uv pip install .
-          else
-            EXTRAS=""
-            for extra in $(echo "${{ matrix.extra }}" | tr ',' ' '); do
-              EXTRAS="$EXTRAS --extra $extra"
-            done
-            uv sync $EXTRAS
-          fi
+          pixi install -e ${{ matrix.environment }}
 
       - name: "Benchmark torch+torchvision"
         run: |
           echo "Benchmarking torch..."
-          hyperfine --warmup 3 --show-output --export-json torch.json 'uv run python -c "import torch, torchvision"'
+          hyperfine --warmup 3 --show-output --export-json torch.json 'pixi run -e ${{ matrix.environment }} python -c "import torch, torchvision"'
 
       - name: "Benchmark PR"
         run: |
           echo "Benchmarking PR branch..."
-          hyperfine --warmup 3 --show-output --export-json head.json 'uv run python -c "import deepinv"'
+          hyperfine --warmup 3 --show-output --export-json head.json 'pixi run -e ${{ matrix.environment }} python -c "import deepinv"'
 
       - name: "Checkout main branch"
         run: |
-          uv pip uninstall deepinv # Clean up for the next step
+          pixi clean cache --yes
+          pixi clean
           git fetch origin main --depth=1
           git checkout main
-          uv pip install .
+          pixi install -e ${{ matrix.environment }}
 
       - name: "Benchmark main"
         run: |
           echo "Benchmarking main branch..."
-          hyperfine --warmup 3 --show-output --export-json base.json 'uv run python -c "import deepinv"'
+          hyperfine --warmup 3 --show-output --export-json base.json 'pixi run -e ${{ matrix.environment }} python -c "import deepinv"'
 
       - name: "Compare results and fail on regression"
         uses: actions/github-script@v7

--- a/.github/workflows/import_time.yml
+++ b/.github/workflows/import_time.yml
@@ -35,11 +35,6 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y hyperfine
 
-      - name: Install deepinv and its dependencies
-        shell: bash
-        run: |
-          pixi install -e ${{ matrix.environment }}
-
       - name: "Benchmark torch+torchvision"
         run: |
           echo "Benchmarking torch..."

--- a/.github/workflows/import_time.yml
+++ b/.github/workflows/import_time.yml
@@ -29,7 +29,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           pixi-version: latest
-          environments: full-cpu test-cpu
+          environments: ${{ matrix.environment }}
 
       - name: "Set up Hyperfine"
         run: |


### PR DESCRIPTION
One remaining test (`import_time.yml`) was still using `uv` instead of `pixi`. I'm implementing the switch to have a uniform setup.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.