### PR TITLE
Brainweb MRI dataset

### DIFF
--- a/deepinv/datasets/__init__.py
+++ b/deepinv/datasets/__init__.py
@@ -21,4 +21,4 @@ from .utils import download_archive
 from .satellite import NBUDataset
 from .base import ImageDataset, check_dataset, TensorDataset, ImageFolder
 from .skmtea import SKMTEASliceDataset
-from .brainweb_mri import BrainwebMRI
+from .brainweb_mri import BrainWebMRI

--- a/deepinv/datasets/__init__.py
+++ b/deepinv/datasets/__init__.py
@@ -21,3 +21,4 @@ from .utils import download_archive
 from .satellite import NBUDataset
 from .base import ImageDataset, check_dataset, TensorDataset, ImageFolder
 from .skmtea import SKMTEASliceDataset
+from .brainweb_mri import BrainwebMRI

--- a/deepinv/datasets/brainweb_mri.py
+++ b/deepinv/datasets/brainweb_mri.py
@@ -1,0 +1,60 @@
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+import torch
+
+from deepinv.datasets.base import ImageDataset
+from deepinv.datasets.utils import resolve_root
+
+
+class BrainwebMRI(ImageDataset):
+    r"""BrainWeb MRI volumes.
+
+    Thin PyTorch wrapper around `brainweb-dl
+    <https://github.com/paquiteau/brainweb-dl>`_. Each sample is a native-resolution,
+    channel-first 3D volume downloaded and cached on first access.
+
+    :param str, pathlib.Path, None root: Dataset directory. Defaults to the
+        DeepInverse cache.
+    :param int, list[int] subject_ids: Subjects to expose.
+        Defaults to subject 0.
+    :param str contrast: MRI contrast. Defaults to ``"T1"``.
+    :param collections.abc.Callable, None transform: Optional volume transform.
+    """
+
+    def __init__(
+        self,
+        root: str | Path | None = None,
+        subject_ids: int | list[int] = 0,
+        contrast: Literal["T1", "T2", "T2*", "PD"] = "T1",
+        transform: Callable | None = None,
+    ) -> None:
+        try:
+            from brainweb_dl import get_mri
+        except ImportError as error:  # pragma: no cover
+            raise ImportError(
+                "BrainwebMRI requires brainweb-dl. Install it with "
+                "`pip install deepinv[dataset]`."
+            ) from error
+
+        self.root = resolve_root(root, "BrainwebMRI")
+        self.subject_ids = (
+            [subject_ids] if isinstance(subject_ids, int) else subject_ids
+        )
+        self.contrast = contrast
+        self.transform = transform
+        self.get_mri = get_mri
+
+    def __len__(self) -> int:
+        return len(self.subject_ids)
+
+    def __getitem__(self, index: int) -> torch.Tensor:
+        volume = self.get_mri(
+            sub_id=self.subject_ids[index],
+            contrast=self.contrast,
+            brainweb_dir=self.root,
+        )
+        volume = torch.from_numpy(np.asarray(volume, dtype=np.float32)).unsqueeze(0)
+        return self.transform(volume) if self.transform is not None else volume

--- a/deepinv/datasets/brainweb_mri.py
+++ b/deepinv/datasets/brainweb_mri.py
@@ -2,44 +2,44 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-import numpy as np
 import torch
 
 from deepinv.datasets.base import ImageDataset
 from deepinv.datasets.utils import resolve_root
 
 
-class BrainwebMRI(ImageDataset):
-    r"""BrainWeb MRI volumes.
+class BrainWebMRI(ImageDataset):
+    r"""Dataset for `BrainWeb <https://brainweb.bic.mni.mcgill.ca/>`_.
 
-    Thin PyTorch wrapper around `brainweb-dl
-    <https://github.com/paquiteau/brainweb-dl>`_. Each sample is a native-resolution,
-    channel-first 3D volume downloaded and cached on first access.
+    BrainWeb brain phantom for Magnetic Resonance Imaging (MRI) research :footcite:p:`collinsDesignConstructionRealistic1998`.
+    The dataset consists of 22 MRI brain phantom scans: 21 normal brains and 1 multiple sclerosis brain (patient 1).
+    Several contrasts are available for each patient: T1, T2, T2* and PD.
+    Each volume has shape (1, 181, 217, 181).
 
