### PR TITLE
Clean minor deprecation warnings in CI

### DIFF
--- a/deepinv/loss/measplit.py
+++ b/deepinv/loss/measplit.py
@@ -365,7 +365,7 @@ class SplittingLoss(Loss):
             warn(
                 "The 'mask' property is deprecated. Use get_masks() instead.",
                 DeprecationWarning,
-                stacklevel=1,
+                stacklevel=2,
             )
             if self.masks:
                 return self.masks[-1]
@@ -383,7 +383,7 @@ class SplittingLoss(Loss):
             warn(
                 "The 'get_mask' method is deprecated. Use get_masks() instead.",
                 DeprecationWarning,
-                stacklevel=1,
+                stacklevel=2,
             )
             if not self.masks:
                 raise ValueError(

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -591,7 +591,7 @@ class Artifact2ArtifactLoss(Phase2PhaseLoss):
         )
 
     def forward(self, x_net, y, physics, model, **kwargs):
-        mask = model.get_mask() * getattr(physics, "mask", 1.0)
+        mask = model.get_masks()[-1] * getattr(physics, "mask", 1.0)
 
         # Create output mask by re-splitting leftover samples
         mask2 = self.mask_generator.step(

--- a/deepinv/loss/mri/measplit.py
+++ b/deepinv/loss/mri/measplit.py
@@ -265,7 +265,8 @@ class RobustSplittingLoss(WeightedSplittingLoss):
         # Usual weighted splitting loss
         recon_loss = super().forward(x_net, y, physics, model, **kwargs)
 
-        mask = model.get_mask() * getattr(physics, "mask", 1.0)  # M_\lambda\cap\omega
+        masks = model.get_masks()
+        mask = masks[-1] * getattr(physics, "mask", 1.0)  # M_\lambda\cap\omega
 
         n2n_metric = self.Noisier2NoiseMetric(
             weight=(1 + 1 / (self.alpha**2)) * self.expand_mask(mask, y),

--- a/deepinv/tests/test_loss.py
+++ b/deepinv/tests/test_loss.py
@@ -732,8 +732,11 @@ def test_measplit_masking(mode, img_size, split_ratio):
     with torch.no_grad():
         out = model(y, physics, update_parameters=True)
 
-    assert torch.all(out == model.mask)
-    assert np.allclose(model.mask.mean().item() * acc, split_ratio, atol=1e-4)
+    masks = model.get_masks()
+    assert len(masks) == 1
+    mask = masks[-1]
+    assert torch.all(out == mask)
+    assert np.allclose(mask.mean().item() * acc, split_ratio, atol=1e-4)
 
     if mode == "test_split_y":
         y1 = out

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -746,9 +746,10 @@ def test_ProgressMeter(
         for _ in range(n_updates):
             meter.update(rng.random())
 
-    progress = deepinv.utils.ProgressMeter(
-        num_epochs, meters, surfix=surfix, prefix=prefix
-    )
+    with pytest.warns(DeprecationWarning):
+        progress = deepinv.utils.ProgressMeter(
+            num_epochs, meters, surfix=surfix, prefix=prefix
+        )
 
     stdout_buf = io.StringIO()
     with contextlib.redirect_stdout(stdout_buf):


### PR DESCRIPTION
Towards #1007

1. The deprecated class ProgressMeter remains tested - I catch the deprecation warning in it (~ 48 warnings)
2. I swap `mask` / `get_mask()` for `get_masks()[-1]` in the code base for measurement splitting (~ 4 warnings)
3. I fix the stacklevel so the warnings are more informative in the future

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] LLM tools helped me to write part of the code
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.