### PR TITLE
Test extract utils and fix apple

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,6 @@ Once the GitHub tests have been approved by a maintainer (only required for firs
 LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:
 
 - [ ] I did not use LLM tools to write the code
-- [ ] LLM tools helped me to write part of the code
+- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
 - [ ] An LLM tool wrote all of the code.
 - [ ] An agent submitted the PR and wrote the description.

--- a/deepinv/datasets/fastmri.py
+++ b/deepinv/datasets/fastmri.py
@@ -647,7 +647,9 @@ class MRISliceTransform(MRIMixin):
         :return: estimated coil maps of shape (N, H, W) and complex dtype
         """
         return MultiCoilMRI.estimate_coil_maps(
-            kspace.unsqueeze(0), calib_size=self.get_acs(metadata=metadata), espirit_crop=self.espirit_crop,
+            kspace.unsqueeze(0),
+            calib_size=self.get_acs(metadata=metadata),
+            espirit_crop=self.espirit_crop,
         ).squeeze(0)
 
     def prewhiten_kspace(self, kspace: torch.Tensor) -> torch.Tensor:

--- a/deepinv/datasets/fastmri.py
+++ b/deepinv/datasets/fastmri.py
@@ -573,6 +573,7 @@ class MRISliceTransform(MRIMixin):
     :param bool, int estimate_coil_maps: if `True`, estimate coil maps using :func:`deepinv.physics.MultiCoilMRI.estimate_coil_maps`.
     :param int acs: optional number of low frequency lines for autocalibration. If `None`, look for acs lines in `mask_generator` attributes (if exists)
         or in metadata (only available for FastMRI test/challenge data). If unavailable, and ACS required, then raises error.
+    :param float espirit_crop: crop parameter used in ESPIRiT coil map sensitivity estimation algorithm, default to 0.95. Lower crop = estimated maps may extend outside anatomy of interest, high crop = maps may be smaller than anatomy.
     :param tuple[slice, slice], bool prewhiten: if `True`, prewhiten kspace noise across coils,
         defaults to using a 30x30 slice in the top left corner. Optionally set tuple of slices for custom location. Defaults to False.
     :param bool normalize: if `True`, normalize kspace by 99th percentile of RSS reconstruction of kspace ACS block.
@@ -585,6 +586,7 @@ class MRISliceTransform(MRIMixin):
         seed_mask_generator: bool = True,
         estimate_coil_maps: bool | int = False,
         acs: int = None,
+        espirit_crop: float = 0.95,
         prewhiten: tuple[slice, slice] = False,
         normalize: bool = False,
     ):
@@ -592,6 +594,7 @@ class MRISliceTransform(MRIMixin):
         self.seed_mask_generator = seed_mask_generator
         self.estimate_coil_maps = estimate_coil_maps
         self.acs = acs
+        self.espirit_crop = espirit_crop
         self.prewhiten = prewhiten
         if self.prewhiten is True:
             self.prewhiten = (slice(0, 30), slice(0, 30))
@@ -644,7 +647,7 @@ class MRISliceTransform(MRIMixin):
         :return: estimated coil maps of shape (N, H, W) and complex dtype
         """
         return MultiCoilMRI.estimate_coil_maps(
-            kspace.unsqueeze(0), calib_size=self.get_acs(metadata=metadata)
+            kspace.unsqueeze(0), calib_size=self.get_acs(metadata=metadata), espirit_crop=self.espirit_crop,
         ).squeeze(0)
 
     def prewhiten_kspace(self, kspace: torch.Tensor) -> torch.Tensor:

--- a/deepinv/datasets/utils.py
+++ b/deepinv/datasets/utils.py
@@ -87,7 +87,7 @@ def download_archive(
         except requests.exceptions.RequestException as exc:
             raise DownloadError(f"Failed to download archive {url}: {exc}") from exc
 
-        if extract:
+        if extract:  # pragma: no cover
             if Path(save_path).suffix == ".zip":
                 extract_zipfile(save_path, Path(save_path).parent)
             elif Path(save_path).suffix == ".tar":

--- a/deepinv/models/bm3d.py
+++ b/deepinv/models/bm3d.py
@@ -119,7 +119,9 @@ class BM3D(Denoiser):
                 periodic=False,
                 dtype=torch.float32,
                 device="cpu",
-            ).to(device)  # (p,)
+            ).to(
+                device
+            )  # (p,)
             self.register_buffer("win", win_1d[:, None] * win_1d[None, :])  # (p, p)
             # helper arrays for aggregation
             self.register_buffer(

--- a/deepinv/models/bm3d.py
+++ b/deepinv/models/bm3d.py
@@ -118,8 +118,8 @@ class BM3D(Denoiser):
                 beta=2.0,
                 periodic=False,
                 dtype=torch.float32,
-                device=device,
-            )  # (p,)
+                device="cpu",
+            ).to(device)  # (p,)
             self.register_buffer("win", win_1d[:, None] * win_1d[None, :])  # (p, p)
             # helper arrays for aggregation
             self.register_buffer(

--- a/deepinv/optim/dpir.py
+++ b/deepinv/optim/dpir.py
@@ -26,8 +26,8 @@ def get_DPIR_params(
         torch.log10(torch.tensor(s2, dtype=torch.float32)),
         steps=max_iter,
         dtype=torch.float32,
-        device=device,
-    )
+        device="cpu",  # see https://github.com/deepinv/deepinv/issues/1177
+    ).to(device)
 
     stepsize = (sigma_denoiser / max(0.01, noise_level_img)) ** 2
     lamb = 1 / 0.23

