### PR TITLE
Fix kwargs applications in parent constructor calls

### DIFF
--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -424,7 +424,7 @@ class EDMDiffusionSDE(DiffusionSDE):
             dtype=dtype,
             device=device,
             *args,
-            *kwargs,
+            **kwargs,
         )
 
     def score(self, x: Tensor, t: Tensor | float, *args, **kwargs) -> torch.Tensor:
@@ -597,7 +597,7 @@ class SongDiffusionSDE(EDMDiffusionSDE):
             dtype=dtype,
             device=device,
             *args,
-            *kwargs,
+            **kwargs,
         )
 
 
@@ -818,7 +818,7 @@ class VariancePreservingDiffusion(SongDiffusionSDE):
             dtype=dtype,
             device=device,
             *args,
-            *kwargs,
+            **kwargs,
         )
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -24,6 +24,7 @@ Fixed
 - Remove redundant parameters `unitary` and `compute_inverse` from :class:`deepinv.physics.RandomPhaseRetrieval` (:gh:`1220` by `Zhiyuan Hu`_)
 - Add :class:`deepinv.utils.DownloadError` to avoid CI errors when downloading demos/datasets (:gh:`1234` by `Julian Tachella`_)
 - Remove unconditional dtype conversion to `torch.cfloat` in :func:`deepinv.optim.phase_retrieval.spectral_methods` (:gh:`1216` by `Zhiyuan Hu`_)
+- Fix kwargs applications in parent constructor calls in the constructors of :class:`deepinv.sampling.EDMDiffusionSDE`, :class:`deepinv.sampling.SongDiffusionSDE` and :class:`deepinv.sampling.VariancePreservingDiffusion` (:gh:`1278` by `Jérémy Scanvic`_)
 
 
 v0.4.1


### PR DESCRIPTION
Fixes #1273

I replace `*kwargs` with `**kwargs` in 3 parent constructor calls

I also checked that there are no other single-star kwargs application using: `git grep -E "[^\\*]\\*kwargs"`

