### PR TITLE
Compute per-sample statistics for norm_inputs="standardize" (fixes #908)

### DIFF
--- a/deepinv/loss/metric/metric.py
+++ b/deepinv/loss/metric/metric.py
@@ -28,7 +28,7 @@ class Metric(Module):
         the data must either be of complex dtype or have size 2 in the channel dimension (usually the second dimension after batch).
     :param bool train_loss: if higher is better, invert metric. If lower is better, does nothing.
     :param str reduction: a method to reduce metric score over individual batch scores. ``mean``: takes the mean, ``sum`` takes the sum, ``none`` or None no reduction will be applied (default).
-    :param str norm_inputs: normalize images before passing to metric. ``l2`` normalizes by :math:`\ell_2` spatial norm, ``min_max`` normalizes by min and max of each input, ``clip`` clips to :math:`[0,1]`, ``standardize`` standardizes to same mean and std as ground truth, ``none`` or None no normalization will be applied (default).
+    :param str norm_inputs: normalize images before passing to metric. ``l2`` normalizes by :math:`\ell_2` spatial norm, ``min_max`` normalizes by min and max of each input, ``clip`` clips to :math:`[0,1]`, ``standardize`` standardizes each sample to the same mean and std as its corresponding ground truth sample (statistics are computed per sample, not over the batch), ``none`` or None no normalization will be applied (default).
     :param int, tuple[int], None center_crop: If not `None` (default), center crop the tensor(s) before computing the metrics.
         If an `int` is provided, the cropping is applied equally on all spatial dimensions (by default, all dimensions except the first two).
         If `tuple` of `int`, cropping is performed over the last `len(center_crop)` dimensions. If positive values are provided, a standard center crop is applied.
@@ -234,7 +234,13 @@ class Metric(Module):
                 raise ValueError(
                     "Both x and x_net must not be None in order to use standardize."
                 )
-            x_net = (x_net - x_net.mean()) / x_net.std() * x.std() + x.mean()
+            # Stats per sample, so batching does not change the result
+            non_batched_dims = list(range(1, x_net.ndim))
+            mean = x.mean(dim=non_batched_dims, keepdim=True)
+            std = x.std(dim=non_batched_dims, keepdim=True)
+            mean_net = x_net.mean(dim=non_batched_dims, keepdim=True)
+            std_net = x_net.std(dim=non_batched_dims, keepdim=True)
+            x_net = (x_net - mean_net) / std_net * std + mean
 
         x_net = self.normalizer(x_net)
         x = self.normalizer(x) if x is not None else None

--- a/deepinv/tests/test_metric.py
+++ b/deepinv/tests/test_metric.py
@@ -372,6 +372,23 @@ def test_metric_kwargs():
         atol=0.0001,
     )
 
+    # Test standardize uses per-sample stats, not batch-wide
+    x_hat = torch.tensor([[1.0, 2.0], [30.0, 40.0], [-5.0, 5.0]])
+    x = torch.tensor([[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]])
+    batched = metric.MSE(norm_inputs="standardize")(x_hat, x)
+    individual = torch.cat(
+        [
+            metric.MSE(norm_inputs="standardize")(x_hat[i : i + 1], x[i : i + 1])
+            for i in range(x.shape[0])
+        ]
+    )
+    assert torch.allclose(batched, individual)
+
+    # Standardizing against itself is a no-op
+    assert torch.allclose(
+        metric.MSE(norm_inputs="standardize")(x, x), torch.zeros(x.shape[0])
+    )
+
     # Test complex_abs
     x = torch.tensor([[[1.0, 2.0], [1.0, 2.0]]])
     x = torch.complex(x[:, 0, :], x[:, 0, :])  # tensor([[1.+1.j, 2.+2.j]])

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -44,6 +44,7 @@ Fixed
 - Fix inversion in :class:`deepinv.transform.Reflect` (:gh:`1236` by `Sarra Amiri`_)
 - (Breaking) Have `x_shift` represent horizontal shifts and `y_shift` vertical shifts in :class:`deepinv.transform.Shift` (:gh:`1236` by `Sarra Amiri`_)
 - Force trainer non_blocking_transfers=False on MPS and CPU (:gh:`1311` by `Andrew Wang`_)
+- (Breaking) Compute per-sample statistics in :class:`deepinv.loss.metric.Metric` when ``norm_inputs="standardize"``, instead of statistics over the whole batch, so that a sample's score no longer depends on the other samples it is batched with (:gh:`1317` by `digvijaysing`_)
 
 
 v0.4.1
@@ -687,3 +688,4 @@ Changed
 .. _Irène Waldspurger: https://github.com/IWalds
 .. _Kushagra Shukla: https://github.com/Kushagra481
 .. _Sarra Amiri: https://github.com/amirisarra18-jpg
+.. _digvijaysing: https://github.com/itsDigvijaysing


### PR DESCRIPTION
Fixes #908.

`Metric.forward` computed mean and std over the whole tensor, batch dimension included,
so a sample's score changed depending on which other samples were in its batch. The
docstring says it standardizes to the same mean and std as the ground truth, which
implies per sample.

Statistics are now computed per sample (all dims except the batch dim), the same way
`normalize_signal` already does it.

```python
x_hat = torch.tensor([[1.0, 2.0], [30.0, 40.0], [-5.0, 5.0]])
x     = torch.tensor([[0.0, 1.0], [2.0,  3.0], [ 4.0, 5.0]])

MSE(norm_inputs="standardize")(x_hat, x)
# before: tensor([ 1.0241,  5.4739, 10.5409])
# after:  tensor([0., 0., 0.])
```

Passing those samples one at a time already gave `[0, 0, 0]`, so the batched and
unbatched paths disagreed. Added a test that checks they now match.

This changes scores for anyone using `standardize` with batch size > 1, so I marked it
`(Breaking)` in the changelog. Nothing else in the library uses `standardize`.

The issue also mentions making the reduction level configurable (batch / sample /
channel). I kept this to the minimal fix, but happy to add the option if you prefer.

Ran pytest deepinv/tests/test_metric.py (179 passed); did not run the full suite locally."

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.
