### PR TITLE
Remove GUI backends in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dataset = [
     "blosc2",
     "tifffile",
     "rarfile",
-    "napari[all]",
+    "napari[optional]",
 ]
 
 # optional dependencies for training
@@ -138,7 +138,7 @@ platforms = ["linux-64", "win-64"]
 [tool.pixi.dependencies]
 python = "<3.13.0"
 numpy = "*"
-matplotlib = "*"
+matplotlib-base = "*"
 tqdm = "*"
 torchmetrics = "*"
 einops = "*"


### PR DESCRIPTION
This removes our dependencies to packages `pyside6` and `pyqt6` which are both Qt backends that can cause conflicts (see issue and discussion in #1293 ).

This follows the recommendations of matplotlib (["Most, if not all, packages that have dependence at runtime on matplotlib should list this dependence as matplotlib-base unless they explicitly need pyside6"](https://conda-forge.org/docs/maintainer/knowledge_base/#matplotlib)) and napari (["Don’t include napari[all], [...] in your plugin’s default dependencies."](https://napari.org/stable/plugins/building_a_plugin/best_practices.html#don-t-include-napari-all-pyside6-pyqt5-or-pyqt6-in-your-plugin-s-default-dependencies)).

Fixes #1293 

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.