--- a/deepinv/physics/compressed_sensing.py
+++ b/deepinv/physics/compressed_sensing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from deepinv.physics.forward import LinearPhysics
+from deepinv.utils.nn import devices_equal
 import torch
 import numpy as np
 from torch import Tensor
@@ -100,10 +101,10 @@ class CompressedSensing(LinearPhysics):
         if rng is None:
             self.rng = torch.Generator(device=device)
         else:
-            # Make sure that the random generator is on the same device as the physic generator
-            assert rng.device == torch.device(
-                device
-            ), f"The random generator is not on the same device as the Physics Generator. Got random generator on {rng.device} and the Physics Generator on {device}."
+            if not devices_equal(rng.device, device):
+                raise ValueError(
+                    f"The random generator is not on the same device as the physics. Got random generator on {rng.device} and the physics on {device}."
+                )
             self.rng = rng
         self.register_buffer("initial_random_state", self.rng.get_state())
 

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -10,6 +10,7 @@ from torch import Tensor
 import torch.nn as nn
 from deepinv.physics.noise import NoiseModel, GaussianNoise, ZeroNoise
 from deepinv.utils.tensorlist import randn_like, TensorList
+from deepinv.utils.nn import devices_equal
 from deepinv.optim.utils import least_squares, lsqr, least_squares_implicit_backward
 
 from deepinv.physics.functional import power_method
@@ -1288,7 +1289,7 @@ class Denoising(DecomposablePhysics):
             noise_model = GaussianNoise(sigma=0.1)
 
         if noise_model.rng is not None:
-            if noise_model.rng.device != device:
+            if not devices_equal(noise_model.rng.device, device):
                 warnings.warn(
                     f"argument `device`={device} is different from the random generator device of the noise model, `noise_model.rng.device`={noise_model.rng.device}. This will likely lead to errors during execution. The device argument will be ignored in favor of `noise_model.rng.device`={noise_model.rng.device}."
                 )

--- a/deepinv/physics/generator/base.py
+++ b/deepinv/physics/generator/base.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn as nn
 from hashlib import sha256
 import warnings
+from deepinv.utils.nn import devices_equal
 
 
 def seed_from_string(seed: str) -> int:
