### PR TITLE
Fix testmon flag in test-cpu and test-gpu

### DIFF
--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -92,17 +92,20 @@ jobs:
           restore-keys: |
             deepinv-url-cache-${{ matrix.os }}-
 
-      # If no .coverage is cached, run pytest without testmon to compute full coverage results
-      # (pytest-cov does not take into account skipped tests by testmon)
-      # If .coverage exists, testmon skips the non-related tests and --cov-append updates coverage with respect to related changes.
+      # On main, we never restore the cache, so .testmondata and .coverage never exist. We run the full suite to compute a base coverage for the main branch, we also run testmon to compute a base .testmondata for the main branch. 
+
+      # On PRs, we restore the cache from main, so testmon skips unrelated tests and --cov-append updates coverage with respect to related changes. 
+      # In case .coverage is not restored properly (for any reasons), but .testmondata is restored, we run pytest without testmon to compute full coverage results. This is a corner case that should not happen, but we handle it anyway.
       - name: Test with pytest
         shell: bash
         run: |
-          TESTMON_FLAG=""
-          if [ -f .coverage ]; then
-            TESTMON_FLAG="--testmon"
+          TESTMON_FLAG="--testmon"
+          if [ -f .testmondata ] && [ ! -f .coverage ]; then
+            TESTMON_FLAG=""
           fi
+          set -x
           pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append $TESTMON_FLAG
+          set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) cache
       # entry so PRs always restore a matching pair. Only on push to main.

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -94,14 +94,20 @@ jobs:
                 f'GPU: {torch.cuda.get_device_name(0)}')
           "
 
+      # On main, we never restore the cache, so .testmondata and .coverage never exist. We run the full suite to compute a base coverage for the main branch, we also run testmon to compute a base .testmondata for the main branch. 
+
+      # On PRs, we restore the cache from main, so testmon skips unrelated tests and --cov-append updates coverage with respect to related changes. 
+      # In case .coverage is not restored properly (for any reasons), but .testmondata is restored, we run pytest without testmon to compute full coverage results. This is a corner case that should not happen, but we handle it anyway.
       - name: Test with pytest
         shell: bash
         run: |
-          TESTMON_FLAG=""
-          if [ -f .coverage ]; then
-            TESTMON_FLAG="--testmon"
+          TESTMON_FLAG="--testmon"
+          if [ -f .testmondata ] && [ ! -f .coverage ]; then
+            TESTMON_FLAG=""
           fi
+          set -x
           pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append $TESTMON_FLAG
+          set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) matched
       # baseline pair. Only on main and only for baseline runs (not PR-dispatch),


### PR DESCRIPTION
In #1254, I inadvertently modified `testmon` behavior on the `main` branch. As a result,  `testmon`was effectively disabled on  `main`, and no `.testmondata` was created and cached. Consequently, `testmon` ran on PRs without a baseline for comparison, eliminating any CI speed improvements.

I'm fixing this here; hopefully this resolves some of our speed issues :')

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.