### PR TITLE
Introduce pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.2.0
+      hooks:
+          - id: check-yaml
+          - id: check-added-large-files
+            args:
+            - --maxkb=2048
+          - id: check-byte-order-marker
+          - id: check-case-conflict
+          - id: check-merge-conflict
+          - id: mixed-line-ending
+    - repo: https://github.com/psf/black
+      rev: 26.5.1
+      hooks:
+          - id: black
+          - id: black-jupyter
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      # Ruff version.
+      rev: v0.15.20
+      hooks:
+          - id: ruff-check
+          # - id: ruff-format  # 56 files reformatted
+    # - repo: https://github.com/adamchainz/blacken-docs
+    #   rev: "v1.12.1"
+    #   hooks:
+    #     - id: blacken-docs
+    #       additional_dependencies:
+    #       - black==26.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,11 @@ repos:
       rev: v0.15.20
       hooks:
           - id: ruff-check
-          # - id: ruff-format  # 56 files reformatted
-    # - repo: https://github.com/adamchainz/blacken-docs
-    #   rev: "v1.12.1"
+          # - id: ruff-format  # 56 modified files
+    # - repo: https://github.com/adamchainz/blacken-docs  # 17 modified files
+    #   rev: "1.20.0"
     #   hooks:
     #     - id: blacken-docs
+    #       args: [-l 140]
     #       additional_dependencies:
-    #       - black==26.3.1
+    #       - black==26.5.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,11 +22,3 @@ repos:
       rev: v0.15.20
       hooks:
           - id: ruff-check
-          # - id: ruff-format  # 56 modified files
-    # - repo: https://github.com/adamchainz/blacken-docs  # 17 modified files
-    #   rev: "1.20.0"
-    #   hooks:
-    #     - id: blacken-docs
-    #       args: [-l 140]
-    #       additional_dependencies:
-    #       - black==26.5.1

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -137,9 +137,8 @@ Writing good documentation is also crucial for helping other users use your code
 Code quality is important to us. We require that your code is compliant with PEP8, the `black <https://black.readthedocs.io>`_ style and `ruff <https://docs.astral.sh/ruff/>`_ checkers:
 
 1. Add `typing <https://fastapi.tiangolo.com/python-types/>`_ to your code and docstrings. Typing rules such as PEP585 are automatically checked using ruff.
-2. Run ``black .`` in the root directory of your repository. This will automatically fix all formatting issues.
-3. Run ``ruff check``, which will check all linting options we've enabled. If it fails, follow the suggestions to make a fix!
-4. Push your code. The automatic checkers will run in GitHub actions, along with other actions that we have in place.
+2. Run ``pre-commit install`` once to set up `pre-commit`. This will run `ruff check` and `black` on your changes when committing.
+3. Push your code. The automatic checkers will run in GitHub actions, along with other actions that we have in place.
 
 .. _log_changes:
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -137,8 +137,18 @@ Writing good documentation is also crucial for helping other users use your code
 Code quality is important to us. We require that your code is compliant with PEP8, the `black <https://black.readthedocs.io>`_ style and `ruff <https://docs.astral.sh/ruff/>`_ checkers:
 
 1. Add `typing <https://fastapi.tiangolo.com/python-types/>`_ to your code and docstrings. Typing rules such as PEP585 are automatically checked using ruff.
-2. Run ``pre-commit install`` once to set up `pre-commit`. This will run `ruff check` and `black` on your changes when committing.
-3. Push your code. The automatic checkers will run in GitHub actions, along with other actions that we have in place.
+2. Run ``black .`` in the root directory of your repository. This will automatically fix all formatting issues.
+3. Run ``ruff check``, which will check all linting options we've enabled. If it fails, follow the suggestions to make a fix!
+4. Push your code. The automatic checkers will run in GitHub actions, along with other actions that we have in place.
+
+Alternatively, you can install `pre-commit <https://pre-commit.com/>`_ with:
+
+.. code-block:: bash
+
+    pip install pre-commit
+    pre-commit install
+
+This runs `ruff` and `black` alongside other tests every time you create a commit.
 
 .. _log_changes:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,8 @@ doc = [
 
 lint = [
     "black",
-    "ruff"
+    "ruff",
+    "pre-commit",
 ]
 
 # optional dependencies for specific denoisers, or transforms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,7 @@ doc = [
 
 lint = [
     "black",
-    "ruff",
-    "pre-commit",
+    "ruff"
 ]
 
 # optional dependencies for specific denoisers, or transforms


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) is a tool that runs a selected list of commands for every git commit on a project. Here, we run `ruff-check` and `black`, which takes ~1s on the whole project (but should be faster on individual commits, as only modified files are checked). For it to work, you have to install it by running `pip install pre-commit` and `pre-commit install`.

If the checks fail, the commit is blocked. You can always bypass pre-commit by using `git commit -n`.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [-] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.