### PR TITLE
datetime convention

### DIFF
--- a/deepinv/utils/logger.py
+++ b/deepinv/utils/logger.py
@@ -92,10 +92,9 @@ class ProgressMeter:
 def get_timestamp() -> str:
     """Get current timestamp string.
 
-    :return str: timestamp, with separators determined by system.
+    :return str: timestamp.
     """
-    sep = "_" if platform.system() == "Windows" else ":"
-    return datetime.now().strftime(f"%y-%m-%d-%H{sep}%M{sep}%S")
+    return datetime.now().strftime(f"%Y%m%d_%H%M%S")
 
 
 @_deprecated_class

--- a/deepinv/utils/logger.py
+++ b/deepinv/utils/logger.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import os
 import csv
 from datetime import datetime
-import platform
 import numpy as np
 from deepinv.utils.decorators import _deprecated_class, _deprecated_func
 


### PR DESCRIPTION
Tiny change to checkpoint timestamp formatting to avoid `:` in directory names.

Although `:` is valid in filenames on most OS, it can fail on some mounted or cloud-backed filesystems (e.g. some gpu servers). 

Suggested output would be:

```bash
"%y-%m-%d-%H{sep}%M{sep}%S"      # 2026-07-04_20:29:10     <- current
"%Y%m%d_%H%M%S"                   # 20260704_202910          <- proposed
```


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.