### PR TITLE
Add no-rescale mode to plot

### DIFF
--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -275,6 +275,18 @@ def test_plot(
             assert axs is None
 
 
+def test_plot_without_rescaling():
+    img = torch.tensor([[[[0.25, 0.5], [0.75, 1.0]]]])
+
+    axs = deepinv.utils.plot(img, rescale_mode=None, show=False, return_axs=True)
+    artist = axs[0, 0].images[0]
+
+    np.testing.assert_array_equal(artist.get_array(), img.squeeze().numpy())
+    assert artist.norm.vmin == 0.0
+    assert artist.norm.vmax == 1.0
+    assert artist.norm.clip
+
+
 @pytest.mark.parametrize("n_plots", [1, 2, 3])
 @pytest.mark.parametrize("titles", [None, "Dummy plot"])
 @pytest.mark.parametrize("save_plot", [False, True])

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -200,10 +200,9 @@ def preprocess_img(
     r"""
     Prepare a batch of images for plotting.
 
-    Real and complex images are transformed into images with values between
-    zero and one by first applying the modulus function for complex images, and
-    then by normalizing the resulting images between zero and one using min-max
-    normalization ``min_max`` or clipping ``clip``.
+    Complex images are first transformed by applying the modulus function.
+    Unless ``rescale_mode`` is ``None``, images are then normalized between zero
+    and one using min-max normalization ``min_max`` or clipping ``clip``.
 
     .. note::
 
@@ -211,7 +210,8 @@ def preprocess_img(
         representation of complex images and are processed accordingly.
 
     :param torch.Tensor im: the batch of images to preprocess, it is expected to be of shape (B, C, *).
-    :param str rescale_mode: the normalization mode, either 'min_max' or 'clip'.
+    :param str, None rescale_mode: the normalization mode, either 'min_max' or
+        'clip', or ``None`` to leave values unchanged.
     :param float, None vmin: minimum value for clipping when using 'clip' rescaling.
     :param float, None vmax: maximum value for clipping when using 'clip' rescaling.
     :param bool return_scale: if ``True``, also return the per-element ``(vmin_orig, vmax_orig)``
@@ -242,13 +242,16 @@ def preprocess_img(
             if not isinstance(mins, list):
                 mins, maxs = [mins], [maxs]
             scales = list(zip(mins, maxs, strict=True))
-        else:  # clip
+        elif rescale_mode == "clip":
             v0 = vmin if vmin is not None else 0.0
             v1 = vmax if vmax is not None else 1.0
             scales = [(v0, v1)] * im.shape[0]
+        else:
+            scales = [(0.0, 1.0)] * im.shape[0]
 
     # Normalize signal between 0 and 1
-    im = normalize_signal(im, mode=rescale_mode, vmin=vmin, vmax=vmax)
+    if rescale_mode is not None:
+        im = normalize_signal(im, mode=rescale_mode, vmin=vmin, vmax=vmax)
 
     if return_scale:
         return im, scales
@@ -290,7 +293,7 @@ def plot(
     save_dir: str | Path | None = None,
     tight: bool = True,
     max_imgs: int = 4,
-    rescale_mode: str = "min_max",
+    rescale_mode: str | None = "min_max",
     show: bool = True,
     close: bool = False,
     figsize: tuple[int, int] | None = None,
@@ -357,8 +360,9 @@ def plot(
     :param None, str, pathlib.Path save_dir: path to save the plots as individual images.
     :param bool tight: use tight layout.
     :param int max_imgs: maximum number of images to plot.
-    :param str rescale_mode: rescale mode, either ``'min_max'`` (images are linearly rescaled between 0 and 1 using
-        their min and max values) or ``'clip'`` (images are clipped between 0 and 1).
+    :param str, None rescale_mode: rescale mode, either ``'min_max'`` (images are linearly rescaled between 0 and 1 using
+        their min and max values), ``'clip'`` (images are clipped between 0 and 1),
+        or ``None`` (values are unchanged and displayed on a fixed 0-to-1 scale).
     :param bool show: show the image plot. Under the hood, this calls the ``plt.show()`` function.
     :param bool close: close the image plot. Under the hood, this calls the ``plt.close()`` function.
     :param tuple[int] figsize: size of the figure. If ``None``, calculated from the size of ``img_list``.
@@ -389,6 +393,14 @@ def plot(
         `imshow docs <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_ for possible kwargs.
     """
     import matplotlib.pyplot as plt
+
+    fixed_norm = None
+    if rescale_mode is None:
+        from matplotlib.colors import Normalize
+
+        fixed_norm = imshow_kwargs.setdefault(
+            "norm", Normalize(vmin=0.0, vmax=1.0, clip=True)
+        )
 
     # Use the matplotlib config from deepinv
     config_matplotlib(fontsize=fontsize)
@@ -527,6 +539,7 @@ def plot(
                     img.squeeze(0).permute(1, 2, 0).cpu().numpy(),
                     cmap=cmap,
                     interpolation=interpolation,
+                    norm=fixed_norm,
                 )
 
                 h, w = img.shape[2], img.shape[3]

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Current
 
 New Features
 ^^^^^^^^^^^^
+- Allow :func:`deepinv.utils.plot` to preserve image values with ``rescale_mode=None`` (:gh:`1281` by `nightcityblade`_)
 - Add :class:`deepinv.loss.metric.RecoveryCoefficient` Recovery Coefficient (RC) metric to evaluate reconstructed activity relative to ground truth within a mask, with dtype-aware numerical stability and a dedicated loss transformation for training (:gh:`1228` by `Kushagra Shukla`_)
 - Add 2D and 3D :class:`deepinv.physics.PET` (:gh:`1099` by `Julian Tachella`_)
 - Add support for multi-channel (chromatic) diffraction PSFs in :class:`deepinv.physics.generator.DiffractionBlurGenerator` with physically consistent wavelength scaling of the pupil cut-off frequency and Zernike coefficients.  (:gh:`1242` by `Pierre Weiss`_ and `Florian Sarron`_)
@@ -666,3 +667,4 @@ Changed
 .. _Kaibo Tang: https://github.com/kvttt
 .. _Irène Waldspurger: https://github.com/IWalds
 .. _Kushagra Shukla: https://github.com/Kushagra481
+.. _nightcityblade: https://github.com/nightcityblade


### PR DESCRIPTION
Fixes #1280

## Summary

- Allow `plot(..., rescale_mode=None)` to preserve image values.
- Display unscaled images with a fixed, clipped 0–1 Matplotlib normalization, including plot insets and colorbar metadata.
- Add focused regression coverage for both the unchanged image data and the fixed display bounds.

## Testing

```text
.venv/bin/python -m pytest -q \
  deepinv/tests/test_utils.py::test_plot_without_rescaling \
  'deepinv/tests/test_utils.py::test_plot[False-False-False-None-False-False-False-False-1-1]' \
  'deepinv/tests/test_utils.py::test_plot[True-False-False-None-False-False-True-False-1-1]'
3 passed, 4 warnings in 0.44s

.venv/bin/black --check deepinv/utils/plotting.py deepinv/tests/test_utils.py
2 files would be left unchanged.

.venv/bin/ruff check deepinv/utils/plotting.py deepinv/tests/test_utils.py
All checks passed!

git diff --check
(no output)
```

Thank you for contributing to DeepInverse!

Please read our [contributing guidelines](https://deepinv.org/contributing.html) for instructions on how to contribute, including writing tests, documentation and code style.

Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/docs_cpu.yml). Look for the workflow run corresponding to your pull request.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully. Not run repository-wide; the new regression and two focused existing plot cases pass locally.
- [ ] `black .` and `ruff check .` run successfully. Not run repository-wide; both checks pass on every changed Python file.
- [ ] `make html` runs successfully (in the `docs/` directory). Not run locally; documentation CI will validate the updated docstrings and changelog.
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [x] An LLM tool wrote all of the code.
- [x] An agent submitted the PR and wrote the description.
