### PR TITLE
Test duration information in CI

### DIFF
--- a/.github/workflows/gpu_trigger.yml
+++ b/.github/workflows/gpu_trigger.yml
@@ -66,7 +66,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: test_gpu.yml
-          ref: main
+          ref: ${{ github.event.pull_request.head.ref }}
           inputs: '{ "pr_number": "${{ steps.pr.outputs.pr_number }}" }'
 
       - name: Trigger GPU Docs Check

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -104,7 +104,7 @@ jobs:
             TESTMON_FLAG=""
           fi
           set -x
-          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append $TESTMON_FLAG --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml 
+          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml 
           set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) cache

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -104,7 +104,7 @@ jobs:
             TESTMON_FLAG=""
           fi
           set -x
-          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append $TESTMON_FLAG
+          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append $TESTMON_FLAG --durations=30
           set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) cache

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -141,7 +141,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pytest_report_cpu
-          path: pytest_report-cpu-${{ matrix.environment }}.xml
+          path: pytest_report-${{ matrix.environment }}.xml
 
       - name: Link to generated pytest report
         if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -104,7 +104,7 @@ jobs:
             TESTMON_FLAG=""
           fi
           set -x
-          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append $TESTMON_FLAG --durations=30
+          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append $TESTMON_FLAG --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml 
           set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) cache
@@ -135,3 +135,15 @@ jobs:
           files: ./coverage-${{ matrix.environment }}.xml
           flags: ${{ matrix.environment }}
           name: ${{ matrix.environment }}-coverage
+
+      - name: Upload pytest report
+        id: upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest_report_cpu
+          path: pytest_report-cpu-${{ matrix.environment }}.xml
+
+      - name: Link to generated pytest report
+        if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+        run: |
+          echo "Pytest XML report URL: ${{ steps.upload-artifact.outputs.artifact-url }}"

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -140,10 +140,5 @@ jobs:
         id: upload-artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pytest_report_cpu
-          path: pytest_report-${{ matrix.environment }}.xml
-
-      - name: Link to generated pytest report
-        if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
-        run: |
-          echo "Pytest XML report URL: ${{ steps.upload-artifact.outputs.artifact-url }}"
+          name: pytest-report-${{ matrix.environment }}
+          path: pytest_report_${{ matrix.environment }}.xml

--- a/.github/workflows/test_cpu.yml
+++ b/.github/workflows/test_cpu.yml
@@ -104,7 +104,7 @@ jobs:
             TESTMON_FLAG=""
           fi
           set -x
-          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml 
+          pixi run -e ${{ matrix.environment }} pytest ${{ matrix.pytest_args }} --cov=deepinv --cov-report=xml:coverage-${{ matrix.environment }}.xml --cov-append $TESTMON_FLAG --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml 
           set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) cache

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -106,7 +106,7 @@ jobs:
             TESTMON_FLAG=""
           fi
           set -x
-          pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append $TESTMON_FLAG --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml
+          pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml
           set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) matched

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pytest_report_gpu
-          path: pytest-report-gpu-${{ matrix.environment }}.xml
+          path: pytest-report-${{ matrix.environment }}.xml
 
       - name: Link to generated pytest report
         if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -106,7 +106,7 @@ jobs:
             TESTMON_FLAG=""
           fi
           set -x
-          pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append $TESTMON_FLAG
+          pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append $TESTMON_FLAG --durations=30
           set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) matched

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -106,7 +106,7 @@ jobs:
             TESTMON_FLAG=""
           fi
           set -x
-          pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append $TESTMON_FLAG --durations=30
+          pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append $TESTMON_FLAG --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml
           set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) matched
@@ -155,3 +155,16 @@ jobs:
         if: always()
         run: |
           rm -rf /local/jtachell/pixi
+
+      - name: Upload pytest report
+        id: upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest_report_gpu
+          path: pytest-report-gpu-${{ matrix.environment }}.xml
+
+      - name: Link to generated pytest report
+        if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+        run: |
+          echo "Pytest XML report URL: ${{ steps.upload-artifact.outputs.artifact-url }}"
+

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -160,11 +160,6 @@ jobs:
         id: upload-artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pytest_report_gpu
-          path: pytest-report-${{ matrix.environment }}.xml
-
-      - name: Link to generated pytest report
-        if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
-        run: |
-          echo "Pytest XML report URL: ${{ steps.upload-artifact.outputs.artifact-url }}"
+          name: pytest-report-${{ matrix.environment }}
+          path: pytest_report_${{ matrix.environment }}.xml
 

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -106,7 +106,7 @@ jobs:
             TESTMON_FLAG=""
           fi
           set -x
-          pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml
+          pixi run -e full pytest -n 2 --dist=loadgroup --cov=deepinv --cov-report=xml:coverage-full.xml --cov-append $TESTMON_FLAG --durations=30 --junit-xml pytest_report-${{ matrix.environment }}.xml
           set +x
 
       # Save the freshly-solved lock + .testmondata + .coverage as a single (atomic) matched


### PR DESCRIPTION
- CI displays the 30 longest tests
- When GPU Tests are run manually by maintainers (/gpu-tests), the PR workflow file is used instead of main
- pytest generates an XML report for all tests that can be downloaded
That way, we can keep track of the longest tests or test duration regressions.
In the future, we may use this report to automate regression detection.

### Checks to be done before submitting your PR

- [-] `python3 -m pytest deepinv/tests` runs successfully.
- [-] `black .` and `ruff check .` run successfully.
- [-] `make html` runs successfully (in the `docs/` directory).
- [-] Updated docstrings related to the changes (as applicable).
- [-] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.