### PR TITLE
Pin parallelproj version <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ transformers = "*"
 torchkbnufft = "*"
 array-api-compat = "*"
 sigpy = "*"
-parallelproj = ">=1.10.0"
+parallelproj = ">=1.10.0,<2.0.0"
 # spyrit is PyPI-only, stays in optional deps
 
 [tool.pixi.feature.physics-gpu.dependencies]


### PR DESCRIPTION
There are [backward compatibility issues](https://github.com/deepinv/deepinv/actions/runs/30089229713/job/89468493516) with the new major release of parallelproj v2.0.0.

In particular, we use `parallelproj.operators.LinearSingleChannelOperator`, which calls at some point `scipy.ndimage.gaussian_filter` which calls `scipy.ndimage.gaussian_filter1d`, which tries to slice a torch tensor with negative steps (x[::-1]). But pytorch doesn't allow negative slicing on torch tensors and doesn't plan on doing so: https://github.com/pytorch/pytorch/issues/175240

I can't find a workaround for now, I think it needs to be fixed on scipy or on parallelproj instead, so for now, I propose that we stay on parallelproj v1 to make sure that it works on DeepInv.


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.