### PR TITLE
Fix latex of log-poisson noise docs

### DIFF
--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -770,12 +770,12 @@ class UniformNoise(NoiseModel):
 
 class LogPoissonNoise(NoiseModel):
     r"""
-    Log-Poisson noise :math:`y = \frac{1}{\mu} \log(\frac{\mathcal{P}(\exp(-\mu x) N_0)}{N_0})`.
+    Log-Poisson noise :math:`y = -\frac{1}{\mu} \log(\frac{\mathcal{P}(\exp(-\mu x) N_0)}{N_0})`.
 
     This noise model is mostly used for modelling the noise for (low dose) computed tomography measurements.
-    Here, N0 describes the average number of measured photons. It acts as a noise-level parameter, where a
-    larger value of N0 corresponds to a lower strength of the noise.
-    The value mu acts as a normalization constant of the forward operator. Consequently it should be chosen antiproportionally to the image size.
+    Here, :math:`N_0` describes the average number of measured photons. It acts as a noise-level parameter, where a
+    larger value of :math:`N_0` corresponds to a lower strength of the noise.
+    The value :math:`\mu` acts as a normalization constant of the forward operator. Consequently, it should be chosen antiproportionally to the image size.
 
     For more details on the interpretation of the parameters for CT measurements, we refer to the paper :footcite:t:`leuschner2021lodopab`.
 

--- a/docs/source/user_guide/physics/physics.rst
+++ b/docs/source/user_guide/physics/physics.rst
@@ -179,7 +179,7 @@ By default, the noise model is set to :class:`ZeroNoise <deepinv.physics.ZeroNoi
      - :math:`y\sim\text{Laplace}(z, b)`
 
    * - :class:`deepinv.physics.LogPoissonNoise`
-     - :math:`y = \frac{1}{\mu} \log(\frac{\mathcal{P}(\exp(-\mu z) N_0)}{N_0})`
+     - :math:`y = -\frac{1}{\mu} \log(\frac{\mathcal{P}(\exp(-\mu z) N_0)}{N_0})`
 
    * - :class:`deepinv.physics.UniformNoise`
      - :math:`y\sim \mathcal{U}(z-a, z+b)`


### PR DESCRIPTION
small fixes of the log poisson noise model, which was missing latex on some equations, and a minus was missing from the main definition

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.