### PR TITLE
add explicit TV subgradient

### DIFF
--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -552,13 +552,16 @@ class TVPrior(Prior):
 
         At locations where the finite difference vanishes, the zero element
         of the subdifferential is selected.
+
+        :param torch.Tensor x: Variable :math:`x` at which the subgradient is computed.
+        :return: (:class:`torch.Tensor`) subgradient at :math:`x`.
         """
         dx = self.nabla(x)
         norm_dx = torch.linalg.vector_norm(dx, dim=-1, keepdim=True)
 
         nonzero = norm_dx > 0
 
-        # Do not evaluate an unsafe division by zero, even in the masked branch.
+        # Do not evaluate an unsafe division by zero
         safe_norm = torch.where(nonzero, norm_dx, torch.ones_like(norm_dx))
         normalized_dx = torch.where(
             nonzero,

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -543,10 +543,15 @@ class TVPrior(Prior):
 
     def grad(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         r"""
-        Computes a subgradient of the total variation prior.
+        Computes a subgradient of the total variation prior:
 
-        At locations where the spatial gradient vanishes, the zero element
-        of the Euclidean-norm subdifferential is selected.
+        .. math::
+            \partial g_\sigma (x) = -\mathrm{div}\left(\frac{Dx}{|D x|}\right)
+
+        where :math:`D` is the finite differences linear operator and :math:`\mathrm{div}` is its adjoint, the divergence operator.
+
+        At locations where the finite difference vanishes, the zero element
+        of the subdifferential is selected.
         """
         dx = self.nabla(x)
         norm_dx = torch.linalg.vector_norm(dx, dim=-1, keepdim=True)

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -541,6 +541,28 @@ class TVPrior(Prior):
         """
         return self.TVModel.nabla_adjoint(x)
 
+    def grad(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        r"""
+        Computes a subgradient of the total variation prior.
+
+        At locations where the spatial gradient vanishes, the zero element
+        of the Euclidean-norm subdifferential is selected.
+        """
+        dx = self.nabla(x)
+        norm_dx = torch.linalg.vector_norm(dx, dim=-1, keepdim=True)
+
+        nonzero = norm_dx > 0
+
+        # Do not evaluate an unsafe division by zero, even in the masked branch.
+        safe_norm = torch.where(nonzero, norm_dx, torch.ones_like(norm_dx))
+        normalized_dx = torch.where(
+            nonzero,
+            dx / safe_norm,
+            torch.zeros_like(dx),
+        )
+
+        return self.nabla_adjoint(normalized_dx)
+
 
 class PatchPrior(Prior):
     r"""

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -275,6 +275,32 @@ def test_zero_prior():
         assert torch.allclose(xhat, x)
 
 
+def test_tvprior_gradient(device):
+    """Test the TVPrior gradient against autodiff away from constant regions."""
+    prior = dinv.optim.TVPrior()
+    x = torch.tensor(
+        [[[[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]]]],
+        dtype=torch.float64,
+        device=device,
+    )
+    # The image is zero except for the center pixel, so that we have both
+    # zero finite difference everywhere except for the center pixel
+    x.requires_grad_()
+
+    grad_value = prior.grad(x)
+    grad_autodiff = torch.func.grad(lambda z: prior.fn(z)[0])(x)
+
+    nonzero_diff = torch.zeros_like(x, dtype=torch.bool)
+    nonzero_diff[..., 1, 1] = True
+    zero_diff = ~nonzero_diff
+
+    assert (~zero_diff[nonzero_diff]).all()
+    assert torch.allclose(grad_value[nonzero_diff], grad_autodiff[nonzero_diff])
+    assert torch.isnan(grad_autodiff[zero_diff]).all()
+    assert torch.isfinite(grad_value[zero_diff]).all()
+    assert torch.isfinite(grad_value).all()
+
+
 def test_data_fidelity_amplitude_loss(device):
     r"""
     Tests if the gradient computed with grad_d method of amplitude loss is consistent with the autograd gradient.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,7 @@ Changed
 ^^^^^^^
 - (Breaking) Drop support for deprecated parameters `num_channels` in :class:`deepinv.physics.generator.PSFGenerator`, :class:`deepinv.physics.generator.GaussianBlurGenerator`, :class:`deepinv.physics.generator.MotionBlurGenerator`, :class:`deepinv.physics.generator.DiffractionBlurGenerator`, :class:`deepinv.physics.generator.DiffractionBlurGenerator3D` (:gh:`1242` by `Pierre Weiss`_ and `Florian Sarron`_)
 - Extend :func:`DST-I <deepinv.physics.functional.dst1>` to make it n-dimensional and add an option to have it compute the regular DST-I instead of the non-standard sign-flipped orthogonal variant (:gh:`934` by `Jérémy Scanvic`_)
+- (Breaking) Make :class:`deepinv.optim.TVPrior()` compute an explicit choice of subgradient instead of using autodiff. (:gh:`1271` by `Thibaut Modrzyk`_)
 
 Fixed
 ^^^^^


### PR DESCRIPTION
This PR implements an explicit subgradient choice for `TVPrior` instead of using autodiff and closes #1259.
This aims at making the use of `.grad` more stable for this prior, so that it can be used in optimization algorithms such as `MLEM`. 

I checked the `demo_poisson_mlem.py` notebook and the results are similar.
Not sure if we need more testing for this as people mostly use TV through the prox.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.