### PR TITLE
Fix clipped image display range

### DIFF
--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -275,6 +275,23 @@ def test_plot(
             assert axs is None
 
 
+def test_plot_clip_uses_fixed_display_range():
+    from matplotlib.colors import Normalize
+
+    image = torch.tensor([[[0.25, 0.5], [0.5, 0.75]]])
+
+    axs = deepinv.utils.plot(image, rescale_mode="clip", show=False, return_axs=True)
+
+    assert axs[0, 0].images[0].norm.vmin == 0.0
+    assert axs[0, 0].images[0].norm.vmax == 1.0
+
+    norm = Normalize(0.0, 1.0, clip=True)
+    axs = deepinv.utils.plot(
+        image, rescale_mode="clip", norm=norm, show=False, return_axs=True
+    )
+    assert axs[0, 0].images[0].norm is norm
+
+
 @pytest.mark.parametrize("n_plots", [1, 2, 3])
 @pytest.mark.parametrize("titles", [None, "Dummy plot"])
 @pytest.mark.parametrize("save_plot", [False, True])

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -358,7 +358,7 @@ def plot(
     :param bool tight: use tight layout.
     :param int max_imgs: maximum number of images to plot.
     :param str rescale_mode: rescale mode, either ``'min_max'`` (images are linearly rescaled between 0 and 1 using
-        their min and max values) or ``'clip'`` (images are clipped between 0 and 1).
+        their min and max values) or ``'clip'`` (images are clipped and displayed on a fixed scale between 0 and 1).
     :param bool show: show the image plot. Under the hood, this calls the ``plt.show()`` function.
     :param bool close: close the image plot. Under the hood, this calls the ``plt.close()`` function.
     :param tuple[int] figsize: size of the figure. If ``None``, calculated from the size of ``img_list``.
@@ -447,6 +447,10 @@ def plot(
     if suptitle:
         plt.suptitle(suptitle, wrap=True)
         fig.subplots_adjust(top=0.75)
+
+    if rescale_mode == "clip" and "norm" not in imshow_kwargs:
+        imshow_kwargs.setdefault("vmin", 0.0)
+        imshow_kwargs.setdefault("vmax", 1.0)
 
     for i, row_imgs in enumerate(imgs):
         for r, img in enumerate(row_imgs):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,7 @@ Changed
 
 Fixed
 ^^^^^
+- Keep :func:`deepinv.utils.plot` images on a fixed display range when using ``rescale_mode="clip"`` (:gh:`1280` by `nightcityblade`_)
 - Remove redundant parameters `unitary` and `compute_inverse` from :class:`deepinv.physics.RandomPhaseRetrieval` (:gh:`1220` by `Zhiyuan Hu`_)
 - Add :class:`deepinv.utils.DownloadError` to avoid CI errors when downloading demos/datasets (:gh:`1234` by `Julian Tachella`_)
 - Remove unconditional dtype conversion to `torch.cfloat` in :func:`deepinv.optim.phase_retrieval.spectral_methods` (:gh:`1216` by `Zhiyuan Hu`_)
@@ -667,3 +668,4 @@ Changed
 .. _Kaibo Tang: https://github.com/kvttt
 .. _Irène Waldspurger: https://github.com/IWalds
 .. _Kushagra Shukla: https://github.com/Kushagra481
+.. _nightcityblade: https://github.com/nightcityblade


### PR DESCRIPTION
Fixes deepinv/deepinv#1280

### Summary

- keep clipped images on a fixed `[0, 1]` Matplotlib display range
- preserve an explicitly supplied `norm` or `vmin`/`vmax` override
- add regression coverage and document the display behavior

### Tests

- `python -m pytest -q deepinv/tests/test_utils.py` (`1513 passed, 8 skipped` in a CPU-only test environment)
- `black --check .`
- `ruff check .`

Thank you for contributing to DeepInverse!

Please read our [contributing guidelines](https://deepinv.org/contributing.html) for instructions on how to contribute, including writing tests, documentation and code style.

Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/docs_cpu.yml). Look for the workflow run corresponding to your pull request.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [x] An LLM tool wrote all of the code.
- [x] An agent submitted the PR and wrote the description.
