### PR TITLE
Fix global fixed point iteration counter increased by failed backtracking

### DIFF
--- a/deepinv/optim/fixed_point.py
+++ b/deepinv/optim/fixed_point.py
@@ -321,10 +321,12 @@ class FixedPoint(nn.Module):
         if self.anderson_acceleration_config is not None:
             self.init_anderson_acceleration(X)
 
-        for it in tqdm(
-            range(self.max_iter),
+        it = 0
+        progress_bar = tqdm(
+            total=self.max_iter,
             disable=(not self.verbose or not self.show_progress_bar),
-        ):
+        )
+        while it < self.max_iter:
             X_prev = X
             X = self.single_iteration(X, it, *args, **kwargs)
 
@@ -338,12 +340,15 @@ class FixedPoint(nn.Module):
                 )
 
                 # Convergence check
-                if (
+                converged = (
                     self.early_stop
                     and self.check_conv_fn is not None
                     and it > 1
                     and self.check_conv_fn(it, X_prev, X)
-                ):
+                )
+                it += 1
+                progress_bar.update()
+                if converged:
                     break
 
             else:
@@ -354,10 +359,11 @@ class FixedPoint(nn.Module):
                     if self.verbose:
                         print(
                             f"[Stopping] Reached maximum number of failed backtracking checks "
-                            f"({self.max_iter_backtracking})."
+                            f"({self.backtracking_config.max_iter})."
                         )
                     break
 
+        progress_bar.close()
         return X, metrics
 
     def single_iteration(

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -369,6 +369,45 @@ OPTIM_ALGO_PARAMS = [
 ]
 
 
+def test_fixed_point_backtracking(device):
+    stepsize = 4.0
+    iteration_indices = []
+
+    def iterator(X, *args):
+        x = X["est"][0] + stepsize
+        return {"est": (x,), "cost": None}
+
+    iterator.cost_fn = None
+
+    def backtracking_check(X_prev, X):
+        nonlocal stepsize
+        if stepsize > 1.0:
+            stepsize *= 0.5
+            return False
+        return True
+
+    fixed_point = dinv.optim.FixedPoint(
+        iterator=iterator,
+        update_params_fn=lambda it: iteration_indices.append(it),
+        init_iterate_fn=lambda init, **kwargs: {"est": (init,), "cost": None},
+        init_metrics_fn=lambda X, **kwargs: [],
+        update_metrics_fn=lambda m, _, X, **kwargs: m + [X["est"][0].clone()],
+        backtracking_check_fn=backtracking_check,
+        max_iter=2,
+        early_stop=False,
+        backtracking_config=dinv.optim.BacktrackingConfig(max_iter=20),
+    )
+    x0 = torch.zeros(1, device=device)
+
+    X, metrics = fixed_point(init=x0, compute_metrics=True)
+
+    assert torch.equal(X["est"][0], torch.full_like(x0, 2.0))
+    assert iteration_indices == [0, 0, 0, 1]
+    assert len(metrics) == fixed_point.max_iter
+    assert torch.equal(torch.stack(metrics), x0.new_tensor([[1.0], [2.0]]))
+    assert stepsize == 1.0
+
+
 @pytest.mark.parametrize(
     "name_algo, and_acc",
     OPTIM_ALGO_PARAMS,


### PR DESCRIPTION
Fixes the bug identified in #1272, and adds a small test related to backtracking in the fixed point class.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.