@@ -68,10 +69,10 @@ class PhysicsGenerator(nn.Module):
         if rng is None:
             self.rng = torch.Generator(device=device)
         else:
-            # Make sure that the random generator is on the same device as the physics generator
-            assert rng.device == torch.device(
-                device
-            ), f"The random generator is not on the same device as the Physics Generator. Got random generator on {rng.device} and the Physics Generator named {self.__class__.__name__} on {device}."
+            if not devices_equal(rng.device, device):
+                raise ValueError(
+                    f"The random generator is not on the same device as the Physics Generator. Got random generator on {rng.device} and the Physics Generator named {self.__class__.__name__} on {device}."
+                )
             self.rng = rng
 
         # NOTE: There is no use in moving RNG states from one device to another

--- a/deepinv/physics/mri.py
+++ b/deepinv/physics/mri.py
@@ -417,7 +417,10 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
 
     @staticmethod
     def estimate_coil_maps(
-        y: Tensor, calib_size: int = 24, use_cupy: bool = False, espirit_crop: float = 0.95,
+        y: Tensor,
+        calib_size: int = 24,
+        use_cupy: bool = False,
+        espirit_crop: float = 0.95,
     ) -> Tensor:
         """Estimate coil sensitivity maps using ESPIRiT.
 
@@ -462,7 +465,11 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
             cupy_maps = cp.stack(
                 [
                     EspiritCalib(
-                        yb, calib_size, show_pbar=False, crop=espirit_crop, device=cupy_y.device,
+                        yb,
+                        calib_size,
+                        show_pbar=False,
+                        crop=espirit_crop,
+                        device=cupy_y.device,
                     ).run()
                     for yb in cupy_y
                 ]
@@ -473,7 +480,13 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
             device = sp.Device(-1)
             maps = np.stack(
                 [
-                    EspiritCalib(yb, calib_size, show_pbar=False, crop=espirit_crop, device=device).run()
+                    EspiritCalib(
+                        yb,
+                        calib_size,
+                        show_pbar=False,
+                        crop=espirit_crop,
+                        device=device,
+                    ).run()
                     for yb in complex_y.numpy(force=True)
                 ]
             )

--- a/deepinv/physics/mri.py
+++ b/deepinv/physics/mri.py
@@ -417,7 +417,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
 
     @staticmethod
     def estimate_coil_maps(
-        y: Tensor, calib_size: int = 24, use_cupy: bool = False
+        y: Tensor, calib_size: int = 24, use_cupy: bool = False, espirit_crop: float = 0.95,
     ) -> Tensor:
         """Estimate coil sensitivity maps using ESPIRiT.
 
@@ -430,6 +430,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
         :param torch.Tensor y: multi-coil kspace measurements with shape [B,2,N,...,H,W] where N is coil dimension.
         :param int calib_size: optional square auto-calibration size in pixels, used by `sigpy`.
         :param bool use_cupy: whether to attempt to use cupy for GPU acceleration.
