### PR TITLE
Preserve iterations on failed backtracking checks

### DIFF
--- a/deepinv/optim/fixed_point.py
+++ b/deepinv/optim/fixed_point.py
@@ -321,10 +321,12 @@ class FixedPoint(nn.Module):
         if self.anderson_acceleration_config is not None:
             self.init_anderson_acceleration(X)
 
-        for it in tqdm(
-            range(self.max_iter),
+        it = 0
+        progress_bar = tqdm(
+            total=self.max_iter,
             disable=(not self.verbose or not self.show_progress_bar),
-        ):
+        )
+        while it < self.max_iter:
             X_prev = X
             X = self.single_iteration(X, it, *args, **kwargs)
 
@@ -338,12 +340,15 @@ class FixedPoint(nn.Module):
                 )
 
                 # Convergence check
-                if (
+                converged = (
                     self.early_stop
                     and self.check_conv_fn is not None
                     and it > 1
                     and self.check_conv_fn(it, X_prev, X)
-                ):
+                )
+                it += 1
+                progress_bar.update()
+                if converged:
                     break
 
             else:
@@ -354,9 +359,11 @@ class FixedPoint(nn.Module):
                     if self.verbose:
                         print(
                             f"[Stopping] Reached maximum number of failed backtracking checks "
-                            f"({self.max_iter_backtracking})."
+                            f"({self.backtracking_config.max_iter})."
                         )
                     break
+
+        progress_bar.close()
 
         return X, metrics
 

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -343,6 +343,27 @@ OPTIM_ALGO_PARAMS = [
 ]
 
 
+def test_backtracking_does_not_consume_global_iterations():
+    physics = dinv.physics.LinearPhysics(A=lambda x: x, A_adjoint=lambda x: x)
+    y = torch.ones(1, 1, 1, 1)
+
+    model = dinv.optim.GD(
+        data_fidelity=L2(),
+        stepsize=4.0,
+        max_iter=2,
+        backtracking=dinv.optim.BacktrackingConfig(
+            gamma=0.1,
+            eta=0.5,
+            max_iter=20,
+        ),
+    )
+
+    x = model(y, physics, init=torch.zeros_like(y))
+
+    assert torch.allclose(x, y)
+    assert model.params_algo["stepsize"] == [1.0]
+
+
 @pytest.mark.parametrize(
     "name_algo, and_acc",
     OPTIM_ALGO_PARAMS,

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,7 @@ Changed
 
 Fixed
 ^^^^^
+- Ensure failed backtracking checks do not consume global fixed-point iterations (:gh:`1283` by `Shreyansh Goyal`_)
 - Remove redundant parameters `unitary` and `compute_inverse` from :class:`deepinv.physics.RandomPhaseRetrieval` (:gh:`1220` by `Zhiyuan Hu`_)
 - Add :class:`deepinv.utils.DownloadError` to avoid CI errors when downloading demos/datasets (:gh:`1234` by `Julian Tachella`_)
 - Remove unconditional dtype conversion to `torch.cfloat` in :func:`deepinv.optim.phase_retrieval.spectral_methods` (:gh:`1216` by `Zhiyuan Hu`_)
@@ -667,3 +668,4 @@ Changed
 .. _Kaibo Tang: https://github.com/kvttt
 .. _Irène Waldspurger: https://github.com/IWalds
 .. _Kushagra Shukla: https://github.com/Kushagra481
+.. _Shreyansh Goyal: https://github.com/ShreyanshGoyal


### PR DESCRIPTION
Closes #1272.

Failed backtracking checks now retry the same fixed-point iteration instead of consuming the global iteration budget. Only accepted iterations update metrics, convergence state, and the progress bar.

The regression test reproduces the reported identity-operator example and verifies that two accepted iterations still run after the stepsize is reduced.

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (not applicable).
- [x] Added an entry to the changelog.

### Test

- `python -m pytest deepinv/tests/test_optim.py::test_backtracking_does_not_consume_global_iterations -q`
- `ruff check deepinv/optim/fixed_point.py deepinv/tests/test_optim.py`
- `black --check deepinv/optim/fixed_point.py deepinv/tests/test_optim.py`

### LLM policy

- [ ] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [x] An LLM tool wrote all of the code.
- [x] An agent submitted the PR and wrote the description.