-    :param str, pathlib.Path, None root: Dataset directory. Defaults to the
-        DeepInverse cache.
-    :param int, list[int] subject_ids: Subjects to expose.
-        Defaults to subject 0.
-    :param str contrast: MRI contrast. Defaults to ``"T1"``.
+    :param int, collections.abc.Sequence[int], None subject_ids: Subjects to include in the dataset. Possible values: [0, 1, 4, 5, 6, 18, 20, 38, 41-54]. Defaults to `None` which includes all subjects.
+    :param str contrast: MRI contrast to return: `"T1"`, `"T2"`, `"T2*"` or `"PD"`. Defaults to ``"T1"``.
+    :param bool download: Download missing subjects. Defaults to `True`.
     :param collections.abc.Callable, None transform: Optional volume transform.
+    :param str, pathlib.Path, None root: Root directory of dataset. Directory path from where we load and save the dataset.
     """
 
     def __init__(
         self,
-        root: str | Path | None = None,
         subject_ids: int | list[int] = 0,
         contrast: Literal["T1", "T2", "T2*", "PD"] = "T1",
+        download: bool = True,
+        root: str | Path | None = None,
         transform: Callable | None = None,
     ) -> None:
         try:
             from brainweb_dl import get_mri
         except ImportError as error:  # pragma: no cover
             raise ImportError(
-                "BrainwebMRI requires brainweb-dl. Install it with "
+                "BrainWebMRI requires brainweb-dl. Install it with "
                 "`pip install deepinv[dataset]`."
             ) from error
 
-        self.root = resolve_root(root, "BrainwebMRI")
+        self.root = resolve_root(root, "BrainWebMRI")
         self.subject_ids = (
             [subject_ids] if isinstance(subject_ids, int) else subject_ids
         )
@@ -56,5 +56,5 @@ class BrainwebMRI(ImageDataset):
             contrast=self.contrast,
             brainweb_dir=self.root,
         )
-        volume = torch.from_numpy(np.asarray(volume, dtype=np.float32)).unsqueeze(0)
+        volume = torch.from_numpy(volume).unsqueeze(0) / 4095
         return self.transform(volume) if self.transform is not None else volume

--- a/deepinv/datasets/brainweb_mri.py
+++ b/deepinv/datasets/brainweb_mri.py
@@ -35,8 +35,7 @@ class BrainWebMRI(ImageDataset):
             from brainweb_dl import get_mri
         except ImportError as error:  # pragma: no cover
             raise ImportError(
-                "BrainWebMRI requires brainweb-dl. Install it with "
-                "`pip install deepinv[dataset]`."
+                "BrainWebMRI requires brainweb-dl. Install it with `pip install deepinv[dataset]`."
             ) from error
 
         self.root = resolve_root(root, "BrainWebMRI")
@@ -44,6 +43,7 @@ class BrainWebMRI(ImageDataset):
             [subject_ids] if isinstance(subject_ids, int) else subject_ids
         )
         self.contrast = contrast
+        self.download = download
         self.transform = transform
         self.get_mri = get_mri
 
@@ -51,10 +51,25 @@ class BrainWebMRI(ImageDataset):
         return len(self.subject_ids)
 
     def __getitem__(self, index: int) -> torch.Tensor:
+        subject_id = self.subject_ids[index]
+        if subject_id == 0 and self.contrast in ("T1", "T2", "PD"):
+            filename = f"{self.contrast}_ICBM_normal_1mm_pn0_rf0.nii.gz"
+        elif subject_id != 0 and self.contrast == "T1":
+            filename = f"subject{subject_id:02d}_t1w.nii.gz"
+        elif subject_id == 0:
+            filename = "phantom_1.0mm_normal_fuzzy.nii.gz"
+        else:
+            filename = f"brainweb_s{subject_id:02d}_fuzzy.nii.gz"
+        if not self.download and not (self.root / filename).exists():
+            raise FileNotFoundError(
+                f"BrainWeb MRI data for subject {subject_id} with "
+                f"contrast {self.contrast!r} was not found at `{self.root / filename}`. "
+                "Set `download=True` to download it."
+            )
         volume = self.get_mri(
-            sub_id=self.subject_ids[index],
+            sub_id=subject_id,
             contrast=self.contrast,
             brainweb_dir=self.root,
         )
-        volume = torch.from_numpy(volume).unsqueeze(0) / 4095
+        volume = torch.from_numpy(volume).to(torch.float32).unsqueeze(0) / 4095
         return self.transform(volume) if self.transform is not None else volume

--- a/deepinv/datasets/brainweb_mri.py
+++ b/deepinv/datasets/brainweb_mri.py
@@ -14,9 +14,16 @@ class BrainWebMRI(ImageDataset):
     BrainWeb brain phantom for Magnetic Resonance Imaging (MRI) research :footcite:p:`collinsDesignConstructionRealistic1998`.
     The dataset consists of 22 MRI brain phantom scans: 21 normal brains and 1 multiple sclerosis brain (patient 1).
     Several contrasts are available for each patient: T1, T2, T2* and PD.
-    Each volume has shape (1, 181, 217, 181).
+    Each T1 volume has shape (1, 181, 256, 256) and is scaled by 1 / 4095 to that it is normalized with values in [0, 1].
 
-    :param int, collections.abc.Sequence[int], None subject_ids: Subjects to include in the dataset. Possible values: [0, 1, 4, 5, 6, 18, 20, 38, 41-54]. Defaults to `None` which includes all subjects.
+    This dataset relies on the original implementation of Pierre-Antoine Comby:
+    <https://github.com/paquiteau/brainweb-dl>`_. Install it with `pip install brainweb-dl`.
+
+    .. note::
+        For a version of this dataset with dedicated features for emission tomography, such
+        as emission / attenuation maps and hot lesions, see :class:`deepinv.datasets.BrainWebPET`.
+
+    :param int, collections.abc.Sequence[int], None subject_ids: Subjects to include in the dataset. Possible values: [4, 5, 6, 18, 20, 38, 41-54]. Defaults to all subjects.
     :param str contrast: MRI contrast to return: `"T1"`, `"T2"`, `"T2*"` or `"PD"`. Defaults to ``"T1"``.
     :param bool download: Download missing subjects. Defaults to `True`.
     :param collections.abc.Callable, None transform: Optional volume transform.
@@ -25,7 +32,7 @@ class BrainWebMRI(ImageDataset):
 
     def __init__(
         self,
-        subject_ids: int | list[int] = 0,
+        subject_ids: int | list[int] | None = None,
         contrast: Literal["T1", "T2", "T2*", "PD"] = "T1",
         download: bool = True,
         root: str | Path | None = None,
@@ -39,6 +46,8 @@ class BrainWebMRI(ImageDataset):
             ) from error
 
         self.root = resolve_root(root, "BrainWebMRI")
+        if subject_ids is None:
+            subject_ids = [4, 5, 6, 18, 20, 38, *range(41, 55)]
         self.subject_ids = (
             [subject_ids] if isinstance(subject_ids, int) else subject_ids
         )
@@ -52,12 +61,8 @@ class BrainWebMRI(ImageDataset):
 
     def __getitem__(self, index: int) -> torch.Tensor:
         subject_id = self.subject_ids[index]
-        if subject_id == 0 and self.contrast in ("T1", "T2", "PD"):
-            filename = f"{self.contrast}_ICBM_normal_1mm_pn0_rf0.nii.gz"
-        elif subject_id != 0 and self.contrast == "T1":
+        if self.contrast == "T1":
             filename = f"subject{subject_id:02d}_t1w.nii.gz"
-        elif subject_id == 0:
-            filename = "phantom_1.0mm_normal_fuzzy.nii.gz"
         else:
             filename = f"brainweb_s{subject_id:02d}_fuzzy.nii.gz"
         if not self.download and not (self.root / filename).exists():

--- a/deepinv/datasets/brainweb_pet.py
+++ b/deepinv/datasets/brainweb_pet.py
@@ -26,6 +26,10 @@ class BrainWebPET(ImageDataset):
     <https://github.com/casperdcl/brainweb>`_. Install it with `pip install brainweb`.
     See the original implementation for a detailed description of the keyword arguments.
 
+    .. note::
+        For a version of this dataset dedicated to magnetic resonance imaging, which contains
+        more contrast options, see :class:`deepinv.datasets.BrainWebMRI`.
+
     :param str, pathlib.Path, None root: Dataset directory. Defaults to the DeepInv cache.
     :param int, collections.abc.Sequence[int], None subject_ids: Subjects to include in the dataset. Defaults to `None` which includes all subjects.
     :param bool download: Download missing subjects. Defaults to `True`.

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -16,7 +16,7 @@ import h5py
 
 import deepinv as dinv
 from deepinv.datasets import (
-    BrainwebMRI,
+    BrainWebMRI,
     DIV2K,
     Urban100HR,
     Set14HR,
@@ -1579,7 +1579,7 @@ def test_RandomPatchSampler(make_data):
 
 def test_brainweb_mri(tmp_path):
     pytest.importorskip("brainweb_dl")
-    dataset = BrainwebMRI(
+    dataset = BrainWebMRI(
         root=tmp_path,
         subject_ids=0,
         transform=lambda x: x / x.max(),

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -1592,6 +1592,23 @@ def test_brainweb_mri(tmp_path):
     assert volume.min() == 0
     assert volume.max() == 1
 
+    cached_dataset = BrainWebMRI(root=tmp_path, subject_ids=0, download=False)
+    assert cached_dataset[0].shape == (1, 181, 217, 181)
+
+    for subject_id, contrast, filename in [
+        (0, "T1", "T1_ICBM_normal_1mm_pn0_rf0.nii.gz"),
+        (0, "T2*", "phantom_1.0mm_normal_fuzzy.nii.gz"),
+        (4, "T1", "subject04_t1w.nii.gz"),
+        (4, "T2", "brainweb_s04_fuzzy.nii.gz"),
+    ]:
+        with pytest.raises(FileNotFoundError, match=filename):
+            BrainWebMRI(
+                root=tmp_path / "missing",
+                subject_ids=subject_id,
+                contrast=contrast,
+                download=False,
+            )[0]
+
 
 @pytest.mark.parametrize("kind", ["zipfile", "tarball", "rarfile"])
 def test_extract_archive(tmp_path, kind):

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -1618,25 +1618,26 @@ def test_brainweb_pet(tmp_path, lesion_diameters):
 
 def test_brainweb_mri(tmp_path):
     pytest.importorskip("brainweb_dl")
+    default_dataset = BrainWebMRI(root=tmp_path)
+    assert default_dataset.subject_ids == [4, 5, 6, 18, 20, 38, *range(41, 55)]
+
     dataset = BrainWebMRI(
         root=tmp_path,
-        subject_ids=0,
+        subject_ids=4,
         transform=lambda x: x / x.max(),
     )
     volume = dataset[0]
 
     assert len(dataset) == 1
-    assert volume.shape == (1, 181, 217, 181)
+    assert volume.shape == (1, 181, 256, 256)
     assert volume.dtype == torch.float32
     assert volume.min() == 0
     assert volume.max() == 1
 
-    cached_dataset = BrainWebMRI(root=tmp_path, subject_ids=0, download=False)
-    assert cached_dataset[0].shape == (1, 181, 217, 181)
+    cached_dataset = BrainWebMRI(root=tmp_path, subject_ids=4, download=False)
+    assert cached_dataset[0].shape == (1, 181, 256, 256)
 
     for subject_id, contrast, filename in [
-        (0, "T1", "T1_ICBM_normal_1mm_pn0_rf0.nii.gz"),
-        (0, "T2*", "phantom_1.0mm_normal_fuzzy.nii.gz"),
         (4, "T1", "subject04_t1w.nii.gz"),
         (4, "T2", "brainweb_s04_fuzzy.nii.gz"),
     ]:

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -16,6 +16,7 @@ import h5py
 
 import deepinv as dinv
 from deepinv.datasets import (
+    BrainwebMRI,
     DIV2K,
     Urban100HR,
     Set14HR,
@@ -1574,6 +1575,22 @@ def test_RandomPatchSampler(make_data):
     assert len(ds) == 2
     x, y = next(iter(ds))
     assert math.isnan(x)
+
+
+def test_brainweb_mri(tmp_path):
+    pytest.importorskip("brainweb_dl")
+    dataset = BrainwebMRI(
+        root=tmp_path,
+        subject_ids=0,
+        transform=lambda x: x / x.max(),
+    )
+    volume = dataset[0]
+
+    assert len(dataset) == 1
+    assert volume.shape == (1, 181, 217, 181)
+    assert volume.dtype == torch.float32
+    assert volume.min() == 0
+    assert volume.max() == 1
 
 
 @pytest.mark.parametrize("kind", ["zipfile", "tarball", "rarfile"])

--- a/docs/source/api/deepinv.datasets.rst
+++ b/docs/source/api/deepinv.datasets.rst
@@ -68,7 +68,7 @@ Image Datasets
     deepinv.datasets.FMD
     deepinv.datasets.Kohler
     deepinv.datasets.NBUDataset
-    deepinv.datasets.BrainwebMRI
+    deepinv.datasets.BrainWebMRI
 
 
 Other Datasets

--- a/docs/source/api/deepinv.datasets.rst
+++ b/docs/source/api/deepinv.datasets.rst
@@ -68,6 +68,7 @@ Image Datasets
     deepinv.datasets.FMD
     deepinv.datasets.Kohler
     deepinv.datasets.NBUDataset
+    deepinv.datasets.BrainwebMRI
 
 
 Other Datasets

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1500,3 +1500,16 @@ journal = {ACM Trans. Graph.}
   year={2025},
   publisher={IEEE}
 }
+
+@article{collinsDesignConstructionRealistic1998,
+  title = {Design and Construction of a Realistic Digital Brain Phantom},
+  author = {Collins, D. L. and Zijdenbos, A. P. and Kollokian, V. and Sled, J. G. and Kabani, N. J. and Holmes, C. J. and Evans, A. C.},
+  year = 1998,
+  month = jun,
+  journal = {IEEE transactions on medical imaging},
+  volume = {17},
+  number = {3},
+  pages = {463--468},
+  doi = {10.1109/42.712135},
+  pmid = {9735909}
+}

--- a/docs/source/user_guide/training/datasets.rst
+++ b/docs/source/user_guide/training/datasets.rst
@@ -220,6 +220,12 @@ All these datasets inherit from :class:`deepinv.datasets.ImageDataset`.
      - Cx256x256 multispectral (C=4 or 8) and 1x1024x1024 panchromatic
      - Multispectral satellite images of urban scenes from 6 different satellites.
 
+   * - :class:`BrainWebMRI <deepinv.datasets.BrainWebMRI>`
+     - `x`
+     - 22 BrainWeb MRI subjects
+     - 1x181x217x181 voxels
+     - 3D MRI volumes with T1, T2, T2* or PD contrast.
+
 
 .. _data-transforms:
 

--- a/docs/source/user_guide/training/datasets.rst
+++ b/docs/source/user_guide/training/datasets.rst
@@ -228,7 +228,7 @@ All these datasets inherit from :class:`deepinv.datasets.ImageDataset`.
 
    * - :class:`BrainWebMRI <deepinv.datasets.BrainWebMRI>`
      - `x`
-     - 22 BrainWeb MRI subjects
+     - 20 MRI brain volumes
      - 1x181x217x181 voxels
      - 3D MRI volumes with T1, T2, T2* or PD contrast.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ physics = [
 
 # optional dependencies for specific datasets
 dataset = [
+    "brainweb-dl>=0.4.6",
     "datasets>=3.5.0",
     "pandas",
     "pydicom",
@@ -172,7 +173,10 @@ scipy = "*"
 nibabel = "*"
 rasterio = "*"
 pydicom = "*"
-# mat73 is PyPI-only, stays in optional deps
+# brainweb-dl and mat73 are PyPI-only, stay in optional deps
+
+[tool.pixi.feature.dataset.pypi-dependencies]
+brainweb-dl = ">=0.4.6"
 
 [tool.pixi.feature.denoisers.dependencies]
 scipy = "*"


### PR DESCRIPTION
This PR adds the MRI version of the Brainweb dataset, mainly wrapping @paquiteau's repository https://github.com/paquiteau/brainweb-dl.

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.