+        :param float espirit_crop: optionally set crop argument of ESPIRiT algorithm, defaults to 0.95.
         :return: torch.Tensor of coil maps of complex dtype and shape [B,N,...,H,W]
         """
         try:
@@ -461,7 +462,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
             cupy_maps = cp.stack(
                 [
                     EspiritCalib(
-                        yb, calib_size, show_pbar=False, device=cupy_y.device
+                        yb, calib_size, show_pbar=False, crop=espirit_crop, device=cupy_y.device,
                     ).run()
                     for yb in cupy_y
                 ]
@@ -472,7 +473,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
             device = sp.Device(-1)
             maps = np.stack(
                 [
-                    EspiritCalib(yb, calib_size, show_pbar=False, device=device).run()
+                    EspiritCalib(yb, calib_size, show_pbar=False, crop=espirit_crop, device=device).run()
                     for yb in complex_y.numpy(force=True)
                 ]
             )

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -1,4 +1,5 @@
 import shutil, os
+import sys
 import math
 from typing import NamedTuple, Sequence, Mapping
 from pathlib import Path
@@ -40,6 +41,9 @@ from deepinv.datasets import (
 )
 from deepinv.datasets.utils import (
     download_archive,
+    extract_zipfile,
+    extract_tarball,
+    extract_rarfile,
     Crop,
     Rescale,
     ToComplex,
@@ -1570,3 +1574,34 @@ def test_RandomPatchSampler(make_data):
     assert len(ds) == 2
     x, y = next(iter(ds))
     assert math.isnan(x)
+
+
+def test_extract_zipfile(tmp_path):
+    mock_zip = MagicMock()
+    mock_zip.__enter__.return_value = mock_zip
+    mock_zip.infolist.return_value = ["a.txt", "b.txt"]
+    with patch("deepinv.datasets.utils.zipfile.ZipFile", return_value=mock_zip) as cls:
+        extract_zipfile("archive.zip", tmp_path)
+    cls.assert_called_once_with("archive.zip", "r")
+    assert mock_zip.extract.call_count == 2
+
+
+def test_extract_tarball(tmp_path):
+    mock_tar = MagicMock()
+    mock_tar.__enter__.return_value = mock_tar
+    mock_tar.getmembers.return_value = ["a.txt", "b.txt"]
+    with patch("deepinv.datasets.utils.tarfile.open", return_value=mock_tar) as fn:
+        extract_tarball("archive.tar", tmp_path)
+    fn.assert_called_once_with("archive.tar", "r:*")
+    assert mock_tar.extract.call_count == 2
+
+
+def test_extract_rarfile(tmp_path):
+    mock_rarfile_module = MagicMock()
+    mock_rar = mock_rarfile_module.RarFile.return_value
+    mock_rar.__enter__.return_value = mock_rar
+    mock_rar.infolist.return_value = ["a.txt"]
+    with patch.dict(sys.modules, {"rarfile": mock_rarfile_module}):
+        extract_rarfile("archive.rar", tmp_path)
+    mock_rarfile_module.RarFile.assert_called_once_with("archive.rar")
+    assert mock_rar.extract.call_count == 1

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -1576,32 +1576,34 @@ def test_RandomPatchSampler(make_data):
     assert math.isnan(x)
 
 
-def test_extract_zipfile(tmp_path):
-    mock_zip = MagicMock()
-    mock_zip.__enter__.return_value = mock_zip
-    mock_zip.infolist.return_value = ["a.txt", "b.txt"]
-    with patch("deepinv.datasets.utils.zipfile.ZipFile", return_value=mock_zip) as cls:
-        extract_zipfile("archive.zip", tmp_path)
-    cls.assert_called_once_with("archive.zip", "r")
-    assert mock_zip.extract.call_count == 2
+@pytest.mark.parametrize("kind", ["zipfile", "tarball", "rarfile"])
+def test_extract_archive(tmp_path, kind):
+    if kind == "zipfile":
+        mock_zip = MagicMock()
+        mock_zip.__enter__.return_value = mock_zip
+        mock_zip.infolist.return_value = ["a.txt", "b.txt"]
+        with patch(
+            "deepinv.datasets.utils.zipfile.ZipFile", return_value=mock_zip
+        ) as cls:
+            extract_zipfile("archive.zip", tmp_path)
+        cls.assert_called_once_with("archive.zip", "r")
+        assert mock_zip.extract.call_count == 2
 
+    elif kind == "tarball":
+        mock_tar = MagicMock()
+        mock_tar.__enter__.return_value = mock_tar
+        mock_tar.getmembers.return_value = ["a.txt", "b.txt"]
+        with patch("deepinv.datasets.utils.tarfile.open", return_value=mock_tar) as fn:
+            extract_tarball("archive.tar", tmp_path)
+        fn.assert_called_once_with("archive.tar", "r:*")
+        assert mock_tar.extract.call_count == 2
 
-def test_extract_tarball(tmp_path):
-    mock_tar = MagicMock()
-    mock_tar.__enter__.return_value = mock_tar
-    mock_tar.getmembers.return_value = ["a.txt", "b.txt"]
-    with patch("deepinv.datasets.utils.tarfile.open", return_value=mock_tar) as fn:
-        extract_tarball("archive.tar", tmp_path)
-    fn.assert_called_once_with("archive.tar", "r:*")
-    assert mock_tar.extract.call_count == 2
-
-
-def test_extract_rarfile(tmp_path):
-    mock_rarfile_module = MagicMock()
-    mock_rar = mock_rarfile_module.RarFile.return_value
-    mock_rar.__enter__.return_value = mock_rar
-    mock_rar.infolist.return_value = ["a.txt"]
-    with patch.dict(sys.modules, {"rarfile": mock_rarfile_module}):
-        extract_rarfile("archive.rar", tmp_path)
-    mock_rarfile_module.RarFile.assert_called_once_with("archive.rar")
-    assert mock_rar.extract.call_count == 1
+    elif kind == "rarfile":
+        mock_rarfile_module = MagicMock()
+        mock_rar = mock_rarfile_module.RarFile.return_value
+        mock_rar.__enter__.return_value = mock_rar
+        mock_rar.infolist.return_value = ["a.txt"]
+        with patch.dict(sys.modules, {"rarfile": mock_rarfile_module}):
+            extract_rarfile("archive.rar", tmp_path)
+        mock_rarfile_module.RarFile.assert_called_once_with("archive.rar")
+        assert mock_rar.extract.call_count == 1

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -1578,32 +1578,30 @@ def test_RandomPatchSampler(make_data):
 
 @pytest.mark.parametrize("kind", ["zipfile", "tarball", "rarfile"])
 def test_extract_archive(tmp_path, kind):
+    mocker = MagicMock()
+    mocker.__enter__.return_value = mocker
+    getattr(mocker, "getmembers" if kind == "tarball" else "infolist").return_value = [
+        "a.txt",
+        "b.txt",
+    ]
+
     if kind == "zipfile":
-        mock_zip = MagicMock()
-        mock_zip.__enter__.return_value = mock_zip
-        mock_zip.infolist.return_value = ["a.txt", "b.txt"]
         with patch(
-            "deepinv.datasets.utils.zipfile.ZipFile", return_value=mock_zip
+            "deepinv.datasets.utils.zipfile.ZipFile", return_value=mocker
         ) as cls:
             extract_zipfile("archive.zip", tmp_path)
         cls.assert_called_once_with("archive.zip", "r")
-        assert mock_zip.extract.call_count == 2
 
     elif kind == "tarball":
-        mock_tar = MagicMock()
-        mock_tar.__enter__.return_value = mock_tar
-        mock_tar.getmembers.return_value = ["a.txt", "b.txt"]
-        with patch("deepinv.datasets.utils.tarfile.open", return_value=mock_tar) as fn:
+        with patch("deepinv.datasets.utils.tarfile.open", return_value=mocker) as fn:
             extract_tarball("archive.tar", tmp_path)
         fn.assert_called_once_with("archive.tar", "r:*")
-        assert mock_tar.extract.call_count == 2
 
     elif kind == "rarfile":
-        mock_rarfile_module = MagicMock()
-        mock_rar = mock_rarfile_module.RarFile.return_value
-        mock_rar.__enter__.return_value = mock_rar
-        mock_rar.infolist.return_value = ["a.txt"]
-        with patch.dict(sys.modules, {"rarfile": mock_rarfile_module}):
+        mock_module = MagicMock()
+        mock_module.RarFile.return_value = mocker
+        with patch.dict(sys.modules, {"rarfile": mock_module}):
             extract_rarfile("archive.rar", tmp_path)
-        mock_rarfile_module.RarFile.assert_called_once_with("archive.rar")
-        assert mock_rar.extract.call_count == 1
+        mock_module.RarFile.assert_called_once_with("archive.rar")
+
+    assert mocker.extract.call_count == 2

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -1292,3 +1292,19 @@ def test_patch_dataset_transform():
 
     for i in range(len(ds)):
         assert torch.equal(ds[i], ds_raw[i] * 2 + 1)
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ("cpu", "cpu", True),
+        ("cpu", torch.device("cpu"), True),
+        ("cuda", "cuda:0", True),
+        ("cuda:0", torch.device("cuda"), True),
+        ("cuda:1", "cuda:0", False),
+        ("cuda", "mps", False),
+        ("mps:0", "mps", True),
+    ],
+)
+def test_devices_equal(a, b, expected):
+    assert deepinv.utils.devices_equal(a, b) == expected

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -657,8 +657,9 @@ class Trainer:
         Get the samples for the online measurements.
 
         In this setting, a new sample is generated at each iteration by calling the physics operator.
-        This function returns a dictionary containing necessary data for the model inference. It needs to contain
-        the measurement, the ground truth, and the current physics operator, but can also contain additional data.
+        This function returns a tuple `(x, y, physics)` for the model inference.
+
+        Assumes the dataloader returns ground truth `x`, or tuples of (`x`, `params`). Note that `params` are ignored if a physics generator is provided.
 
         :param list iterators: List of dataloader iterators.
         :param int g: Current dataloader index.
@@ -674,7 +675,7 @@ class Trainer:
                 params = data[1]
             else:
                 warnings.warn(
-                    "Generating online measurements from data x but dataloader returns tuples (x, ...). Discarding all data after x."
+                    f"Generating online measurements requires dataloader to return tensor `x` or (tensor `x`, dict `params`) but got ({type(x)}, {type(data[1])}, ...). Discarding all data after `x`."
                 )
         else:
             x = data
@@ -703,9 +704,7 @@ class Trainer:
         Get the samples for the offline measurements.
 
         In this setting, samples have been generated offline and are loaded from the dataloader.
-        This function returns a tuple containing necessary data for the model inference. It needs to contain
-        the measurement, the ground truth, and the current physics operator, but can also contain additional data
-        (you can override this function to add custom data).
+        This function returns a tuple `(x, y, physics)` for the model inference. You can override this function to add custom data.
 
         If the dataloader returns 3-tuples, this is assumed to be ``(x, y, params)`` where
         ``params`` is a dict of physics generator params. These params are then used to update

--- a/deepinv/utils/__init__.py
+++ b/deepinv/utils/__init__.py
@@ -28,7 +28,7 @@ from .demo import (
     load_torch_url,
     load_np_url,
 )
-from .nn import get_freer_gpu, get_device
+from .nn import get_freer_gpu, get_device, devices_equal
 from .tensorlist import (
     TensorList,
     rand_like,

--- a/deepinv/utils/nn.py
+++ b/deepinv/utils/nn.py
@@ -149,3 +149,19 @@ def get_freer_gpu(verbose=True, use_torch_api=True, hide_warnings=False):
         print(f"Selected GPU {idx} with {mem} MiB free memory")
 
     return device
+
+
+def devices_equal(device1: torch.device | str, device2: torch.device | str) -> bool:
+    """Test whether two torch devices or strs are equal.
+
+    0th index and no index devices are treated equal.
+
+    :param torch.device, str a: device 1 to check
+    :param torch.device, str b: device 2 to check
+    :return: bool check result
+    """
+    d1 = torch.device(device1)
+    d2 = torch.device(device2)
+    if d1.type != d2.type:
+        return False
+    return (d1.index or 0) == (d2.index or 0)

--- a/deepinv/utils/nn.py
+++ b/deepinv/utils/nn.py
@@ -99,7 +99,9 @@ def get_device(verbose=True, use_torch_api=True):
 
     if torch.backends.mps.is_available():
         if verbose:
-            print("Selected MPS device (Apple Silicon)")
+            print(
+                "Selected MPS device (Apple Silicon). Note that some PyTorch functions are not yet implemented for MPS. Please see https://github.com/deepinv/deepinv/issues/1177 and https://github.com/pytorch/pytorch/issues/141287 for details, and report an issue if you encounter problems. Otherwise, set the environment variable to fallback to CPU: import os; os.environ['PYTORCH_ENABLE_MPS_FALLBACK']='1'"
+            )
         return torch.device("mps")
 
     if verbose:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,7 +24,7 @@ Fixed
 - Remove redundant parameters `unitary` and `compute_inverse` from :class:`deepinv.physics.RandomPhaseRetrieval` (:gh:`1220` by `Zhiyuan Hu`_)
 - Add :class:`deepinv.utils.DownloadError` to avoid CI errors when downloading demos/datasets (:gh:`1234` by `Julian Tachella`_)
 - Remove unconditional dtype conversion to `torch.cfloat` in :func:`deepinv.optim.phase_retrieval.spectral_methods` (:gh:`1216` by `Zhiyuan Hu`_)
-
+- Let quickstart run as default on Apple MPS (:gh:`1263` by `Andrew Wang`_)
 
 v0.4.1
 ------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,6 +16,7 @@ New Features
 - Add :func:`deepinv.utils.plot_napari` to interactively view 2D images/3D vols with napari (:gh:`1249` by `Andrew Wang`_)
 - Add support for :func:`Liu-Jia padding <deepinv.physics.functional.liu_jia_pad>` (:gh:`934` by `Jérémy Scanvic`_)
 - Add support for TV-L1 priors :class:`deepinv.optim.TVL1Prior` (:gh:`1236` by `Sarra Amiri`_)
+- Add espirit_crop parameter to control ESPIRiT multicoil MRI map estimation (:gh:`1263` by `Andrew Wang`_)
 
 Changed
 ^^^^^^^
@@ -28,7 +29,8 @@ Fixed
 - Remove redundant parameters `unitary` and `compute_inverse` from :class:`deepinv.physics.RandomPhaseRetrieval` (:gh:`1220` by `Zhiyuan Hu`_)
 - Add :class:`deepinv.utils.DownloadError` to avoid CI errors when downloading demos/datasets (:gh:`1234` by `Julian Tachella`_)
 - Remove unconditional dtype conversion to `torch.cfloat` in :func:`deepinv.optim.phase_retrieval.spectral_methods` (:gh:`1216` by `Zhiyuan Hu`_)
-- Let quickstart run as default on Apple MPS (:gh:`1263` by `Andrew Wang`_)
+- Let quickstart run as default on Apple MPS, and all BM3D and DPIR to be used on MPS (:gh:`1263` by `Andrew Wang`_)
+- Fix physics and rng devices incorrectly compared in noise and physics and add better device equal checking (:gh:`1263` by `Andrew Wang`_)
 - Deprecate `deepinv.models.WaveletDenoiser.thresold_2D` and `deepinv.models.WaveletDenoiser.thresold_func` in favor of :func:`deepinv.models.WaveletDenoiser.threshold_2D` and :func:`deepinv.models.WaveletDenoiser.threshold_func` (:gh:`1266` by `Paul Bernard`_)
 - Fix kwargs applications in parent constructor calls in the constructors of :class:`deepinv.sampling.EDMDiffusionSDE`, :class:`deepinv.sampling.SongDiffusionSDE` and :class:`deepinv.sampling.VariancePreservingDiffusion` (:gh:`1278` by `Jérémy Scanvic`_)
 - Fix :func:`deepinv.transform.rotate_via_shear` for angles outside :math:`[0, 2pi)` (:gh:`1236` by `Sarra Amiri`_)


### PR DESCRIPTION
- fixes #1177 - now any Apple MPS user can run the quickstart with no problem, with the default device (MPS).
- fix DPIR and BM3D for Apple MPS
- add espirit crop option to multicoil MRI estimating coil maps
- 
- add mock tests for extract zipfile, tarball and rarfile

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.