### PR TITLE
Migrating from LinearPhysics to Physics.linear PoC

### DIFF
--- a/deepinv/distributed/distrib_framework.py
+++ b/deepinv/distributed/distrib_framework.py
@@ -8,7 +8,8 @@ import warnings
 import torch
 import torch.distributed as dist
 
-from deepinv.physics import Physics, LinearPhysics
+from deepinv.physics import Physics
+from deepinv.physics.forward import _linear_alias_metaclass
 from deepinv.optim.data_fidelity import DataFidelity
 from deepinv.utils.tensorlist import TensorList
 
@@ -304,6 +305,8 @@ class DistributedStackedPhysics(Physics):
             p_i = factory(i, ctx.device, self.factory_kwargs)
             self.local_physics.append(p_i)
 
+        self.linear = all(getattr(p, "linear", False) for p in self.local_physics)
+
     # -------- Factorized map-reduce logic --------
     def _map_reduce_gather(
         self,
@@ -383,70 +386,6 @@ class DistributedStackedPhysics(Physics):
             **kwargs,
         )
 
-
-class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
-    r"""
-    Distributed linear physics operators.
-
-    This class extends :class:`DistributedStackedPhysics` for linear operators. It provides distributed
-    operations that automatically handle communication and reductions.
-
-    .. note::
-
-        This class is intended to distribute a *collection* of linear operators (e.g.,
-        :class:`deepinv.physics.StackedLinearPhysics` or an explicit Python list of
-        :class:`deepinv.physics.LinearPhysics` objects) across ranks. It is **not** a
-        mechanism to shard a single linear operator internally.
-
-    If you have one linear physics operator that can naturally be split into multiple
-    operators, you must do that split yourself (build a stacked/list representation) and
-    provide those operators through the `factory`.
-
-    All linear operations (`A_adjoint`, `A_vjp`, etc.) support a `reduce_op` parameter:
-
-        - If `reduce_op='sum'` (default): The method computes the global result by performing a single all-reduce across all ranks.
-        - If `reduce_op=None`: The method computes only the local contribution from operators owned by this rank, without any inter-rank communication. This is useful for deferring reductions in custom algorithms. Beware, using `reduce_op=None` may lead to errors or incorrect results if the full global operation is required (e.g., for correct gradients in training) and should be used with caution.
-
-    :param DistributedContext ctx: distributed context manager.
-    :param int num_operators: total number of physics operators to distribute.
-    :param Callable factory: factory function that creates linear physics operators.
-        Should have signature `factory(index: int, device: torch.device, factory_kwargs: dict | None) -> LinearPhysics`.
-    :param dict | None factory_kwargs: shared data dictionary passed to factory function for all operators. Default is `None`.
-    :param torch.dtype | None dtype: data type for operations. Default is `None`.
-    :param str gather_strategy: strategy for gathering distributed results in forward operations.
-        Options are `'naive'`, `'concatenated'`, or `'broadcast'`. Default is `'concatenated'`.
-    """
-
-    def __init__(
-        self,
-        ctx: DistributedContext,
-        num_operators: int,
-        factory,
-        *,
-        factory_kwargs: dict | None = None,
-        dtype: torch.dtype | None = None,
-        gather_strategy: str = "concatenated",
-        **kwargs,
-    ):
-        r"""
-        Initialize distributed linear physics operators.
-        """
-        super().__init__(
-            ctx=ctx,
-            num_operators=num_operators,
-            factory=factory,
-            factory_kwargs=factory_kwargs,
-            dtype=dtype,
-            gather_strategy=gather_strategy,
-            A=lambda x, **kw: x,
-            A_adjoint=lambda y, **kw: y,
-            **kwargs,
-        )
-
-        for p in self.local_physics:
-            if not isinstance(p, LinearPhysics):
-                raise ValueError("factory must return LinearPhysics instances.")
-
     def A_adjoint(
         self,
         y: TensorList | list[torch.Tensor],
@@ -461,12 +400,18 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
         across all ranks to obtain the complete :math:`A^T y = \sum_{i=1}^n A_i^T y_i` where :math:`A` is the
         stacked operator :math:`A = [A_1, A_2, \ldots, A_n]`, :math:`A_i` and :math:`y_i` are the individual linear operators and measurements respectively.
 
+        Only available when ``self.linear=True``, i.e. when every local physics operator is linear.
+
         :param TensorList | list[torch.Tensor] y: full list of measurements from all operators.
         :param bool gather: whether to gather results across ranks. If False, returns local contribution. Default is `True`.
         :param str | None reduce_op: reduction operation to apply across ranks. If `None`, no reduction (neither local or global) is performed, reduction must be performed manually to produce complete adjoint result :math:`A^T y`. Default is `"sum"`.
         :param kwargs: optional parameters for the adjoint operation.
         :return: complete adjoint result :math:`A^T y` (or local contribution if gather=False).
         """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_adjoint requires all local physics to have linear=True."
+            )
 
         # Extract local measurements
         if len(y) == self.num_operators:
@@ -502,6 +447,8 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
         Extracts local cotangent vectors, computes local VJP contributions, and reduces
         across all ranks to obtain the complete VJP.
 
+        Only available when ``self.linear=True``, i.e. when every local physics operator is linear.
+
         :param torch.Tensor x: input tensor.
         :param TensorList | list[torch.Tensor] v: full list of cotangent vectors from all operators.
         :param bool gather: whether to gather results across ranks. If False, returns local contribution. Default is `True`.
@@ -509,6 +456,10 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
         :param kwargs: optional parameters for the VJP operation.
         :return: complete VJP result (or local contribution if gather=False).
         """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_vjp requires all local physics to have linear=True."
+            )
 
         if len(v) == self.num_operators:
             v_local = [v[i] for i in self.local_indexes]
@@ -540,12 +491,18 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
         Computes the complete normal operator :math:`A^T A x = \sum_i A_i^T A_i x` by
         combining local contributions from all ranks.
 
+        Only available when ``self.linear=True``, i.e. when every local physics operator is linear.
+
         :param torch.Tensor x: input tensor.
         :param bool gather: whether to gather results across ranks. If False, returns local contribution. Default is `True`.
         :param str | None reduce_op: reduction operation to apply across ranks. If `None`, no reduction (neither local or global) is performed, reduction must be performed manually to produce complete  result :math:`A^T A x`. Default is `"sum"`.
         :param kwargs: optional parameters for the operation.
         :return: complete :math:`A^T A x` result (or local contribution if gather=False).
         """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_adjoint_A requires all local physics to have linear=True."
+            )
 
         return self._map_reduce_gather(
             x,
@@ -567,6 +524,8 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
         For stacked operators, this computes :math:`A A^T y` where :math:`A^T y = \sum_i A_i^T y_i`
         and then applies the forward operator to get :math:`[A_1(A^T y), A_2(A^T y), \ldots, A_n(A^T y)]`.
 
+        Only available when ``self.linear=True``, i.e. when every local physics operator is linear.
+
         .. note::
 
             Unlike other operations, the adjoint step `A^T y` is always computed globally (with full
@@ -580,6 +539,10 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
         :param kwargs: optional parameters for the operation.
         :return: TensorList with entries :math:`A_i A^T y` for all operators (or local list if `gather=False`).
         """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_A_adjoint requires all local physics to have linear=True."
+            )
 
         # First compute A^T y globally (always with reduction to get the full adjoint)
         # This is necessary because A_A_adjoint(y) = A(A^T y) and A^T y = sum_i A_i^T y_i
@@ -615,6 +578,8 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
             with distributed :meth:`A_adjoint_A` and :meth:`A_A_adjoint` operations.
             This computes the exact pseudoinverse but requires communication at every iteration.
 
+        Only available when ``self.linear=True``, i.e. when every local physics operator is linear.
+
         :param TensorList | list[torch.Tensor] y: measurements to invert.
         :param str solver: least squares solver to use (only for `local_only=False`).
             Choose between `'CG'`, `'lsqr'`, `'BiCGStab'` and `'minres'`. Default is `'CG'`.
@@ -629,6 +594,11 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
         :return: pseudoinverse solution. If `local_only=True`, returns approximation.
             If `local_only=False`, returns exact least squares solution.
         """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_dagger requires all local physics to have linear=True."
+            )
+
         if local_only:
             # Efficient local computation with single sum reduction
             if isinstance(y, TensorList):
@@ -690,6 +660,8 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
             with communication at every power iteration. This computes the exact norm but is
             communication-intensive.
 
+        Only available when ``self.linear=True``, i.e. when every local physics operator is linear.
+
         :param torch.Tensor x0: an unbatched tensor sharing its shape, dtype and device with the initial iterate.
         :param int max_iter: maximum number of iterations for power method. Default is `50`.
         :param float tol: relative variation criterion for convergence. Default is `1e-3`.
@@ -702,6 +674,10 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
         :return: Squared spectral norm. If `local_only=True`, returns upper bound.
             If `local_only=False`, returns exact value.
         """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.compute_sqnorm requires all local physics to have linear=True."
+            )
 
         if local_only:
             # Efficient local computation with single max reduction
@@ -728,6 +704,66 @@ class DistributedStackedLinearPhysics(DistributedStackedPhysics, LinearPhysics):
             verbose_flag = verbose and self.ctx.rank == 0
             return super().compute_sqnorm(
                 x0, max_iter=max_iter, tol=tol, verbose=verbose_flag, **kwargs
+            )
+
+
+class DistributedStackedLinearPhysics(
+    DistributedStackedPhysics,
+    metaclass=_linear_alias_metaclass(DistributedStackedPhysics),
+):
+    r"""
+    Deprecated alias of :class:`deepinv.distributed.DistributedStackedPhysics`.
+
+    .. deprecated::
+
+        :class:`deepinv.distributed.DistributedStackedPhysics` now supports linear physics
+        operators directly (its linearity, ``physics.linear``, is derived automatically from the
+        local physics operators built by the factory). This class is kept only for backward
+        compatibility (including ``isinstance`` checks against it, and the eager validation that
+        the factory returns linear operators) and will be removed in a future version.
+
+    :param DistributedContext ctx: distributed context manager.
+    :param int num_operators: total number of physics operators to distribute.
+    :param Callable factory: factory function that creates linear physics operators.
+        Should have signature `factory(index: int, device: torch.device, factory_kwargs: dict | None) -> Physics`.
+    :param dict | None factory_kwargs: shared data dictionary passed to factory function for all operators. Default is `None`.
+    :param torch.dtype | None dtype: data type for operations. Default is `None`.
+    :param str gather_strategy: strategy for gathering distributed results in forward operations.
+        Options are `'naive'`, `'concatenated'`, or `'broadcast'`. Default is `'concatenated'`.
+    """
+
+    def __init__(
+        self,
+        ctx: DistributedContext,
+        num_operators: int,
+        factory,
+        *,
+        factory_kwargs: dict | None = None,
+        dtype: torch.dtype | None = None,
+        gather_strategy: str = "concatenated",
+        **kwargs,
+    ):
+        warnings.warn(
+            "DistributedStackedLinearPhysics is deprecated and will be removed in a future "
+            "version. Use DistributedStackedPhysics instead — linearity is now derived "
+            "automatically from the local physics operators via `.linear`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(
+            ctx=ctx,
+            num_operators=num_operators,
+            factory=factory,
+            factory_kwargs=factory_kwargs,
+            dtype=dtype,
+            gather_strategy=gather_strategy,
+            **kwargs,
+        )
+
+        if not self.linear:
+            raise ValueError(
+                "factory must return physics instances with linear=True when using "
+                "DistributedStackedLinearPhysics."
             )
 
 
@@ -1015,10 +1051,14 @@ class DistributedDataFidelity:
             return self.single_fidelity
         return self.local_data_fidelities[i]
 
-    def _check_is_distributed_physics(self, physics: DistributedStackedLinearPhysics):
-        if not isinstance(physics, DistributedStackedLinearPhysics):
+    def _check_is_distributed_physics(self, physics: DistributedStackedPhysics):
+        if not isinstance(physics, DistributedStackedPhysics):
             raise ValueError(
-                "physics must be a DistributedStackedLinearPhysics instance to be used with DistributedDataFidelity."
+                "physics must be a DistributedStackedPhysics instance to be used with DistributedDataFidelity."
+            )
+        if not physics.linear:
+            raise ValueError(
+                "physics must be linear (physics.linear=True) to be used with DistributedDataFidelity."
             )
 
     def _apply_op(

--- a/deepinv/distributed/distribute.py
+++ b/deepinv/distributed/distribute.py
@@ -4,8 +4,8 @@ from typing import Callable
 
 import torch
 
-from deepinv.physics import Physics, LinearPhysics
-from deepinv.physics.forward import StackedPhysics, StackedLinearPhysics
+from deepinv.physics import Physics
+from deepinv.physics.forward import StackedPhysics
 from deepinv.optim.data_fidelity import DataFidelity, StackedPhysicsDataFidelity
 from deepinv.optim.prior import Prior
 from deepinv.models.base import Denoiser
@@ -54,7 +54,7 @@ def _distribute_physics(
     :return: Distributed version of the input Physics object.
     """
     # Physics factory
-    if isinstance(physics, (StackedPhysics, StackedLinearPhysics)):
+    if isinstance(physics, StackedPhysics):
         # Extract physics_list from StackedPhysics
         physics_list_extracted = physics.physics_list
         num_operators = len(physics_list_extracted)
@@ -79,24 +79,20 @@ def _distribute_physics(
         ):
             return physics_list_extracted[idx].to(device)
 
-    if type_object == "linear_physics":
-        return DistributedStackedLinearPhysics(
-            ctx,
-            num_operators=num_operators,
-            factory=physics_factory,
-            dtype=dtype,
-            gather_strategy=gather_strategy,
-            **kwargs,
+    result = DistributedStackedPhysics(
+        ctx,
+        num_operators=num_operators,
+        factory=physics_factory,
+        dtype=dtype,
+        gather_strategy=gather_strategy,
+        **kwargs,
+    )
+    if type_object == "linear_physics" and not result.linear:
+        raise ValueError(
+            "factory must return physics instances with linear=True when "
+            "type_object='linear_physics'."
         )
-    else:
-        return DistributedStackedPhysics(
-            ctx,
-            num_operators=num_operators,
-            factory=physics_factory,
-            dtype=dtype,
-            gather_strategy=gather_strategy,
-            **kwargs,
-        )
+    return result
 
 
 def _distribute_processor(
@@ -320,19 +316,17 @@ def distribute(
     """
     # Check object type and distribute accordingly
     if type_object == "auto":
-        if isinstance(object, (StackedPhysics, StackedLinearPhysics)) or (
+        if isinstance(object, StackedPhysics) or (
             isinstance(object, list)
             and len(object) > 0
             and isinstance(object[0], Physics)
         ):
-            type_object = (
-                "linear_physics"
-                if isinstance(object, (StackedLinearPhysics, list))
-                and (
-                    not isinstance(object, list) or isinstance(object[0], LinearPhysics)
-                )
-                else "physics"
+            is_linear = (
+                object.linear
+                if isinstance(object, StackedPhysics)
+                else getattr(object[0], "linear", False)
             )
+            type_object = "linear_physics" if is_linear else "physics"
         elif isinstance(object, (DataFidelity, StackedPhysicsDataFidelity)) or (
             isinstance(object, list)
             and len(object) > 0

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 import torch.nn.utils.parametrize as P
 from torch import Tensor, nn
 
-from deepinv.physics import Denoising, LinearPhysics
+from deepinv.physics import Denoising, Physics
 from deepinv.optim.linear import conjugate_gradient
 from .base import Reconstructor
 from .utils import load_state_dict_from_url
@@ -156,14 +156,14 @@ class DEAL(Reconstructor):
         return self.model.mask
 
     def forward(
-        self, y: torch.Tensor, physics: LinearPhysics | None = None, sigma: float = None
+        self, y: torch.Tensor, physics: Physics | None = None, sigma: float = None
     ) -> torch.Tensor:
         """
         Run DEAL as either a denoiser or a reconstructor.
 
         :param torch.Tensor y: input measurements
-        :param LinearPhysics | None physics: forward operator for reconstruction. If
-            ``None``, DEAL is applied as a denoiser.
+        :param Physics | None physics: forward operator for reconstruction (``physics.linear``
+            should be `True`). If ``None``, DEAL is applied as a denoiser.
         :param float | None sigma: denoising noise level used when ``physics`` is
             ``None``
         :return: reconstructed or denoised image
@@ -177,7 +177,7 @@ class DEAL(Reconstructor):
         if (
             sigma is None
             and physics is not None
-            and not isinstance(physics, LinearPhysics)
+            and not getattr(physics, "linear", False)
         ):
             sigma = physics
             physics = None

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 from torch import Tensor
 
 import deepinv as dinv
-from deepinv.physics import LinearPhysicsMultiScaler, PhysicsCropper
+from deepinv.physics import PhysicsMultiScaler, PhysicsCropper
 from deepinv.utils.tensorlist import TensorList
 from deepinv.models.base import Reconstructor, Denoiser
 from .utils import load_state_dict_from_url
@@ -250,7 +250,7 @@ class RAM(Reconstructor, Denoiser):
         :param torch.Tensor y: measurements
         """
         img_channels = x0.shape[1]
-        physics = LinearPhysicsMultiScaler(physics, x0.shape[-3:], device=x0.device)
+        physics = PhysicsMultiScaler(physics, x0.shape[-3:], device=x0.device)
 
         y_list = []
         for scale in [0, 1, 2, 3]:

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -14,7 +14,6 @@ from deepinv.optim.distance import (
     ZeroDistance,
 )
 
-import deepinv as dinv
 
 from deepinv.optim.potential import Potential
 from deepinv.physics.functional import dct_2d, idct_2d

--- a/deepinv/optim/data_fidelity.py
+++ b/deepinv/optim/data_fidelity.py
@@ -312,7 +312,7 @@ class L2(DataFidelity):
         r"""
         Calculates the gradient of the data fidelity term :math:`\datafidname` at :math:`x`.
 
-        The gradient is either computed using the chain rule, or using specific implementation of deepinv.physics.LinearPhysics.A_adjoint_A in the case of a LinearPhysics.
+        The gradient is either computed using the chain rule, or using specific implementation of deepinv.physics.Physics.A_adjoint_A in the case of a linear physics (``physics.linear=True``).
         Formally, the chain rule is given as
 
         .. math::
@@ -332,7 +332,7 @@ class L2(DataFidelity):
         :param deepinv.physics.Physics physics: physics model.
         :return: (:class:`torch.Tensor`) gradient :math:`\nabla_x \datafid{x}{y}`, computed in :math:`x`.
         """
-        if isinstance(physics, dinv.physics.LinearPhysics):
+        if getattr(physics, "linear", False):
             return self.norm * (physics.A_adjoint_A(x) - physics.A_adjoint(y))
         else:
             return super().grad(x, y, physics, *args, **kwargs)

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -4,7 +4,7 @@ import torch
 import torch.fft as fft
 from torch import Tensor
 import torch.nn.functional as F
-from deepinv.physics.forward import LinearPhysics, DecomposablePhysics, adjoint_function
+from deepinv.physics.forward import Physics, DecomposablePhysics, adjoint_function
 import deepinv.physics.functional as dF
 from deepinv.utils.mixins import TiledMixin2d
 from deepinv.utils._internal import _as_pair, _add_tuple
@@ -12,7 +12,7 @@ from deepinv.utils._tiling import _resolve_tiling_params, _compute_needed_pad
 from deepinv.utils.decorators import _deprecated_func_replaced_by
 
 
-class Downsampling(LinearPhysics):
+class Downsampling(Physics):
     r"""
     Downsampling operator for super-resolution problems.
 
@@ -69,7 +69,7 @@ class Downsampling(LinearPhysics):
                 stacklevel=2,
             )
             filter = None
-        super().__init__(device=device, **kwargs)
+        super().__init__(device=device, linear=True, **kwargs)
         self.imsize = tuple(img_size) if isinstance(img_size, list) else img_size
         self.imsize_dynamic = (3, 128, 128)  # placeholder
         self.padding = padding
@@ -360,7 +360,7 @@ class Downsampling(LinearPhysics):
             r = torch.real(fft.ifft2(rc))
             return (z_hat - r) * gamma
         else:
-            return LinearPhysics.prox_l2(self, z, y, gamma, **kwargs)
+            return Physics.prox_l2(self, z, y, gamma, **kwargs)
 
     @staticmethod
     def check_factor(factor: int | float | Tensor) -> int:
@@ -440,7 +440,7 @@ class Upsampling(Downsampling):
         return super().prox_l2(z, y, gamma, **kwargs)
 
 
-class Blur(LinearPhysics):
+class Blur(Physics):
     r"""
 
     Blur operator.
@@ -501,7 +501,7 @@ class Blur(LinearPhysics):
         device: torch.device = torch.device("cpu"),
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(linear=True, **kwargs)
         self.device = device
         self.padding = padding
         assert (
@@ -737,7 +737,7 @@ class BlurFFT(DecomposablePhysics):
         super().update_parameters(**filter_parameters)
 
 
-class SpaceVaryingBlur(LinearPhysics):
+class SpaceVaryingBlur(Physics):
     r"""
     Space varying blur via product-convolution.
 
@@ -792,7 +792,7 @@ class SpaceVaryingBlur(LinearPhysics):
         device: torch.device | str = "cpu",
         **kwargs,
     ):
-        super().__init__(device=device, **kwargs)
+        super().__init__(device=device, linear=True, **kwargs)
 
         self.register_buffer("filters", filters)
         self.register_buffer("multipliers", multipliers)
@@ -868,7 +868,7 @@ class SpaceVaryingBlur(LinearPhysics):
         super().update_parameters(filters=filters, multipliers=multipliers, **kwargs)
 
 
-class TiledSpaceVaryingBlur(TiledMixin2d, LinearPhysics):
+class TiledSpaceVaryingBlur(TiledMixin2d, Physics):
     r"""
     Space varying blur via tiled-convolution.
 
@@ -955,7 +955,11 @@ class TiledSpaceVaryingBlur(TiledMixin2d, LinearPhysics):
         **kwargs,
     ):
         super().__init__(
-            patch_size=patch_size, stride=stride, pad_if_needed=True, **kwargs
+            patch_size=patch_size,
+            stride=stride,
+            pad_if_needed=True,
+            linear=True,
+            **kwargs,
         )
         # Always use pad_if_needed=True to ensure that the image is padded to fit an integer number of patches, and the extra padding is removed automatically after processing.
 

--- a/deepinv/physics/cassi.py
+++ b/deepinv/physics/cassi.py
@@ -3,12 +3,12 @@ import torch
 from torch import Tensor
 from torch.nn.functional import pad
 
-from deepinv.physics.forward import LinearPhysics
+from deepinv.physics.forward import Physics
 from deepinv.physics.generator import BernoulliSplittingMaskGenerator
 from deepinv.physics.functional.convolution import conv2d
 
 
-class CompressiveSpectralImaging(LinearPhysics):
+class CompressiveSpectralImaging(Physics):
     r"""Compressive Hyperspectral Imaging operator.
 
     Coded-aperture snapshot spectral imaging (CASSI) operator, which is a popular
@@ -70,7 +70,7 @@ class CompressiveSpectralImaging(LinearPhysics):
         rng: torch.Generator = None,
         **kwargs,
     ):
-        super().__init__(device=device, **kwargs)
+        super().__init__(device=device, linear=True, **kwargs)
 
         if len(img_size) != 3:
             raise ValueError("img_size must be (C, H, W)")

--- a/deepinv/physics/compressed_sensing.py
+++ b/deepinv/physics/compressed_sensing.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from deepinv.physics.forward import LinearPhysics
+from deepinv.physics.forward import Physics
 from deepinv.utils.nn import devices_equal
 import torch
 import numpy as np
@@ -29,7 +29,7 @@ def dst1(x: Tensor) -> Tensor:
     return x.view(*x_shape)
 
 
-class CompressedSensing(LinearPhysics):
+class CompressedSensing(Physics):
     r"""
     Compressed Sensing forward operator. Creates a random sampling :math:`m \times n` matrix where :math:`n` is the
     number of elements of the signal, i.e., ``np.prod(img_size)`` and ``m`` is the number of measurements.
@@ -92,7 +92,7 @@ class CompressedSensing(LinearPhysics):
         rng: torch.Generator = None,
         **kwargs,
     ):
-        super().__init__(device=device, **kwargs)
+        super().__init__(device=device, linear=True, **kwargs)
         self.name = f"CS_m{m}"
         self.img_size = img_size
         self.channelwise = channelwise

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -1016,7 +1016,9 @@ class ComposedPhysics(Physics):
         return self.physics_list[item]
 
 
-class ComposedLinearPhysics(ComposedPhysics, metaclass=_linear_alias_metaclass(ComposedPhysics)):
+class ComposedLinearPhysics(
+    ComposedPhysics, metaclass=_linear_alias_metaclass(ComposedPhysics)
+):
     r"""
     Deprecated alias of :class:`deepinv.physics.ComposedPhysics`.
 
@@ -1592,7 +1594,9 @@ class StackedPhysics(Physics):
         )
 
 
-class StackedLinearPhysics(StackedPhysics, metaclass=_linear_alias_metaclass(StackedPhysics)):
+class StackedLinearPhysics(
+    StackedPhysics, metaclass=_linear_alias_metaclass(StackedPhysics)
+):
     r"""
     Deprecated alias of :class:`deepinv.physics.StackedPhysics`.
 

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -31,44 +31,130 @@ class Physics(torch.nn.Module):  # parent class for forward models
     and :math:`N:\yset\mapsto \yset` is a stochastic mapping which characterizes the noise affecting
     the measurements.
 
+    If :math:`A` is linear, set ``linear=True``. This unlocks a family of methods that are only
+    well-defined for linear operators: :meth:`A_adjoint`, :meth:`A_A_adjoint`, :meth:`A_adjoint_A`,
+    :meth:`adjointness_test`, :meth:`condition_number` and :meth:`prox_l2`, as well as
+    linear-operator-specific behavior of :meth:`A_vjp`, :meth:`A_dagger` and :meth:`compute_norm`/
+    :meth:`compute_sqnorm`. This functionality used to live on the (now deprecated)
+    :class:`deepinv.physics.LinearPhysics` class; it is now available directly on ``Physics`` by
+    setting ``linear=True``, which also makes ``isinstance(physics, LinearPhysics)`` return `True`
+    for backward compatibility.
+
     :param Callable A: forward operator function which maps an image to the observed measurements :math:`x\mapsto y`.
+        It is recommended to normalize it to have unit norm when ``linear=True``.
+    :param None, Callable A_adjoint: (only used if ``linear=True``) transpose of the forward operator, which
+        should verify the adjointness test. By default, it is set to `None`, which means that the adjoint is
+        computed automatically using :func:`deepinv.physics.adjoint_function`. This automatic adjoint is
+        computed using automatic differentiation, which is slower than a closed form adjoint, and can have a
+        larger memory footprint. If you want to use the automatic adjoint, you should set the `img_size`
+        parameter. If you have a closed form for the adjoint, you can pass it as a callable function or
+        rewrite the class method.
     :param deepinv.physics.NoiseModel, Callable noise_model: function that adds noise to the measurements :math:`\noise{z}`.
         See the noise module for some predefined functions.
     :param Callable sensor_model: function that incorporates any sensor non-linearities to the sensing process,
         such as quantization or saturation, defined as a function :math:`\sensor{z}`, such that
         :math:`y=\sensor{\noise{\forw{x}}}`. By default, the `sensor_model` is set to the identity :math:`\sensor{z}=z`.
-    :param int max_iter: If the operator does not have a closed form pseudoinverse, the gradient descent algorithm
-        is used for computing it, and this parameter fixes the maximum number of gradient descent iterations.
-    :param float tol: If the operator does not have a closed form pseudoinverse, the gradient descent algorithm
-        is used for computing it, and this parameter fixes the absolute tolerance of the gradient descent algorithm.
-    :param str solver: least squares solver to use. Only gradient descent is available for non-linear operators.
+    :param tuple img_size: (only used if ``linear=True``, and only required if `A_adjoint` is not provided)
+        Size of the signal/image `x`, e.g. `(C, ...)` where `C` is the number of channels and `...` are the
+        spatial dimensions, used for the automatic adjoint computation.
+    :param int max_iter: If the operator does not have a closed form pseudoinverse, an iterative algorithm
+        is used for computing it, and this parameter fixes the maximum number of iterations.
+    :param float tol: If the operator does not have a closed form pseudoinverse, an iterative algorithm
+        is used for computing it, and this parameter fixes the tolerance of the algorithm.
+    :param str solver: least squares solver to use. Only gradient descent is available for non-linear
+        operators. Defaults to `'gradient_descent'` if ``linear=False``, `'lsqr'` if ``linear=True``. For
+        linear operators, choose between `'CG'`, `'lsqr'`, `'BiCGStab'` and `'minres'` (see
+        :func:`deepinv.optim.linear.least_squares` for more details).
+    :param bool implicit_backward_solver: (only used if ``linear=True``) If `True`, uses implicit
+        differentiation for computing gradients through :meth:`A_dagger` and :meth:`prox_l2`, using
+        :func:`deepinv.optim.linear.least_squares_implicit_backward` instead of
+        :func:`deepinv.optim.linear.least_squares`. This can significantly reduce memory consumption,
+        especially when using many iterations. If `False`, uses the standard autograd mechanism, which can
+        be memory-intensive. Default is `True`.
+    :param torch.device, str device: (only used if ``linear=True``) cpu or cuda, every registered buffer and
+        module parameters are recursively pushed onto the device during initialization.
+    :param bool linear: whether the forward operator :math:`A` is linear. Defaults to `False`.
     """
 
     def __init__(
         self,
         A: Callable = lambda x, **kwargs: x,
+        A_adjoint: Callable | None = None,
+        img_size: tuple | None = None,
         noise_model: NoiseModel | None = None,
         sensor_model: Callable = lambda x: x,
-        solver: str = "gradient_descent",
         max_iter: int = 50,
         tol: float = 1e-4,
+        solver: str | None = None,
+        implicit_backward_solver: bool = True,
+        device: torch.device | str = "cpu",
+        linear: bool = False,
         **kwargs,
     ):
         if noise_model is None:
             noise_model = ZeroNoise()
         super().__init__()
+        self.linear = linear
         self.noise_model = noise_model
         self.sensor_model = sensor_model
         self.forw = A
         self.SVD = False  # flag indicating SVD available
         self.max_iter = max_iter
         self.tol = tol
-        self.solver = solver
+        self.solver = solver or ("lsqr" if linear else "gradient_descent")
+
+        if linear:
+            self.A_adj = A_adjoint
+            self.img_size = img_size
+            self.implicit_backward_solver = implicit_backward_solver
+
+            _lstsq_conv_iter = 20  # heuristic number of iterations for convergence
+            if self.implicit_backward_solver and self.max_iter < _lstsq_conv_iter:
+                warnings.warn(
+                    "Using implicit_backward_solver with a low number of iterations may produce inaccurate gradients during the backward pass. If you are not doing backpropagation through `A_dagger` or `prox_l2`, ignore this message. If you are training unfolded models, consider increasing max_iter."
+                )
+
+            device_holder = torch.tensor(0.0, device=device)
+            self.register_buffer("_device_holder", device_holder, persistent=False)
+            # pushes all parameters/buffers to the specified device, including `noise_model`
+            self.to(device)
 
         if len(kwargs) > 0:
             warnings.warn(
                 f"Arguments {kwargs} are passed to {self.__class__.__name__} but are ignored."
             )
+
+    @property
+    def device(self) -> torch.device | str:
+        r"""
+        Returns the device where the physics parameters/buffers are stored.
+
+        Only available when ``linear=True``.
+
+        :return: device of the physics parameters.
+        """
+        warnings.warn(
+            "Following torch.nn.Module's design, the 'device' attribute is deprecated and will be removed in a future version. To move the module's buffers/parameters to a different device, use the `to()` method.",
+            DeprecationWarning,
+        )
+
+        return self._device_holder.device
+
+    @device.setter
+    def device(self, value: torch.device | str):
+        r"""
+        Sets the device where the physics parameters/buffers are stored.
+
+        Only available when ``linear=True``.
+
+        :param device: device to which the physics parameters will be moved.
+        """
+        warnings.warn(
+            "Following torch.nn.Module's design, the 'device' attribute is deprecated and will be removed in a future version, i.e. doing `physics.device = device` will no longer work and throw an `AttributeError`. Use `physics.to(device)` instead.",
+            DeprecationWarning,
+        )
+
+        self.to(value)
 
     def __mul__(self, other):
         r"""
@@ -80,11 +166,11 @@ class Physics(torch.nn.Module):  # parent class for forward models
         :return: (:class:`deepinv.physics.Physics`) concatenated operator
 
         """
-
-        warnings.warn(
-            "You are composing two physics objects. The resulting physics will not retain the original attributes. "
-            "You may instead retrieve attributes of the original physics by indexing the resulting physics."
-        )
+        if not (self.linear and getattr(other, "linear", False)):
+            warnings.warn(
+                "You are composing two physics objects. The resulting physics will not retain the original attributes. "
+                "You may instead retrieve attributes of the original physics by indexing the resulting physics."
+            )
         return compose(other, self, max_iter=self.max_iter, tol=self.tol)
 
     def stack(self, other):
@@ -158,7 +244,109 @@ class Physics(torch.nn.Module):  # parent class for forward models
 
         return self.noise_model(x, **kwargs)
 
-    def A_dagger(self, y, x_init=None):
+    def A_adjoint(self, y, **kwargs):
+        r"""
+        Computes transpose of the forward operator :math:`\tilde{x} = A^{\top}y`.
+        If :math:`A` is linear, it should be the exact transpose of the forward matrix.
+
+        Only available when ``linear=True``.
+
+        .. note::
+
+            If the problem is non-linear, there is not a well-defined transpose operation,
+            but defining one can be useful for some reconstruction networks, such as :class:`deepinv.models.ArtifactRemoval`.
+            In that case, override this method in a subclass instead of relying on the default implementation.
+
+        :param torch.Tensor y: measurements.
+        :param None, torch.Tensor params: optional additional parameters for the adjoint operator.
+        :return: (:class:`torch.Tensor`) linear reconstruction :math:`\tilde{x} = A^{\top}y`.
+
+        """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_adjoint is undefined because physics.linear=False. "
+                "Set linear=True, or override A_adjoint in a subclass if a custom transpose-like "
+                "operator makes sense for your non-linear physics."
+            )
+        if self.A_adj is None:
+            if self.img_size is None:
+                raise ValueError(
+                    "img_size must be set for using the automatic A_adjoint implementation."
+                    "Set img_size in the constructor of the Physics class or pass it as a keyword argument."
+                )
+            else:
+                tensor_size = (y.shape[0],) + self.img_size
+            return adjoint_function(self.A, tensor_size, device=y.device)(y, **kwargs)
+        else:
+            return self.A_adj(y, **kwargs)
+
+    def A_vjp(self, x, v):
+        r"""
+        Computes the product between a vector :math:`v` and the Jacobian of the forward operator :math:`A` evaluated at :math:`x`, defined as:
+
+        .. math::
+
+            A_{vjp}(x, v) = \left. \frac{\partial A}{\partial x}  \right|_x^\top  v.
+
+        If ``linear=True``, this is computed as :math:`A_{vjp}(x, v) = \conj{A} v = A^{\top}v`, i.e., it is
+        equal to :meth:`A_adjoint` and does not depend on :math:`x`. Otherwise, the Jacobian is computed using
+        automatic differentiation.
+
+        :param torch.Tensor x: signal/image.
+        :param torch.Tensor v: vector.
+        :return: (:class:`torch.Tensor`) the VJP product between :math:`v` and the Jacobian.
+        """
+        if self.linear:
+            return self.A_adjoint(v)
+        _, vjpfunc = torch.func.vjp(self.A, x)
+        return vjpfunc(v)[0]
+
+    def A_A_adjoint(self, y, **kwargs):
+        r"""
+        A helper function that computes :math:`A A^{\top}y`.
+
+        Only available when ``linear=True``.
+
+        This function can speed up computation when :math:`A A^{\top}` is available in closed form.
+        Otherwise it just calls :func:`deepinv.physics.Physics.A` and :func:`deepinv.physics.Physics.A_adjoint`.
+
+        :param torch.Tensor y: measurement.
+        :return: (:class:`torch.Tensor`) the product :math:`AA^{\top}y`.
+        """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_A_adjoint is undefined because physics.linear=False."
+            )
+        return self.A(self.A_adjoint(y, **kwargs), **kwargs)
+
+    def A_adjoint_A(self, x, **kwargs):
+        r"""
+        A helper function that computes :math:`A^{\top}Ax`.
+
+        Only available when ``linear=True``.
+
+        This function can speed up computation when :math:`A^{\top}A` is available in closed form.
+        Otherwise it just calls :func:`deepinv.physics.Physics.A` and :func:`deepinv.physics.Physics.A_adjoint`.
+
+        :param torch.Tensor x: signal/image.
+        :return: (:class:`torch.Tensor`) the product :math:`A^{\top}Ax`.
+        """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_adjoint_A is undefined because physics.linear=False."
+            )
+        return self.A_adjoint(self.A(x, **kwargs), **kwargs)
+
+    def A_dagger(
+        self,
+        y,
+        x_init=None,
+        solver="CG",
+        max_iter=None,
+        tol=None,
+        verbose=False,
+        **kwargs,
+    ):
         r"""
         Computes an inverse as:
 
@@ -166,38 +354,80 @@ class Physics(torch.nn.Module):  # parent class for forward models
 
             x^* \in \underset{x}{\arg\min} \quad \|\forw{x}-y\|^2.
 
-        This function uses gradient descent to find the inverse. It can be overwritten by a more efficient pseudoinverse in cases where closed form formulas exist.
+        If ``linear=False``, this function uses gradient descent to find the inverse (it can be overwritten by
+        a more efficient pseudoinverse in cases where closed form formulas exist). If ``linear=True``, this
+        function uses a least squares solver instead (`x_init` is then ignored).
 
         :param torch.Tensor y: a measurement :math:`y` to reconstruct via the pseudoinverse.
-        :param None, torch.Tensor x_init: initial guess for the reconstruction. If `None` (default) it is set to the adjoint of the forward operator (it it exists) applied to the measurements :math:`y`, i.e., :math:`x_0 = A^{\top}y`.
+        :param None, torch.Tensor x_init: (only used if ``linear=False``) initial guess for the reconstruction.
+            If `None` (default) it is set to the adjoint of the forward operator (if it exists) applied to the
+            measurements :math:`y`, i.e., :math:`x_0 = A^{\top}y`.
+        :param str solver: (only used if ``linear=True``) least squares solver to use. Choose between `'CG'`,
+            `'lsqr'`, `'BiCGStab'` and `'minres'`. See :func:`deepinv.optim.linear.least_squares` for more details.
         :return: (:class:`torch.Tensor`) The reconstructed image :math:`x`.
 
         """
-        if self.solver == "gradient_descent":
-            if x_init is None:
-                if hasattr(self, "A_adjoint"):
-                    x_init = self.A_adjoint(y)
-                else:
-                    raise ValueError(
-                        "x_init must be provided for gradient descent solver if the physics does not have"
-                        " A_adjoint defined."
-                    )
+        if not self.linear:
+            if self.solver == "gradient_descent":
+                if x_init is None:
+                    try:
+                        x_init = self.A_adjoint(y)
+                    except (AttributeError, NotImplementedError):
+                        raise ValueError(
+                            "x_init must be provided for gradient descent solver if the physics does not have"
+                            " A_adjoint defined."
+                        )
 
-            x = x_init
+                x = x_init
 
-            lr = 1e-1
-            loss = torch.nn.MSELoss()
-            for _ in range(self.max_iter):
-                x = x - lr * self.A_vjp(x, self.A(x) - y)
-                err = loss(self.A(x), y)
-                if err < self.tol:
-                    break
-        else:
-            raise NotImplementedError(
-                f"Solver {self.solver} not implemented for A_dagger"
+                lr = 1e-1
+                loss = torch.nn.MSELoss()
+                for _ in range(self.max_iter):
+                    x = x - lr * self.A_vjp(x, self.A(x) - y)
+                    err = loss(self.A(x), y)
+                    if err < self.tol:
+                        break
+            else:
+                raise NotImplementedError(
+                    f"Solver {self.solver} not implemented for A_dagger"
+                )
+
+            return x.clone()
+
+        if max_iter is not None:
+            self.max_iter = max_iter
+        if tol is not None:
+            self.tol = tol
+        if solver is not None:
+            self.solver = solver
+        if not self.implicit_backward_solver:
+            return least_squares(
+                self.A,
+                self.A_adjoint,
+                y,
+                parallel_dim=[0],
+                AAT=self.A_A_adjoint,
+                verbose=verbose,
+                ATA=self.A_adjoint_A,
+                max_iter=self.max_iter,
+                tol=self.tol,
+                solver=self.solver,
+                **kwargs,
             )
-
-        return x.clone()
+        else:
+            return least_squares_implicit_backward(
+                self,
+                y,
+                z=None,
+                init=None,
+                parallel_dim=[0],
+                gamma=1e8,  # Large gamma to approximate A_dagger
+                verbose=verbose,
+                max_iter=self.max_iter,
+                tol=self.tol,
+                solver=self.solver,
+                **kwargs,
+            )
 
     def set_ls_solver(self, solver, max_iter=None, tol=None):
         r"""
@@ -218,23 +448,6 @@ class Physics(torch.nn.Module):  # parent class for forward models
         if tol is not None:
             self.tol = tol
         self.solver = solver
-
-    def A_vjp(self, x, v):
-        r"""
-        Computes the product between a vector :math:`v` and the Jacobian of the forward operator :math:`A` evaluated at :math:`x`, defined as:
-
-        .. math::
-
-            A_{vjp}(x, v) = \left. \frac{\partial A}{\partial x}  \right|_x^\top  v.
-
-        By default, the Jacobian is computed using automatic differentiation.
-
-        :param torch.Tensor x: signal/image.
-        :param torch.Tensor v: vector.
-        :return: (:class:`torch.Tensor`) the VJP product between :math:`v` and the Jacobian.
-        """
-        _, vjpfunc = torch.func.vjp(self.A, x)
-        return vjpfunc(v)[0]
 
     def update(self, **kwargs):
         r"""
@@ -335,25 +548,280 @@ class Physics(torch.nn.Module):  # parent class for forward models
 
         return copy.deepcopy(self, memo=memo)
 
-    def compute_norm(self, x, verbose=True):
+    def compute_sqnorm(
+        self,
+        x0: torch.Tensor,
+        *,
+        max_iter: int = 100,
+        tol: float = 1e-3,
+        verbose: bool = True,
+        rng: torch.Generator | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
         r"""
-        Computes an estimate of the operator norm of the forward operator :math:`\|A\|_2` at point `x`.
+        Computes the squared spectral :math:`\ell_2` norm of the operator :math:`A`.
 
-        This function uses the power method to compute the operator norm.
+        If ``linear=True``, this is equivalent to computing the spectral norm of :math:`A^{\top}A`, i.e.,
+        :math:`\|A^{\top}A\|_2`. If ``linear=False``, this is computed via :meth:`A_vjp` and :meth:`A_jvp`
+        (the latter must be implemented by the subclass).
 
-        :param torch.Tensor x: input tensor used to estimate the norm.
-        :param bool verbose: if `True`, prints the estimated norm.
-        :return: (:class:`torch.Tensor`) estimated operator norm.
+        Uses the `power method <https://en.wikipedia.org/wiki/Power_iteration>`_.
+
+        :param torch.Tensor x0: an unbatched tensor sharing its shape, dtype and device with the initial iterate of the algorithm (its values are ignored)
+        :param int max_iter: maximum number of iterations
+        :param float tol: relative variation criterion for convergence
+        :param bool verbose: print information
+        :param dict kwargs: optional parameters for the forward operator
+
+        :return: (torch.Tensor) squared spectral norm of :math:`A`, i.e., :math:`\|A^{\top}A\|_2 = \|A\|_2^2`.
+        """
+        if self.linear:
+            if rng is None:
+                rng = torch.Generator(x0.device)
+            return power_method(
+                operator=self.A_adjoint_A,
+                x0=x0,
+                max_iter=max_iter,
+                tol=tol,
+                verbose=verbose,
+                **kwargs,
+            )
+        else:
+            linear_operator = lambda v: self.A_vjp(x0, self.A_jvp(x0, v))
+            return power_method(
+                linear_operator, x0, max_iter=max_iter, tol=tol, verbose=verbose
+            )
+
+    def compute_norm(
+        self,
+        x0: torch.Tensor,
+        max_iter: int = 100,
+        tol: float = 1e-3,
+        verbose: bool = True,
+        squared: bool = True,
+        **kwargs,
+    ) -> torch.Tensor:
+        r"""
+        Computes the spectral :math:`\ell_2` norm (Lipschitz constant) of the operator :math:`A`.
+
+        .. warning::
+
+            By default, for backward compatibility, this method computes the **squared** spectral norm of :math:`A`,
+            i.e., :math:`\|A^{\top}A\|_2`. This behavior is deprecated and will change in a future version.
+            Set ``squared=False`` to compute the non-squared spectral norm :math:`\|A\|_2`, or use
+            :meth:`compute_sqnorm` to explicitly compute the squared norm.
+
+        Uses the `power method <https://en.wikipedia.org/wiki/Power_iteration>`_.
+
+        :param torch.Tensor x0: an unbatched tensor sharing its shape, dtype and device with the initial iterate of the algorithm (its values are ignored)
+        :param int max_iter: maximum number of iterations
+        :param float tol: relative variation criterion for convergence
+        :param bool verbose: print information
+        :param bool squared: If ``True`` (default, deprecated), computes :math:`\|A^{\top}A\|_2` (squared spectral norm of :math:`A`).
+            Use :meth:`compute_sqnorm` instead.
+            If ``False``, computes :math:`\|A\|_2` (spectral norm of :math:`A`).
+        :param dict kwargs: optional parameters for the forward operator
+
+        :return: (torch.Tensor) spectral norm. If ``squared=True``, returns :math:`\|A^{\top}A\|_2` (squared spectral norm of :math:`A`).
+            If ``squared=False``, returns :math:`\|A\|_2` (spectral norm of :math:`A`).
+        """
+        if squared is True:
+            warnings.warn(
+                "Using `compute_norm(squared=True)` is deprecated. "
+                "Use `compute_sqnorm()` instead to compute the squared spectral norm (||A^T A||_2). "
+                "In a future version, `compute_norm()` will compute the non-squared spectral norm (||A||_2) by default.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+        elif squared is not False:
+            raise ValueError(f"squared must be True or False, got {squared}")
+
+        # Compute squared norm using compute_sqnorm
+        sqnorm = self.compute_sqnorm(
+            x0, max_iter=max_iter, tol=tol, verbose=verbose, **kwargs
+        )
+
+        # Return squared or non-squared norm based on parameter
+        if squared:
+            return sqnorm
+        else:
+            return sqnorm.sqrt()
+
+    def adjointness_test(self, u, **kwargs):
+        r"""
+        Numerically check that :math:`A^{\top}` is indeed the adjoint of :math:`A`.
+
+        Only available when ``linear=True``.
+
+        :param torch.Tensor u: initialization point of the adjointness test method
+
+        :return: (float) a quantity that should be theoretically 0. In practice, it should be of the order of the chosen dtype precision (i.e. single or double).
 
         """
-        linear_operator = lambda v: self.A_vjp(x, self.A_jvp(x, v))
-        norm = power_method(linear_operator, x, max_iter=100, tol=1e-6)
-        return norm
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.adjointness_test is undefined because physics.linear=False."
+            )
+        u_in = u  # .type(self.dtype)
+        Au = self.A(u_in, **kwargs)
+
+        if isinstance(Au, tuple) or isinstance(Au, list):
+            V = [randn_like(au) for au in Au]
+            Atv = self.A_adjoint(V, **kwargs)
+            s1 = 0
+            for au, v in zip(Au, V, strict=True):
+                s1 += (v.conj() * au).flatten().sum()
+
+        else:
+            v = randn_like(Au)
+            Atv = self.A_adjoint(v, **kwargs)
+
+            s1 = (v.conj() * Au).flatten().sum()
+
+        s2 = (Atv * u_in.conj()).flatten().sum()
+
+        return s1.conj() - s2
+
+    def condition_number(self, x, max_iter=500, tol=1e-6, verbose=False, **kwargs):
+        r"""
+        Computes an approximation of the condition number of the linear operator :math:`A`.
+
+        Only available when ``linear=True``.
+
+        Uses the LSQR algorithm, see :func:`deepinv.optim.linear.lsqr` for more details.
+
+        :param torch.Tensor x: Any input tensor (e.g. random)
+        :param int max_iter: maximum number of iterations
+        :param float tol: relative variation criterion for convergence
+        :param bool verbose: print information
+        :return: (:class:`torch.Tensor`) condition number of the operator
+        """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.condition_number is undefined because physics.linear=False."
+            )
+        y = self.A(x, **kwargs)
+        _, cond = lsqr(
+            self.A,
+            self.A_adjoint,
+            y,
+            max_iter=max_iter,
+            verbose=verbose,
+            tol=tol,
+            parallel_dim=None,
+            **kwargs,
+        )
+
+        return cond
+
+    def prox_l2(
+        self, z, y, gamma, solver="CG", max_iter=None, tol=None, verbose=False, **kwargs
+    ):
+        r"""
+        Computes proximal operator of :math:`f(x) = \frac{1}{2}\|Ax-y\|^2`, i.e.,
+
+        .. math::
+
+            \underset{x}{\arg\min} \; \frac{\gamma}{2}\|Ax-y\|^2 + \frac{1}{2}\|x-z\|^2
+
+        Only available when ``linear=True``.
+
+        :param torch.Tensor y: measurements tensor
+        :param torch.Tensor, float, int, None z: signal tensor
+        :param float gamma: hyperparameter of the proximal operator
+        :param str solver: solver to use for the proximal operator, see :func:`deepinv.optim.linear.least_squares` for details
+        :param int max_iter: maximum number of iterations for iterative solvers
+        :param float tol: tolerance for iterative solvers
+        :param bool verbose: whether to print information during the solver execution
+        :param int scale: scale at which to apply the physics operator
+        :return: (:class:`torch.Tensor`) estimated signal tensor
+
+        """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.prox_l2 is undefined because physics.linear=False."
+            )
+        if max_iter is not None:
+            self.max_iter = max_iter
+        if tol is not None:
+            self.tol = tol
+        if solver is not None:
+            self.solver = solver
+
+        if z is None or isinstance(z, float) or isinstance(z, int):
+            z = torch.full_like(
+                self.A_adjoint(y), fill_value=0.0 if z is None else float(z)
+            )
+
+        if not self.implicit_backward_solver:
+            return least_squares(
+                self.A,
+                self.A_adjoint,
+                y,
+                solver=solver,
+                gamma=gamma,
+                verbose=verbose,
+                init=z,
+                z=z,
+                parallel_dim=[0],
+                ATA=self.A_adjoint_A,
+                AAT=self.A_A_adjoint,
+                max_iter=self.max_iter,
+                tol=self.tol,
+                **kwargs,
+            )
+        else:
+            return least_squares_implicit_backward(
+                self,
+                y,
+                z=z,
+                init=z,
+                solver=solver,
+                gamma=gamma,
+                verbose=verbose,
+                max_iter=self.max_iter,
+                tol=self.tol,
+                parallel_dim=[0],
+                **kwargs,
+            )
 
 
-class LinearPhysics(Physics):
+def _linear_alias_metaclass(structural_cls):
+    r"""
+    Builds a metaclass whose ``isinstance()`` check reflects ``physics.linear`` instead of literal
+    inheritance from ``structural_cls``.
+
+    This is what lets classes like :class:`deepinv.physics.LinearPhysics` be deprecated (i.e. no
+    longer used internally as a real base class) while ``isinstance(physics, LinearPhysics)`` keeps
+    working for any :class:`deepinv.physics.Physics` instance with ``physics.linear=True``,
+    regardless of its concrete class.
+
+    .. note::
+
+        Only ``isinstance()`` is supported this way; ``issubclass()`` still reflects literal
+        inheritance, since nothing in the library relies on ``issubclass`` against these classes.
+    """
+
+    class _LinearAliasMeta(type):
+        def __instancecheck__(cls, instance):
+            return isinstance(instance, structural_cls) and bool(
+                getattr(instance, "linear", False)
+            )
+
+    return _LinearAliasMeta
+
+
+class LinearPhysics(Physics, metaclass=_linear_alias_metaclass(Physics)):
     r"""
     Parent class for linear operators.
+
+    .. deprecated::
+
+        ``LinearPhysics`` is deprecated and will be removed in a future version. Use
+        :class:`deepinv.physics.Physics` with ``linear=True`` instead, e.g. subclass
+        :class:`deepinv.physics.Physics` and pass ``linear=True`` to ``super().__init__()``.
+        ``isinstance(physics, LinearPhysics)`` keeps working for any ``Physics`` instance with
+        ``physics.linear=True``, so existing checks against this class remain valid.
 
     It describes the linear forward measurement process of the form
 
@@ -439,427 +907,16 @@ class LinearPhysics(Physics):
 
     """
 
-    def __init__(
-        self,
-        A=lambda x, **kwargs: x,
-        A_adjoint=None,
-        img_size=None,
-        noise_model=ZeroNoise(),
-        sensor_model=lambda x: x,
-        max_iter=50,
-        tol=1e-4,
-        solver="lsqr",
-        implicit_backward_solver: bool = True,
-        device: torch.device | str = "cpu",
-        **kwargs,
-    ):
-        super().__init__(
-            A=A,
-            noise_model=noise_model,
-            sensor_model=sensor_model,
-            max_iter=max_iter,
-            solver=solver,
-            tol=tol,
-            **kwargs,
-        )
-        self.A_adj = A_adjoint
-        self.img_size = img_size
-        self.implicit_backward_solver = implicit_backward_solver
-
-        _lstsq_conv_iter = 20  # heuristic number of iterations for convergence
-        if self.implicit_backward_solver and self.max_iter < _lstsq_conv_iter:
-            warnings.warn(
-                "Using implicit_backward_solver with a low number of iterations may produce inaccurate gradients during the backward pass. If you are not doing backpropagation through `A_dagger` or `prox_l2`, ignore this message. If you are training unfolded models, consider increasing max_iter."
-            )
-
-        device_holder = torch.tensor(0.0, device=device)
-        self.register_buffer("_device_holder", device_holder, persistent=False)
-        # pushes all parameters/buffers to the specified device, including `noise_model`
-        self.to(device)
-
-    @property
-    def device(self) -> torch.device | str:
-        r"""
-        Returns the device where the physics parameters/buffers are stored.
-
-        :return: device of the physics parameters.
-        """
+    def __init__(self, *args, **kwargs):
         warnings.warn(
-            "Following torch.nn.Module's design, the 'device' attribute is deprecated and will be removed in a future version. To move the module's buffers/parameters to a different device, use the `to()` method.",
+            "LinearPhysics is deprecated and will be removed in a future version. "
+            "Use Physics(..., linear=True) instead, or subclass Physics directly and pass "
+            "linear=True to super().__init__().",
             DeprecationWarning,
+            stacklevel=2,
         )
-
-        return self._device_holder.device
-
-    @device.setter
-    def device(self, value: torch.device | str):
-        r"""
-        Sets the device where the physics parameters/buffers are stored.
-
-        :param device: device to which the physics parameters will be moved.
-        """
-        warnings.warn(
-            "Following torch.nn.Module's design, the 'device' attribute is deprecated and will be removed in a future version, i.e. doing `physics.device = device` will no longer work and throw an `AttributeError`. Use `physics.to(device)` instead.",
-            DeprecationWarning,
-        )
-
-        self.to(value)
-
-    def A_adjoint(self, y, **kwargs):
-        r"""
-        Computes transpose of the forward operator :math:`\tilde{x} = A^{\top}y`.
-        If :math:`A` is linear, it should be the exact transpose of the forward matrix.
-
-        .. note::
-
-            If the problem is non-linear, there is not a well-defined transpose operation,
-            but defining one can be useful for some reconstruction networks, such as :class:`deepinv.models.ArtifactRemoval`.
-
-        :param torch.Tensor y: measurements.
-        :param None, torch.Tensor params: optional additional parameters for the adjoint operator.
-        :return: (:class:`torch.Tensor`) linear reconstruction :math:`\tilde{x} = A^{\top}y`.
-
-        """
-        if self.A_adj is None:
-            if self.img_size is None:
-                raise ValueError(
-                    "img_size must be set for using the automatic A_adjoint implementation."
-                    "Set img_size in the constructor of the LinearPhysics class or pass it as a keyword argument."
-                )
-            else:
-                tensor_size = (y.shape[0],) + self.img_size
-            return adjoint_function(self.A, tensor_size, device=y.device)(y, **kwargs)
-        else:
-            return self.A_adj(y, **kwargs)
-
-    def A_vjp(self, x, v):
-        r"""
-        Computes the product between a vector :math:`v` and the Jacobian of the forward operator :math:`A` evaluated at :math:`x`, defined as:
-
-        .. math::
-
-            A_{vjp}(x, v) = \left. \frac{\partial A}{\partial x}  \right|_x^\top  v = \conj{A} v.
-
-        :param torch.Tensor x: signal/image.
-        :param torch.Tensor v: vector of the size of the measurements.
-        :return: (:class:`torch.Tensor`) the VJP product between :math:`v` and the Jacobian.
-        """
-        return self.A_adjoint(v)
-
-    def A_A_adjoint(self, y, **kwargs):
-        r"""
-        A helper function that computes :math:`A A^{\top}y`.
-
-        This function can speed up computation when :math:`A A^{\top}` is available in closed form.
-        Otherwise it just calls :func:`deepinv.physics.Physics.A` and :func:`deepinv.physics.LinearPhysics.A_adjoint`.
-
-        :param torch.Tensor y: measurement.
-        :return: (:class:`torch.Tensor`) the product :math:`AA^{\top}y`.
-        """
-        return self.A(self.A_adjoint(y, **kwargs), **kwargs)
-
-    def A_adjoint_A(self, x, **kwargs):
-        r"""
-        A helper function that computes :math:`A^{\top}Ax`.
-
-        This function can speed up computation when :math:`A^{\top}A` is available in closed form.
-        Otherwise it just calls :func:`deepinv.physics.Physics.A` and :func:`deepinv.physics.LinearPhysics.A_adjoint`.
-
-        :param torch.Tensor x: signal/image.
-        :return: (:class:`torch.Tensor`) the product :math:`A^{\top}Ax`.
-        """
-        return self.A_adjoint(self.A(x, **kwargs), **kwargs)
-
-    def __mul__(self, other, **kwargs):
-        r"""
-        Concatenates two linear forward operators :math:`A = A_1 \circ A_2` via the * operation
-
-        The resulting linear operator keeps the noise and sensor models of :math:`A_1`.
-
-        :param deepinv.physics.LinearPhysics other: Physics operator :math:`A_2`
-        :return: (:class:`deepinv.physics.LinearPhysics`) concatenated operator
-
-        """
-        return compose(other, self, max_iter=self.max_iter, tol=self.tol, **kwargs)
-
-    def stack(self, other):
-        r"""
-        Stacks forward operators :math:`A = \begin{bmatrix} A_1 \\ A_2 \end{bmatrix}`.
-
-        The measurements produced by the resulting model are :class:`deepinv.utils.TensorList` objects, where
-        each entry corresponds to the measurements of the corresponding operator.
-
-        .. note::
-
-            When using the ``stack`` operator between two noise objects, the operation will retain only the second
-            noise.
-
-        See :ref:`physics_combining` for more information.
-
-        :param deepinv.physics.Physics other: Physics operator :math:`A_2`
-        :return: (:class:`deepinv.physics.StackedPhysics`) stacked operator
-
-        """
-        return stack(self, other)
-
-    def compute_norm(
-        self,
-        x0: torch.Tensor,
-        max_iter: int = 100,
-        tol: float = 1e-3,
-        verbose: bool = True,
-        squared: bool = True,
-        **kwargs,
-    ) -> torch.Tensor:
-        r"""
-        Computes the spectral :math:`\ell_2` norm (Lipschitz constant) of the operator :math:`A`.
-
-        .. warning::
-
-            By default, for backward compatibility, this method computes the **squared** spectral norm of :math:`A`,
-            i.e., :math:`\|A^{\top}A\|_2`. This behavior is deprecated and will change in a future version.
-            Set ``squared=False`` to compute the non-squared spectral norm :math:`\|A\|_2`, or use
-            :meth:`compute_sqnorm` to explicitly compute the squared norm.
-
-        Uses the `power method <https://en.wikipedia.org/wiki/Power_iteration>`_.
-
-        :param torch.Tensor x0: an unbatched tensor sharing its shape, dtype and device with the initial iterate of the algorithm (its values are ignored)
-        :param int max_iter: maximum number of iterations
-        :param float tol: relative variation criterion for convergence
-        :param bool verbose: print information
-        :param bool squared: If ``True`` (default, deprecated), computes :math:`\|A^{\top}A\|_2` (squared spectral norm of :math:`A`).
-            Use :meth:`compute_sqnorm` instead.
-            If ``False``, computes :math:`\|A\|_2` (spectral norm of :math:`A`).
-        :param dict kwargs: optional parameters for the forward operator
-
-        :return: (torch.Tensor) spectral norm. If ``squared=True``, returns :math:`\|A^{\top}A\|_2` (squared spectral norm of :math:`A`).
-            If ``squared=False``, returns :math:`\|A\|_2` (spectral norm of :math:`A`).
-        """
-        if squared is True:
-            warnings.warn(
-                "Using `compute_norm(squared=True)` is deprecated. "
-                "Use `compute_sqnorm()` instead to compute the squared spectral norm (||A^T A||_2). "
-                "In a future version, `compute_norm()` will compute the non-squared spectral norm (||A||_2) by default.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
-        elif squared is not False:
-            raise ValueError(f"squared must be True or False, got {squared}")
-
-        # Compute squared norm using compute_sqnorm
-        sqnorm = self.compute_sqnorm(
-            x0, max_iter=max_iter, tol=tol, verbose=verbose, **kwargs
-        )
-
-        # Return squared or non-squared norm based on parameter
-        if squared:
-            return sqnorm
-        else:
-            return sqnorm.sqrt()
-
-    def compute_sqnorm(
-        self,
-        x0: torch.Tensor,
-        *,
-        max_iter: int = 100,
-        tol: float = 1e-3,
-        verbose: bool = True,
-        rng: torch.Generator | None = None,
-        **kwargs,
-    ) -> torch.Tensor:
-        r"""
-        Computes the squared spectral :math:`\ell_2` norm of the operator :math:`A`.
-
-        This is equivalent to computing the spectral norm of :math:`A^{\top}A`, i.e., :math:`\|A^{\top}A\|_2`.
-
-        Uses the `power method <https://en.wikipedia.org/wiki/Power_iteration>`_.
-
-        :param torch.Tensor x0: an unbatched tensor sharing its shape, dtype and device with the initial iterate of the algorithm (its values are ignored)
-        :param int max_iter: maximum number of iterations
-        :param float tol: relative variation criterion for convergence
-        :param bool verbose: print information
-        :param dict kwargs: optional parameters for the forward operator
-
-        :return: (torch.Tensor) squared spectral norm of :math:`A`, i.e., :math:`\|A^{\top}A\|_2 = \|A\|_2^2`.
-        """
-        if rng is None:
-            rng = torch.Generator(x0.device)
-        return power_method(
-            operator=self.A_adjoint_A,
-            x0=x0,
-            max_iter=max_iter,
-            tol=tol,
-            verbose=verbose,
-            **kwargs,
-        )
-
-    def adjointness_test(self, u, **kwargs):
-        r"""
-        Numerically check that :math:`A^{\top}` is indeed the adjoint of :math:`A`.
-
-        :param torch.Tensor u: initialization point of the adjointness test method
-
-        :return: (float) a quantity that should be theoretically 0. In practice, it should be of the order of the chosen dtype precision (i.e. single or double).
-
-        """
-        u_in = u  # .type(self.dtype)
-        Au = self.A(u_in, **kwargs)
-
-        if isinstance(Au, tuple) or isinstance(Au, list):
-            V = [randn_like(au) for au in Au]
-            Atv = self.A_adjoint(V, **kwargs)
-            s1 = 0
-            for au, v in zip(Au, V, strict=True):
-                s1 += (v.conj() * au).flatten().sum()
-
-        else:
-            v = randn_like(Au)
-            Atv = self.A_adjoint(v, **kwargs)
-
-            s1 = (v.conj() * Au).flatten().sum()
-
-        s2 = (Atv * u_in.conj()).flatten().sum()
-
-        return s1.conj() - s2
-
-    def condition_number(self, x, max_iter=500, tol=1e-6, verbose=False, **kwargs):
-        r"""
-        Computes an approximation of the condition number of the linear operator :math:`A`.
-
-        Uses the LSQR algorithm, see :func:`deepinv.optim.linear.lsqr` for more details.
-
-        :param torch.Tensor x: Any input tensor (e.g. random)
-        :param int max_iter: maximum number of iterations
-        :param float tol: relative variation criterion for convergence
-        :param bool verbose: print information
-        :return: (:class:`torch.Tensor`) condition number of the operator
-        """
-        y = self.A(x, **kwargs)
-        _, cond = lsqr(
-            self.A,
-            self.A_adjoint,
-            y,
-            max_iter=max_iter,
-            verbose=verbose,
-            tol=tol,
-            parallel_dim=None,
-            **kwargs,
-        )
-
-        return cond
-
-    def prox_l2(
-        self, z, y, gamma, solver="CG", max_iter=None, tol=None, verbose=False, **kwargs
-    ):
-        r"""
-        Computes proximal operator of :math:`f(x) = \frac{1}{2}\|Ax-y\|^2`, i.e.,
-
-        .. math::
-
-            \underset{x}{\arg\min} \; \frac{\gamma}{2}\|Ax-y\|^2 + \frac{1}{2}\|x-z\|^2
-
-        :param torch.Tensor y: measurements tensor
-        :param torch.Tensor, float, int, None z: signal tensor
-        :param float gamma: hyperparameter of the proximal operator
-        :param str solver: solver to use for the proximal operator, see :func:`deepinv.optim.linear.least_squares` for details
-        :param int max_iter: maximum number of iterations for iterative solvers
-        :param float tol: tolerance for iterative solvers
-        :param bool verbose: whether to print information during the solver execution
-        :param int scale: scale at which to apply the physics operator
-        :return: (:class:`torch.Tensor`) estimated signal tensor
-
-        """
-        if max_iter is not None:
-            self.max_iter = max_iter
-        if tol is not None:
-            self.tol = tol
-        if solver is not None:
-            self.solver = solver
-
-        if z is None or isinstance(z, float) or isinstance(z, int):
-            z = torch.full_like(
-                self.A_adjoint(y), fill_value=0.0 if z is None else float(z)
-            )
-
-        if not self.implicit_backward_solver:
-            return least_squares(
-                self.A,
-                self.A_adjoint,
-                y,
-                solver=solver,
-                gamma=gamma,
-                verbose=verbose,
-                init=z,
-                z=z,
-                parallel_dim=[0],
-                ATA=self.A_adjoint_A,
-                AAT=self.A_A_adjoint,
-                max_iter=self.max_iter,
-                tol=self.tol,
-                **kwargs,
-            )
-        else:
-            return least_squares_implicit_backward(
-                self,
-                y,
-                z=z,
-                init=z,
-                solver=solver,
-                gamma=gamma,
-                verbose=verbose,
-                max_iter=self.max_iter,
-                tol=self.tol,
-                parallel_dim=[0],
-                **kwargs,
-            )
-
-    def A_dagger(
-        self, y, solver="CG", max_iter=None, tol=None, verbose=False, **kwargs
-    ):
-        r"""
-        Computes the solution in :math:`x` to :math:`y = Ax` using a least squares solver.
-
-        This function can be overwritten by a more efficient pseudoinverse in cases where closed form formulas exist.
-
-        :param torch.Tensor y: a measurement :math:`y` to reconstruct via the pseudoinverse.
-        :param str solver: least squares solver to use. Choose between `'CG'`, `'lsqr'`, `'BiCGStab'` and `'minres'`. See :func:`deepinv.optim.linear.least_squares` for more details.
-        :return: (:class:`torch.Tensor`) The reconstructed image :math:`x`.
-
-        """
-        if max_iter is not None:
-            self.max_iter = max_iter
-        if tol is not None:
-            self.tol = tol
-        if solver is not None:
-            self.solver = solver
-        if not self.implicit_backward_solver:
-            return least_squares(
-                self.A,
-                self.A_adjoint,
-                y,
-                parallel_dim=[0],
-                AAT=self.A_A_adjoint,
-                verbose=verbose,
-                ATA=self.A_adjoint_A,
-                max_iter=self.max_iter,
-                tol=self.tol,
-                solver=self.solver,
-                **kwargs,
-            )
-        else:
-            return least_squares_implicit_backward(
-                self,
-                y,
-                z=None,
-                init=None,
-                parallel_dim=[0],
-                gamma=1e8,  # Large gamma to approximate A_dagger
-                verbose=verbose,
-                max_iter=self.max_iter,
-                tol=self.tol,
-                solver=self.solver,
-                **kwargs,
-            )
+        kwargs["linear"] = True
+        super().__init__(*args, **kwargs)
 
 
 class ComposedPhysics(Physics):
@@ -873,6 +930,10 @@ class ComposedPhysics(Physics):
         \noise{\forw{x}} = N_k(A_k(\dots A_2(A_1(x))))
 
     where :math:`A_i(\cdot)` is the ith physics operator and :math:`N_k(\cdot)` is the noise of the last operator.
+
+    The resulting operator's linearity (``self.linear``) is automatically derived as the conjunction of
+    the linearity of all composed operators, which in turn determines whether :meth:`A_adjoint` is
+    available.
 
     :param Iterable[deepinv.physics.Physics] physics: variable number of physics to compose.
     """
@@ -889,6 +950,7 @@ class ComposedPhysics(Physics):
             )
         self.noise_model = physics[-1].noise_model
         self.sensor_model = physics[-1].sensor_model
+        self.linear = all(getattr(p, "linear", False) for p in self.physics_list)
 
     def A(self, x: Tensor, **kwargs) -> Tensor:
         r"""
@@ -904,6 +966,27 @@ class ComposedPhysics(Physics):
         for physics in self.physics_list:
             x = physics.A(x, **kwargs)
         return x
+
+    def A_adjoint(self, y: Tensor, **kwargs) -> Tensor:
+        r"""
+        Computes adjoint of composed operator
+
+        .. math::
+
+            x = A_1^{\top} A_2^{\top} \dots A_k^{\top} y
+
+        Only available when ``self.linear=True``, i.e. when every composed operator is linear.
+
+        :param torch.Tensor y: measurements
+        :return: signal/image
+        """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_adjoint requires all composed physics to have linear=True."
+            )
+        for physics in reversed(self.physics_list):
+            y = physics.A_adjoint(y, **kwargs)
+        return y
 
     def update_parameters(self, **kwargs):
         r"""
@@ -933,61 +1016,50 @@ class ComposedPhysics(Physics):
         return self.physics_list[item]
 
 
-class ComposedLinearPhysics(ComposedPhysics, LinearPhysics):
+class ComposedLinearPhysics(ComposedPhysics, metaclass=_linear_alias_metaclass(ComposedPhysics)):
     r"""
-    Composes multiple linear physics operators into a single operator.
+    Deprecated alias of :class:`deepinv.physics.ComposedPhysics`.
 
-    The measurements produced by the resulting model are defined as
+    .. deprecated::
 
-    .. math::
+        Composing physics operators via :func:`deepinv.physics.compose` (or the ``*`` operator) now
+        always returns a :class:`deepinv.physics.ComposedPhysics` instance, whose linearity is
+        automatically derived from the composed operators (``physics.linear``). This class is kept
+        only for backward compatibility (including ``isinstance`` checks against it) and will be
+        removed in a future version.
 
-        \noise{\forw{x}} = N_k(A_k \dots A_2(A_1(x)))
-
-    where :math:`A_i(\cdot)` is the i-th physics operator and :math:`N_k(\cdot)` is the noise of the last operator.
-
-    :param Iterable[deepinv.physics.LinearPhysics] physics: variable number of physics to compose.
+    :param Iterable[deepinv.physics.Physics] physics: variable number of physics to compose.
     """
 
-    def __init__(self, *physics: Iterable[LinearPhysics], **kwargs):
+    def __init__(self, *physics: Iterable[Physics], **kwargs):
+        warnings.warn(
+            "ComposedLinearPhysics is deprecated and will be removed in a future version. "
+            "Use ComposedPhysics (or compose()) instead — linearity is now derived automatically "
+            "from the composed operators via `.linear`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(*physics, **kwargs)
 
-    def A_adjoint(self, y: Tensor, **kwargs) -> Tensor:
-        r"""
-        Computes adjoint of composed operator
 
-        .. math::
-
-            x = A_1^{\top} A_2^{\top} \dots A_k^{\top} y
-
-        :param torch.Tensor y: measurements
-        :return: signal/image
-        """
-        for physics in reversed(self.physics_list):
-            y = physics.A_adjoint(y, **kwargs)
-        return y
-
-
-def compose(*physics: Iterable[Physics | LinearPhysics], **kwargs):
+def compose(*physics: Iterable[Physics], **kwargs):
     r"""
     Composes multiple forward operators :math:`A = A_1\circ A_2\circ \dots \circ A_n`.
 
     The measurements produced by the resulting model are :class:`deepinv.utils.TensorList` objects, where
     each entry corresponds to the measurements of the corresponding operator.
 
-    :param Iterable[deepinv.physics.Physics | deepinv.physics.LinearPhysics] physics: Physics operators :math:`A_i` to be composed.
+    :param Iterable[deepinv.physics.Physics] physics: Physics operators :math:`A_i` to be composed.
     """
     if any(isinstance(phys, DecomposablePhysics) for phys in physics):
         warnings.warn(
             "At least one input physics is a DecomposablePhysics, but resulting physics will not be decomposable. `A_dagger` and `prox_l2` will fall back to approximate methods, which may impact performance."
         )
 
-    if all(isinstance(phys, LinearPhysics) for phys in physics):
-        return ComposedLinearPhysics(*physics, **kwargs)
-    else:
-        return ComposedPhysics(*physics, **kwargs)
+    return ComposedPhysics(*physics, **kwargs)
 
 
-class DecomposablePhysics(LinearPhysics):
+class DecomposablePhysics(Physics):
     r"""
     Parent class for linear operators with SVD decomposition.
 
@@ -1054,7 +1126,7 @@ class DecomposablePhysics(LinearPhysics):
         device: torch.device | str = "cpu",
         **kwargs,
     ):
-        super().__init__(device=device, **kwargs)
+        super().__init__(device=device, linear=True, **kwargs)
 
         if U is None and not (U_adjoint is None):  # pragma: no cover
             raise ValueError("U must be provided if U_adjoint is provided.")
@@ -1362,7 +1434,7 @@ def adjoint_function(A, input_size, device="cpu", dtype=torch.float):
     return Adjoint.apply
 
 
-def stack(*physics: Physics | LinearPhysics):
+def stack(*physics: Physics):
     r"""
     Stacks multiple forward operators :math:`A = \begin{bmatrix} A_1(x) \\ A_2(x) \\ \vdots \\ A_n(x) \end{bmatrix}`.
 
@@ -1371,10 +1443,7 @@ def stack(*physics: Physics | LinearPhysics):
 
     :param deepinv.physics.Physics physics: Physics operators :math:`A_i` to be stacked.
     """
-    if all(isinstance(phys, LinearPhysics) for phys in physics):
-        return StackedLinearPhysics(physics)
-    else:
-        return StackedPhysics(physics)
+    return StackedPhysics(physics)
 
 
 class StackedPhysics(Physics):
@@ -1384,12 +1453,19 @@ class StackedPhysics(Physics):
     The measurements produced by the resulting model are :class:`deepinv.utils.TensorList` objects, where
     each entry corresponds to the measurements of the corresponding operator.
 
+    The resulting operator's linearity (``self.linear``) is automatically derived as the conjunction of
+    the linearity of all stacked operators, which in turn determines whether :meth:`A_adjoint` is
+    available.
+
     See :ref:`physics_combining` for more information.
 
     :param list[deepinv.physics.Physics] physics_list: list of physics operators to stack.
+    :param str reduction: (only relevant when the resulting operator is linear) how to combine
+        tensorlist outputs of adjoint operators into a single adjoint output. Choose between ``sum``,
+        ``mean`` or ``None``.
     """
 
-    def __init__(self, physics_list: list[Physics], **kwargs):
+    def __init__(self, physics_list: list[Physics], reduction="sum", **kwargs):
         super(StackedPhysics, self).__init__()
 
         self.physics_list = []
@@ -1398,6 +1474,23 @@ class StackedPhysics(Physics):
                 [physics]
                 if not isinstance(physics, StackedPhysics)
                 else physics.physics_list
+            )
+        self.linear = all(getattr(p, "linear", False) for p in self.physics_list)
+
+        if reduction == "sum":
+            self.reduction = sum
+        elif reduction == "mean":
+            self.reduction = lambda x: sum(x) / len(x)
+        elif reduction in ("none", None):
+            self.reduction = lambda x: x
+        else:
+            raise ValueError("reduction must be either sum, mean or none.")
+
+        if reduction != "sum":
+            warnings.warn(
+                f"Using `reduction={reduction}` is deprecated and will be removed in a future version. Using `reduction={reduction}` breaks the adjointness property of the operator, and can lead to suboptimal performance of certain algorithms. Use `reduction='sum'` instead.",
+                DeprecationWarning,
+                stacklevel=2,
             )
 
     def A(self, x: Tensor, **kwargs) -> TensorList:
@@ -1475,39 +1568,6 @@ class StackedPhysics(Physics):
         for physics in self.physics_list:
             physics.update_parameters(**kwargs)
 
-
-class StackedLinearPhysics(StackedPhysics, LinearPhysics):
-    r"""
-    Stacks multiple linear physics operators into a single operator.
-
-    The measurements produced by the resulting model are :class:`deepinv.utils.TensorList` objects, where
-    each entry corresponds to the measurements of the corresponding operator.
-
-    See :ref:`physics_combining` for more information.
-
-    :param list[deepinv.physics.Physics] physics_list: list of physics operators to stack.
-    :param str reduction: how to combine tensorlist outputs of adjoint operators into single
-        adjoint output. Choose between ``sum``, ``mean`` or ``None``.
-    """
-
-    def __init__(self, physics_list, reduction="sum", **kwargs):
-        super(StackedLinearPhysics, self).__init__(physics_list, **kwargs)
-        if reduction == "sum":
-            self.reduction = sum
-        elif reduction == "mean":
-            self.reduction = lambda x: sum(x) / len(x)
-        elif reduction in ("none", None):
-            self.reduction = lambda x: x
-        else:
-            raise ValueError("reduction must be either sum, mean or none.")
-
-        if reduction != "sum":
-            warnings.warn(
-                f"Using `reduction={reduction}` is deprecated and will be removed in a future version. Using `reduction={reduction}` breaks the adjointness property of the operator, and can lead to suboptimal performance of certain algorithms. Use `reduction='sum'` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
     def A_adjoint(self, y: TensorList, **kwargs) -> torch.Tensor:
         r"""
         Computes the adjoint of the stacked operator, defined as
@@ -1516,11 +1576,45 @@ class StackedLinearPhysics(StackedPhysics, LinearPhysics):
 
             A^{\top}y = \sum_{i=1}^{n} A_i^{\top}y_i.
 
+        Only available when ``self.linear=True``, i.e. when every stacked operator is linear.
+
         :param deepinv.utils.TensorList y: measurements
         """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_adjoint requires all stacked physics to have linear=True."
+            )
         return self.reduction(
             [
                 physics.A_adjoint(y[i], **kwargs)
                 for i, physics in enumerate(self.physics_list)
             ]
         )
+
+
+class StackedLinearPhysics(StackedPhysics, metaclass=_linear_alias_metaclass(StackedPhysics)):
+    r"""
+    Deprecated alias of :class:`deepinv.physics.StackedPhysics`.
+
+    .. deprecated::
+
+        Stacking physics operators via :func:`deepinv.physics.stack` (or :meth:`Physics.stack`) now
+        always returns a :class:`deepinv.physics.StackedPhysics` instance, whose linearity is
+        automatically derived from the stacked operators (``physics.linear``). This class is kept
+        only for backward compatibility (including ``isinstance`` checks against it) and will be
+        removed in a future version.
+
+    :param list[deepinv.physics.Physics] physics_list: list of physics operators to stack.
+    :param str reduction: how to combine tensorlist outputs of adjoint operators into single
+        adjoint output. Choose between ``sum``, ``mean`` or ``None``.
+    """
+
+    def __init__(self, physics_list, reduction="sum", **kwargs):
+        warnings.warn(
+            "StackedLinearPhysics is deprecated and will be removed in a future version. "
+            "Use StackedPhysics (or stack()) instead — linearity is now derived automatically "
+            "from the stacked operators via `.linear`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(physics_list, reduction=reduction, **kwargs)

--- a/deepinv/physics/mri.py
+++ b/deepinv/physics/mri.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from deepinv.physics.forward import DecomposablePhysics, LinearPhysics
+from deepinv.physics.forward import DecomposablePhysics, Physics
 from deepinv.utils.mixins import MRIMixin, TimeMixin
 
 
@@ -163,7 +163,7 @@ class MRI(MRIMixin, DecomposablePhysics):
         super().update_parameters(mask=mask, **kwargs)
 
 
-class MultiCoilMRI(MRIMixin, LinearPhysics):
+class MultiCoilMRI(MRIMixin, Physics):
     r"""
     Multi-coil 2D or 3D MRI operator.
 
@@ -229,7 +229,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
         device: torch.device | str = torch.device("cpu"),
         **kwargs,
     ):
-        super().__init__(device=device, **kwargs)
+        super().__init__(device=device, linear=True, **kwargs)
         self.img_size = img_size
         self.three_d = three_d
 
@@ -336,7 +336,7 @@ class MultiCoilMRI(MRIMixin, LinearPhysics):
         :param torch.Tensor y: multi-coil kspace measurements with shape [B,2,N,...,H,W] where N is coil dimension.
         :param torch.Tensor mask: optionally set the mask on-the-fly.
         :param torch.Tensor coil_maps: optionally set the mask on-the-fly.
-        :param dict kwargs: kwargs to pass to base :meth:`deepinv.physics.LinearPhysics.A_dagger`.
+        :param dict kwargs: kwargs to pass to base :meth:`deepinv.physics.Physics.A_dagger`.
         :returns: (:class:`torch.Tensor`) image with shape `(B,2,...,H,W)`
         """
         self.update_parameters(mask=mask, coil_maps=coil_maps)

--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from .forward import LinearPhysics
+from .forward import Physics
 from .noise import PoissonNoise
 import torch
 from typing import TYPE_CHECKING
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import parallelproj
 
 
-class PET(LinearPhysics):
+class PET(Physics):
     r"""
     Non time-of-flight Positron emission tomography (PET) physics model.
 
@@ -33,7 +33,7 @@ class PET(LinearPhysics):
 
     The operator relies on parameters `background` and `attenuation` that can be updated through the
     :meth:`physics.update <deepinv.physics.Physics.update>` method or when evaluating
-    :meth:`physics.A <deepinv.physics.Physics.A>` or :meth:`physics.A_adjoint <deepinv.physics.LinearPhysics.A_adjoint>`.
+    :meth:`physics.A <deepinv.physics.Physics.A>` or :meth:`physics.A_adjoint <deepinv.physics.Physics.A_adjoint>`.
 
     .. note::
 
@@ -124,7 +124,7 @@ class PET(LinearPhysics):
         attenuation: torch.Tensor | None = None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(linear=True, **kwargs)
         if isinstance(img_size, tuple):
             # remove first entries = 1
             while len(img_size) > 0 and img_size[0] == 1:

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -314,7 +314,7 @@ class StructuredRandomPhaseRetrieval(PhaseRetrieval):
         return "FD" * math.floor(n_layers) + "F" * (n_layers % 1 == 0.5)
 
 
-class PtychographyLinearOperator(LinearPhysics):
+class PtychographyLinearOperator(Physics):
     r"""
     Forward linear operator for phase retrieval in ptychography.
 
@@ -345,7 +345,7 @@ class PtychographyLinearOperator(LinearPhysics):
         device="cpu",
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(linear=True, **kwargs)
 
         self.img_size = img_size
 

--- a/deepinv/physics/radio.py
+++ b/deepinv/physics/radio.py
@@ -49,9 +49,7 @@ class RadioInterferometry(Physics):
     ):
         import torchkbnufft as tkbn
 
-        super(RadioInterferometry, self).__init__(
-            device=device, linear=True, **kwargs
-        )
+        super(RadioInterferometry, self).__init__(device=device, linear=True, **kwargs)
 
         if dataWeight is None:
             dataWeight = torch.tensor([1.0], device=device)

--- a/deepinv/physics/radio.py
+++ b/deepinv/physics/radio.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from typing import Sequence
 import torch
-from deepinv.physics import LinearPhysics
+from deepinv.physics import Physics
 
 
-class RadioInterferometry(LinearPhysics):
+class RadioInterferometry(Physics):
     r"""
     Radio Interferometry measurement operator.
 
@@ -49,7 +49,9 @@ class RadioInterferometry(LinearPhysics):
     ):
         import torchkbnufft as tkbn
 
-        super(RadioInterferometry, self).__init__(device=device, **kwargs)
+        super(RadioInterferometry, self).__init__(
+            device=device, linear=True, **kwargs
+        )
 
         if dataWeight is None:
             dataWeight = torch.tensor([1.0], device=device)

--- a/deepinv/physics/remote_sensing.py
+++ b/deepinv/physics/remote_sensing.py
@@ -1,11 +1,11 @@
 from deepinv.physics.noise import ZeroNoise
-from deepinv.physics.forward import StackedLinearPhysics
+from deepinv.physics.forward import StackedPhysics
 from deepinv.physics.blur import Downsampling
 from deepinv.physics.range import Decolorize
 from deepinv.utils.tensorlist import TensorList
 
 
-class Pansharpen(StackedLinearPhysics):
+class Pansharpen(StackedPhysics):
     r"""
     Pansharpening forward operator.
 

--- a/deepinv/physics/scattering.py
+++ b/deepinv/physics/scattering.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import torch
 from deepinv.optim.linear import least_squares
 from dataclasses import dataclass
-from deepinv.physics.forward import Physics, LinearPhysics
+from deepinv.physics.forward import Physics
 
 
 def hankel1(n, x):
@@ -226,7 +226,7 @@ class Scattering(Physics):
 
         :param torch.Tensor x: Scattering potential of size `(B,1,H,W)`.
         """
-        norm = self.compute_norm(x).sqrt()
+        norm = self.compute_sqnorm(x).sqrt()
         self.incident_field /= norm
         if hasattr(self.noise_model, "sigma"):
             self.noise_model.sigma /= norm
@@ -516,7 +516,7 @@ class Scattering(Physics):
         return x
 
 
-class BornOperator(LinearPhysics):
+class BornOperator(Physics):
     r"""
     Linear operator implementing the Born approximation for the scattering problem.
 
@@ -549,7 +549,7 @@ class BornOperator(LinearPhysics):
         img_width: int,
         verbose: bool = False,
     ):
-        super().__init__()
+        super().__init__(linear=True)
         self.register_buffer("total_field", total_field)
         green_operator = self.compute_operator(
             receivers,

--- a/deepinv/physics/structured_random.py
+++ b/deepinv/physics/structured_random.py
@@ -4,7 +4,7 @@ from deepinv.physics.functional import dst1
 import numpy as np
 import torch
 
-from deepinv.physics.forward import LinearPhysics
+from deepinv.physics.forward import Physics
 
 
 def compare(img_size: tuple, output_size: tuple) -> str:
@@ -105,7 +105,7 @@ def generate_diagonal(
     return diag.to(device)
 
 
-class StructuredRandom(LinearPhysics):
+class StructuredRandom(Physics):
     r"""
     Structured random linear operator model corresponding to the operator
 
@@ -137,7 +137,7 @@ class StructuredRandom(LinearPhysics):
         rng: torch.Generator = None,
         **kwargs,
     ):
-        super().__init__(device=device, **kwargs)
+        super().__init__(device=device, linear=True, **kwargs)
 
         if len(img_size) == 3:
             self.mode = compare(img_size, output_size)

--- a/deepinv/physics/tomography.py
+++ b/deepinv/physics/tomography.py
@@ -7,7 +7,7 @@ import math
 from numpy import ndarray
 import torch
 
-from deepinv.physics.forward import LinearPhysics, adjoint_function
+from deepinv.physics.forward import Physics, adjoint_function
 from deepinv.physics.functional import (
     Radon,
     IRadon,
@@ -23,7 +23,7 @@ from deepinv.physics.functional.astra import (
 from deepinv.utils.decorators import _deprecated_alias
 
 
-class Tomography(LinearPhysics):
+class Tomography(Physics):
     r"""
     (Computed) Tomography operator.
 
@@ -131,7 +131,7 @@ class Tomography(LinearPhysics):
         dtype: torch.dtype = torch.float,
         **kwargs,
     ):
-        super().__init__(device=device, **kwargs)
+        super().__init__(device=device, linear=True, **kwargs)
 
         if isinstance(angles, int):
             angles = torch.linspace(0, 180, steps=angles + 1, device=device)[:-1].to(
@@ -350,7 +350,7 @@ class Tomography(LinearPhysics):
         return output
 
 
-class TomographyWithAstra(LinearPhysics):
+class TomographyWithAstra(Physics):
     r"""Computed Tomography operator with `astra-toolbox <https://astra-toolbox.com/>`_ backend.
     It is more memory efficient than the :class:`deepinv.physics.Tomography` operator and support 3D geometries.
     See documentation of :class:`deepinv.physics.functional.XrayTransform` for more
@@ -524,7 +524,7 @@ class TomographyWithAstra(LinearPhysics):
         device: torch.device | str = torch.device("cuda"),
         **kwargs,
     ):
-        super().__init__(device=device, **kwargs)
+        super().__init__(device=device, linear=True, **kwargs)
 
         if isinstance(geometry_parameters, MappingProxyType):
             geometry_parameters = geometry_parameters.copy()

--- a/deepinv/physics/unmixing.py
+++ b/deepinv/physics/unmixing.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from math import sqrt
 import torch
-from deepinv.physics.forward import LinearPhysics
+from deepinv.physics.forward import Physics
 
 
-class HyperSpectralUnmixing(LinearPhysics):
+class HyperSpectralUnmixing(Physics):
     r"""
     Hyperspectral Unmixing operator.
 
@@ -60,7 +60,9 @@ class HyperSpectralUnmixing(LinearPhysics):
         device: torch.device | str = "cpu",
         **kwargs,
     ):
-        super(HyperSpectralUnmixing, self).__init__(device=device, **kwargs)
+        super(HyperSpectralUnmixing, self).__init__(
+            device=device, linear=True, **kwargs
+        )
 
         if M is None:
             # Simulate random normalized M

--- a/deepinv/physics/virtual.py
+++ b/deepinv/physics/virtual.py
@@ -1,9 +1,9 @@
 import torch
-from deepinv.physics.forward import LinearPhysics
+from deepinv.physics.forward import Physics
 from deepinv.transform.base import Transform
 
 
-class VirtualLinearPhysics(LinearPhysics):
+class VirtualLinearPhysics(Physics):
     r"""
     Virtual linear operator
 
@@ -27,13 +27,13 @@ class VirtualLinearPhysics(LinearPhysics):
 
         The adjoint and pseudo-inverse might be incorrect if the transformation is not invertible, for instance due to boundary effects.
 
-    :param LinearPhysics physics: linear physics operator :math:`\tilde{A}`.
+    :param Physics physics: linear physics operator :math:`\tilde{A}` (``physics.linear`` should be `True`).
     :param Transform transform: transformation :math:`T_g`
     :param dict g_params: parameters of the transformation :math:`g`.
     """
 
-    def __init__(self, *, physics: LinearPhysics, transform: Transform, g_params: dict):
-        super().__init__()
+    def __init__(self, *, physics: Physics, transform: Transform, g_params: dict):
+        super().__init__(linear=True)
         self.physics = physics
         self.T = lambda x: transform.transform(x, **g_params)
         self.T_inv = lambda x: transform.inverse(x, **g_params)

--- a/deepinv/physics/wrappers.py
+++ b/deepinv/physics/wrappers.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 import torch
 import torch.nn.functional as F
 import math
+import warnings
 
-from deepinv.physics import Physics, LinearPhysics, Inpainting
+from deepinv.physics import Physics, Inpainting
+from deepinv.physics.forward import _linear_alias_metaclass
 from deepinv.physics.blur import Upsampling, Blur, BlurFFT
 from typing import Sequence  # noqa: F401
 
@@ -43,8 +45,12 @@ class PhysicsMultiScaler(Physics):
         dtype: torch.dtype | None = None,
         **kwargs,
     ):
-        # NOTE: `device` is passed to super().__init__ (even if Physics does not use it) for proper variable propagation during Method Resolution Order (MRO: https://docs.python.org/3/howto/mro.html) when inherited jointly with another class, e.g., with LinearPhysics
-        super().__init__(noise_model=physics.noise_model, device=device, **kwargs)
+        super().__init__(
+            noise_model=physics.noise_model,
+            device=device,
+            linear=getattr(physics, "linear", False),
+            **kwargs,
+        )
         self.base = physics
         self.factors = factors
         self.img_size = img_size
@@ -113,12 +119,120 @@ class PhysicsMultiScaler(Physics):
     def update_parameters(self, **kwargs):
         self.base.update_parameters(**kwargs)
 
+    def A_adjoint(self, y: torch.Tensor, scale: int | None = None, **kwargs):
+        r"""
+        Computes the adjoint of the multi-scale linear operator :math:`A`.
 
-class LinearPhysicsMultiScaler(PhysicsMultiScaler, LinearPhysics):
+        Only available when ``self.linear=True``, i.e. when the wrapped physics is linear.
+        """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_adjoint requires the wrapped physics to have linear=True."
+            )
+        self.set_scale(scale)
+        y = self.base.A_adjoint(y, **kwargs)
+        if self.scale == 0:
+            return y
+        else:
+            return self.upsamplings[self.scale - 1].A_adjoint(y)
+
+    def A_dagger(self, y: torch.Tensor, scale: int | None = None, **kwargs):
+        r"""
+        Computes the pseudo-inverse of the linear operator :math:`A`.
+
+        If the scale is set to 0, it uses the base physics pseudo-inverse, which might have a more efficient implementation.
+
+        Only available when ``self.linear=True``, i.e. when the wrapped physics is linear.
+
+        :param torch.Tensor y: measurements tensor
+        :return: (:class:`torch.Tensor`) estimated signal tensor
+        """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.A_dagger requires the wrapped physics to have linear=True."
+            )
+        self.set_scale(scale)
+        if self.scale == 0:
+            # use efficient implementation if available (eg SVD-based)
+            return self.base.A_dagger(y, **kwargs)
+        else:
+            return super().A_dagger(y, **kwargs)
+
+    def prox_l2(
+        self,
+        z,
+        y,
+        gamma,
+        solver="CG",
+        max_iter=None,
+        tol=None,
+        verbose=False,
+        scale=None,
+        **kwargs,
+    ):
+        r"""
+        Computes proximal operator of :math:`f(x) = \frac{1}{2}\|Ax-y\|^2`, i.e.,
+
+        .. math::
+
+            \underset{x}{\arg\min} \; \frac{\gamma}{2}\|Ax-y\|^2 + \frac{1}{2}\|x-z\|^2
+
+        If the scale is set to 0, it uses the base physics proximal operator, which might have a more efficient implementation.
+
+        Only available when ``self.linear=True``, i.e. when the wrapped physics is linear.
+
+        :param torch.Tensor y: measurements tensor
+        :param torch.Tensor z: signal tensor
+        :param float gamma: hyperparameter of the proximal operator
+        :param str solver: solver to use for the proximal operator, see :func:`deepinv.optim.linear.least_squares` for details
+        :param int max_iter: maximum number of iterations for iterative solvers
+        :param float tol: tolerance for iterative solvers
+        :param bool verbose: whether to print information during the solver execution
+        :param int scale: scale at which to apply the physics operator
+        :return: (:class:`torch.Tensor`) estimated signal tensor
+
+        """
+        if not self.linear:
+            raise NotImplementedError(
+                f"{type(self).__name__}.prox_l2 requires the wrapped physics to have linear=True."
+            )
+        self.set_scale(scale)
+        if self.scale == 0:
+            return self.base.prox_l2(
+                z,
+                y,
+                gamma,
+                solver=solver,
+                max_iter=max_iter,
+                tol=tol,
+                verbose=verbose,
+                **kwargs,
+            )
+        else:
+            return super().prox_l2(
+                z,
+                y,
+                gamma,
+                solver=solver,
+                max_iter=max_iter,
+                tol=tol,
+                verbose=verbose,
+                **kwargs,
+            )
+
+
+class LinearPhysicsMultiScaler(
+    PhysicsMultiScaler, metaclass=_linear_alias_metaclass(PhysicsMultiScaler)
+):
     r"""
-    Multi-scale wrapper for linear physics operators.
+    Deprecated alias of :class:`deepinv.physics.PhysicsMultiScaler`.
 
-    See :class:`PhysicsMultiScaler` for details.
+    .. deprecated::
+
+        :class:`deepinv.physics.PhysicsMultiScaler` now supports linear physics operators directly
+        (its linearity, ``physics.linear``, is derived automatically from the wrapped physics). This
+        class is kept only for backward compatibility (including ``isinstance`` checks against it)
+        and will be removed in a future version.
 
     :Examples:
 
@@ -149,6 +263,13 @@ class LinearPhysicsMultiScaler(PhysicsMultiScaler, LinearPhysics):
         device: str | torch.device = "cpu",
         **kwargs,
     ):
+        warnings.warn(
+            "LinearPhysicsMultiScaler is deprecated and will be removed in a future version. "
+            "Use PhysicsMultiScaler (or to_multiscale()) instead — linearity is now derived "
+            "automatically from the wrapped physics via `.linear`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(
             physics=physics,
             img_size=img_size,
@@ -157,86 +278,6 @@ class LinearPhysicsMultiScaler(PhysicsMultiScaler, LinearPhysics):
             device=device,
             **kwargs,
         )
-
-    def A_adjoint(self, y: torch.Tensor, scale: int | None = None, **kwargs):
-        self.set_scale(scale)
-        y = self.base.A_adjoint(y, **kwargs)
-        if self.scale == 0:
-            return y
-        else:
-            return self.upsamplings[self.scale - 1].A_adjoint(y)
-
-    def A_dagger(self, y: torch.Tensor, scale: int | None = None, **kwargs):
-        r"""
-        Computes the pseudo-inverse of the linear operator :math:`A`.
-
-        If the scale is set to 0, it uses the base physics pseudo-inverse, which might have a more efficient implementation.
-
-        :param torch.Tensor y: measurements tensor
-        :return: (:class:`torch.Tensor`) estimated signal tensor
-        """
-        self.set_scale(scale)
-        if self.scale == 0:
-            # use efficient implementation if available (eg SVD-based)
-            return self.base.A_dagger(y, **kwargs)
-        else:
-            return self.super().A_dagger(y, **kwargs)
-
-    def prox_l2(
-        self,
-        z,
-        y,
-        gamma,
-        solver="CG",
-        max_iter=None,
-        tol=None,
-        verbose=False,
-        scale=None,
-        **kwargs,
-    ):
-        r"""
-        Computes proximal operator of :math:`f(x) = \frac{1}{2}\|Ax-y\|^2`, i.e.,
-
-        .. math::
-
-            \underset{x}{\arg\min} \; \frac{\gamma}{2}\|Ax-y\|^2 + \frac{1}{2}\|x-z\|^2
-
-        If the scale is set to 0, it uses the base physics proximal operator, which might have a more efficient implementation.
-
-        :param torch.Tensor y: measurements tensor
-        :param torch.Tensor z: signal tensor
-        :param float gamma: hyperparameter of the proximal operator
-        :param str solver: solver to use for the proximal operator, see :func:`deepinv.optim.linear.least_squares` for details
-        :param int max_iter: maximum number of iterations for iterative solvers
-        :param float tol: tolerance for iterative solvers
-        :param bool verbose: whether to print information during the solver execution
-        :param int scale: scale at which to apply the physics operator
-        :return: (:class:`torch.Tensor`) estimated signal tensor
-
-        """
-        self.set_scale(scale)
-        if self.scale == 0:
-            return self.base.prox_l2(
-                z,
-                y,
-                gamma,
-                solver=solver,
-                max_iter=max_iter,
-                tol=tol,
-                verbose=verbose,
-                **kwargs,
-            )
-        else:
-            return super().prox_l2(
-                z,
-                y,
-                gamma,
-                solver=solver,
-                max_iter=max_iter,
-                tol=tol,
-                verbose=verbose,
-                **kwargs,
-            )
 
 
 def coarse_blur_filter(
@@ -278,7 +319,7 @@ def coarse_blur_filter(
     return coarse_filter
 
 
-class BlurMultiScaler(LinearPhysicsMultiScaler, LinearPhysics):
+class BlurMultiScaler(LinearPhysicsMultiScaler):
     r"""
     Multi-scale wrapper for blur physics operators. This particular class handles A_adjoint_A with a particular implementation for each scale.
 
@@ -342,7 +383,7 @@ class BlurMultiScaler(LinearPhysicsMultiScaler, LinearPhysics):
         return physics.A_adjoint_A(x) / factor**2
 
 
-class BlurFFTMultiScaler(LinearPhysicsMultiScaler, LinearPhysics):
+class BlurFFTMultiScaler(LinearPhysicsMultiScaler):
     r"""
     Multi-scale wrapper for BlurFFT operators. This particular class handles A_adjoint_A with a particular implementation for each scale.
 
@@ -412,7 +453,7 @@ class BlurFFTMultiScaler(LinearPhysicsMultiScaler, LinearPhysics):
         return physics.A_adjoint_A(x) / factor**2
 
 
-class InpaintingMultiScaler(LinearPhysicsMultiScaler, LinearPhysics):
+class InpaintingMultiScaler(LinearPhysicsMultiScaler):
     r"""
     Multi-scale wrapper for inpainting/demosaicing operators. This particular class handles A_adjoint_A with a particular implementation for each scale.
 
@@ -552,24 +593,20 @@ def to_multiscale(
         return InpaintingMultiScaler(
             physics, img_size, factors=factors, device=device, dtype=dtype
         )
-    elif isinstance(physics, LinearPhysics):
-        return LinearPhysicsMultiScaler(
-            physics, img_size, factors=factors, device=device, dtype=dtype
-        )
     else:
         return PhysicsMultiScaler(
             physics, img_size, factors=factors, device=device, dtype=dtype
         )
 
 
-class PhysicsCropper(LinearPhysics):
+class PhysicsCropper(Physics):
     r"""
     Cropping for linear physics operators.
 
     Given a linear physics operator :math:`A`, this operator instantiates a new operator :math:`\tilde{A} = A \circ C` where :math:`C` is a cropping operator that crops the input tensor.
     The adjoint operator is defined as :math:`\tilde{A}^{\top} = C^{\top} \circ A^{\top}` and :math:`C^{\top}` is a padding operator that pads the input tensor to the original size.
 
-    :param deepinv.physics.LinearPhysics physics: base linear physics operator.
+    :param deepinv.physics.Physics physics: base linear physics operator (``physics.linear`` should be `True`).
     :param tuple crop: padding to apply to the input tensor, e.g., `(pad_height, pad_width)` or `(pad_z, pad_height, pad_weight)` where `pad_z` is either channel or depth dimension pad.
     :param torch.device, str device: cpu or cuda, every registered buffer and module parameters are recursively pushed onto the device during initialization.
 
@@ -581,7 +618,11 @@ class PhysicsCropper(LinearPhysics):
         crop,
         device: torch.device | str = "cpu",
     ):
-        super().__init__(noise_model=physics.noise_model, device=device)
+        super().__init__(
+            noise_model=physics.noise_model,
+            device=device,
+            linear=getattr(physics, "linear", False),
+        )
         self.base = physics
         self.crop = crop
         if len(self.crop) not in (2, 3):

--- a/deepinv/sampling/noisy_datafidelity.py
+++ b/deepinv/sampling/noisy_datafidelity.py
@@ -52,7 +52,7 @@ class NoisyDataFidelity(DataFidelity):
         """
         return (
             physics.A_adjoint(u)
-            if isinstance(physics, dinv.physics.LinearPhysics)
+            if getattr(physics, "linear", False)
             else physics.A_dagger(u)
         )
 

--- a/deepinv/sampling/sampling.py
+++ b/deepinv/sampling/sampling.py
@@ -10,7 +10,7 @@ from deepinv.models import Reconstructor
 from deepinv.optim.data_fidelity import DataFidelity
 from deepinv.optim.prior import Prior
 from deepinv.optim.utils import check_conv
-from deepinv.physics import Physics, LinearPhysics
+from deepinv.physics import Physics
 from deepinv.sampling import sampling_iterators as _sampling_iterators
 from deepinv.sampling.sampling_iterators import SamplingIterator
 from deepinv.sampling.utils import Welford
@@ -195,7 +195,7 @@ class BaseSampling(Reconstructor):
             # Initialization of both our image chain and any latent variables
             if x_init is None:
                 # if linear take adjoint (pseudo-inverse can be a bit unstable) else fall back to pseudoinverse
-                if isinstance(physics, LinearPhysics):
+                if getattr(physics, "linear", False):
                     X = self.iterator.initialize_latent_variables(
                         physics.A_adjoint(y), y, physics, self.data_fidelity, self.prior
                     )

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1133,14 +1133,14 @@ def test_condition_number(device):
 
     c = torch.rand(imsize, device=device) * 0.95 + 0.05
 
-    class DummyPhysics(dinv.physics.LinearPhysics):
+    class DummyPhysics(dinv.physics.Physics):
         def A(self, x, **kwargs):
             return x * c
 
         def A_adjoint(self, y, **kwargs):
             return y * c
 
-    physics = DummyPhysics()
+    physics = DummyPhysics(linear=True)
     x = torch.randn(imsize, device=device)
     cond = physics.condition_number(x)
     gt_cond = c.max() / c.min()
@@ -1294,9 +1294,9 @@ def test_least_squares_implicit_backward_nonleaf_buffer_grad(device):
     batch_size = 2
     dim = 12
 
-    class DummyPhysics(dinv.physics.LinearPhysics):
+    class DummyPhysics(dinv.physics.Physics):
         def __init__(self, mat):
-            super().__init__()
+            super().__init__(linear=True)
             self.register_buffer("mat", mat)
 
         def A(self, x):

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -950,31 +950,38 @@ class Trainer:
         """
 
         y = y.to(self.device)
+        physics_ = (
+            physics.module if isinstance(physics, torch.nn.DataParallel) else physics
+        )
+
+        def _not_implemented():
+            return ValueError(
+                f"No learning reconstruction method {self.no_learning_method} not recognized or physics does not implement it"
+            )
+
         if isinstance(self.no_learning_method, Reconstructor):
             x_nl = self.no_learning_method(y, physics)
-        elif self.no_learning_method == "A_adjoint" and hasattr(physics, "A_adjoint"):
-            if isinstance(physics, torch.nn.DataParallel):
-                x_nl = physics.module.A_adjoint(y)
-            else:
-                x_nl = physics.A_adjoint(y)
-        elif self.no_learning_method == "A_dagger" and hasattr(physics, "A_dagger"):
-            if isinstance(physics, torch.nn.DataParallel):
-                x_nl = physics.module.A_dagger(y)
-            else:
-                x_nl = physics.A_dagger(y)
-        elif self.no_learning_method == "prox_l2" and hasattr(physics, "prox_l2"):
+        elif self.no_learning_method == "A_adjoint":
+            try:
+                x_nl = physics_.A_adjoint(y)
+            except (AttributeError, NotImplementedError):
+                raise _not_implemented()
+        elif self.no_learning_method == "A_dagger":
+            try:
+                x_nl = physics_.A_dagger(y)
+            except (AttributeError, NotImplementedError):
+                raise _not_implemented()
+        elif self.no_learning_method == "prox_l2":
             # this is a regularized version of the pseudo-inverse, with an l2 regularization
             # with parameter set to 5.0 for a mild regularization
-            if isinstance(physics, torch.nn.DataParallel):
-                x_nl = physics.module.prox_l2(0.0, y, 5.0)
-            else:
-                x_nl = physics.prox_l2(0.0, y, 5.0)
+            try:
+                x_nl = physics_.prox_l2(0.0, y, 5.0)
+            except (AttributeError, NotImplementedError):
+                raise _not_implemented()
         elif self.no_learning_method == "y":
             x_nl = y
         else:
-            raise ValueError(
-                f"No learning reconstruction method {self.no_learning_method} not recognized or physics does not implement it"
-            )
+            raise _not_implemented()
 
         return x_nl
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,7 @@ New Features
 
 Changed
 ^^^^^^^
+- Deprecate :class:`deepinv.physics.LinearPhysics`, :class:`deepinv.physics.ComposedLinearPhysics`, :class:`deepinv.physics.StackedLinearPhysics`, :class:`deepinv.physics.LinearPhysicsMultiScaler` and :class:`deepinv.distributed.DistributedStackedLinearPhysics` in favor of a new boolean attribute ``Physics.linear``. All the corresponding functionality (``A_adjoint``, ``A_dagger``, ``prox_l2``, ``compute_norm``, etc.) now lives directly on :class:`deepinv.physics.Physics`, gated by ``self.linear``. The deprecated classes remain fully functional, and ``isinstance(physics, LinearPhysics)`` keeps working for any ``Physics`` instance with ``physics.linear=True``, regardless of its concrete class (by `Jérémy Scanvic`_)
 - (Breaking) Drop support for deprecated parameters `num_channels` in :class:`deepinv.physics.generator.PSFGenerator`, :class:`deepinv.physics.generator.GaussianBlurGenerator`, :class:`deepinv.physics.generator.MotionBlurGenerator`, :class:`deepinv.physics.generator.DiffractionBlurGenerator`, :class:`deepinv.physics.generator.DiffractionBlurGenerator3D` (:gh:`1242` by `Pierre Weiss`_ and `Florian Sarron`_)
 - Extend :func:`DST-I <deepinv.physics.functional.dst1>` to make it n-dimensional and add an option to have it compute the regular DST-I instead of the non-standard sign-flipped orthogonal variant (:gh:`934` by `Jérémy Scanvic`_)
 - (Breaking) Make :class:`deepinv.optim.TVPrior()` compute an explicit choice of subgradient instead of using autodiff. (:gh:`1271` by `Thibaut Modrzyk`_)

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -281,7 +281,7 @@ Adding a physical operator follows the general contribution guidelines. Specific
 
 - Implementing a new class that inherits from the appropriate physics base class. Refer to the design outlined in `Bring your own physics <https://deepinv.org/auto_examples/basics/demo_custom_physics.html>`_ for guidance.
 
-- Registering the physics in the appropriate test suite and verifying that the tests pass -- when inheriting from :class:`deepinv.physics.LinearPhysics`, it involves the following modifications to `deepinv/tests/test_physics.py`:
+- Registering the physics in the appropriate test suite and verifying that the tests pass -- when your operator is linear (i.e. you subclass :class:`deepinv.physics.Physics` and pass ``linear=True`` to ``super().__init__()``), it involves the following modifications to `deepinv/tests/test_physics.py`:
 
   1. Adding a new entry corresponding to your physics configuration to the list variable ``OPERATORS``
 

--- a/examples/basics/demo_custom_physics.py
+++ b/examples/basics/demo_custom_physics.py
@@ -10,8 +10,7 @@ you can also bring your own forward operator for your specific imaging problem.
 DeepInverse's modular :ref:`physics framework <physics_intro>` makes this easy by letting you inherit useful methods from the most appropriate
 physics base class:
 
-* :class:`deepinv.physics.Physics` for non-linear operators;
-* :class:`deepinv.physics.LinearPhysics` for linear operators;
+* :class:`deepinv.physics.Physics` for non-linear operators, or linear operators by passing ``linear=True``;
 * :class:`deepinv.physics.DecomposablePhysics` for linear operators with a closed-form singular value decomposition.
 
 .. seealso::
@@ -36,14 +35,14 @@ import torch
 # Creating a custom forward operator.
 # ----------------------------------------------------------------------------------------
 # Defining a new linear operator only requires a forward function :math:`\forw{\cdot}` and its adjoint operation :math:`A^\top(\cdot)`,
-# inheriting the remaining structure of the :class:`deepinv.physics.LinearPhysics` class.
+# inheriting the remaining structure of the :class:`deepinv.physics.Physics` class by passing ``linear=True``
+# to ``super().__init__()``.
 #
-# Once the operator is defined, we can use any of the functions in the :class:`deepinv.physics.Physics` class and
-# :class:`deepinv.physics.LinearPhysics` class, such as computing the norm of the operator, testing the adjointness,
-# computing the proximal operator, etc.
+# Once the operator is defined, we can use any of the linear-only methods of the :class:`deepinv.physics.Physics`
+# class, such as computing the norm of the operator, testing the adjointness, computing the proximal operator, etc.
 #
 # .. tip::
-#     By default, the adjoint of a :class:`LinearPhysics <deepinv.physics.LinearPhysics>` is computed using autograd with :class:`deepinv.physics.adjoint_function`.
+#     By default, the adjoint of a linear :class:`Physics <deepinv.physics.Physics>` operator is computed using autograd with :class:`deepinv.physics.adjoint_function`.
 #     Note however that defining a closed form adjoint is generally more computationally efficient in memory and time.
 #
 # .. note::
@@ -59,7 +58,7 @@ import torch
 #     Inherit from :ref:`mixin <mixin>` classes to provide specialized methods for your physics.
 
 
-class Decolorize(dinv.physics.LinearPhysics):
+class Decolorize(dinv.physics.Physics):
     r"""
     Converts RGB images to grayscale.
     """
@@ -70,7 +69,7 @@ class Decolorize(dinv.physics.LinearPhysics):
         dtype: torch.dtype = torch.float32,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(linear=True, **kwargs)
         coefficients = torch.tensor(
             [0.2989, 0.5870, 0.1140], dtype=dtype, device=device
         )
@@ -118,7 +117,7 @@ y = physics(x)
 dinv.utils.plot({"x": x, "y": y, "Linear pseudo-inverse": physics.A_dagger(y)})
 
 # %%
-# It is often useful for reconstruction algorithms that the physics has unit norm, which you can verify using :func:`deepinv.physics.LinearPhysics.compute_norm`.
+# It is often useful for reconstruction algorithms that the physics has unit norm, which you can verify using :func:`deepinv.physics.Physics.compute_norm`.
 # We see that this physics fails this.
 
 print(f"The linear operator has norm={physics.compute_sqnorm(x):.2f}")
@@ -151,14 +150,14 @@ print(
 # Implementing a closed form adjoint
 # --------------------------------------------
 # Instead, if we know the closed form of the adjoint operator, we can implement it directly in
-# :func:`deepinv.physics.LinearPhysics.A_adjoint`, instead of relying on
+# :func:`deepinv.physics.Physics.A_adjoint`, instead of relying on
 # :func:`autodifferentiation <deepinv.physics.adjoint_function>` which is generally less efficient.
 #
 # An additional benefit of implementing the adjoint is that we no longer require the `img_size` parameter when creating the
 # operator, which was needed for autodifferentiation.
 #
 # If you implement your own adjoint, it is recommended to verify that it is well-defined using
-# :func:`deepinv.physics.LinearPhysics.adjointness_test`.
+# :func:`deepinv.physics.Physics.adjointness_test`.
 
 
 class Decolorize2(Decolorize):
@@ -199,8 +198,9 @@ if physics.adjointness_test(x) < 1e-5:
 #
 #
 # .. tip::
-#    As in the case of `LinearPhysics`, `V` and `U_adjoint` are implemented using autodifferentiation by default,
-#    but you can implement them directly if you know the closed form of the operator.
+#    As in the case of a linear `Physics <deepinv.physics.Physics>` operator, `V` and `U_adjoint` are implemented
+#    using autodifferentiation by default, but you can implement them directly if you know the closed form of the
+#    operator.
 
 
 class DecolorizeSVD(dinv.physics.DecomposablePhysics):
@@ -260,7 +260,7 @@ for i in range(10):
 
 sync_cuda()
 end = time.time()
-print(f"Elapsed time for LinearPhysics: {end - start:.2f} seconds")
+print(f"Elapsed time for Physics(linear=True): {end - start:.2f} seconds")
 
 sync_cuda()
 start = time.time()

--- a/examples/external-libraries/demo_ri_basic.py
+++ b/examples/external-libraries/demo_ri_basic.py
@@ -44,13 +44,13 @@ device = dinv.utils.get_device()
 # and :math:`\epsilon \in \mathbb{C}^{m}` is a realization of some i.i.d. Gaussian random noise.
 #
 # This operator can be implemented with `TorchKbNUFFT <https://github.com/mmuckley/torchkbnufft>`_.
-# Below, we propose an implementation using the :class:`deepinv.physics.LinearPhysics`.
+# Below, we propose an implementation using the :class:`deepinv.physics.Physics` class with ``linear=True``.
 # As such, operations like grad and prox are available.
 
-from deepinv.physics import LinearPhysics
+from deepinv.physics import Physics
 
 
-class RadioInterferometry(LinearPhysics):
+class RadioInterferometry(Physics):
     r"""
     Radio Interferometry measurement operator.
 
@@ -79,7 +79,7 @@ class RadioInterferometry(LinearPhysics):
         device="cpu",
         **kwargs,
     ):
-        super(RadioInterferometry, self).__init__(**kwargs)
+        super(RadioInterferometry, self).__init__(linear=True, **kwargs)
 
         if dataWeight is None:
             dataWeight = torch.tensor([1.0], device=device)


### PR DESCRIPTION
Toying around for #1125

(Fully generated with an agent)

## Summary

Deprecates `deepinv.physics.LinearPhysics` as suggested in the class-hierarchy-complexity issue: instead of a separate class, linearity is now a queryable boolean attribute `Physics.linear`. Following the newly-adopted backwards-compatibility policy (#1316), nothing is removed -- `LinearPhysics` and its siblings remain fully functional, deprecated shims.

- All functionality previously exclusive to `LinearPhysics` (`A_adjoint`, `A_dagger`, `prox_l2`, `compute_norm`/`compute_sqnorm`, `adjointness_test`, `condition_number`, `A_A_adjoint`, `A_adjoint_A`) now lives directly on `Physics`, dispatching on `self.linear`. Calling a linear-only method on a non-linear `Physics` instance now raises a clear `NotImplementedError` instead of `AttributeError`.
- `isinstance(physics, LinearPhysics)` keeps working for **any** `Physics` instance with `linear=True`, regardless of its concrete class, via a metaclass `__instancecheck__` override -- exactly the mechanism the issue anticipated.
- `ComposedPhysics`/`StackedPhysics` now auto-derive `.linear` from their sub-operators and absorb `ComposedLinearPhysics`/`StackedLinearPhysics`, which directly resolves the "coexistence of `Physics` and `LinearPhysics`" complexity item (no more dispatching between two classes in `compose()`/`stack()`). Same treatment applied to `PhysicsMultiScaler`/`LinearPhysicsMultiScaler` and `DistributedStackedPhysics`/`DistributedStackedLinearPhysics`.
- `DecomposablePhysics` is **not** deprecated -- it now subclasses `Physics` directly (forcing `linear=True`) instead of `LinearPhysics`. The separate `Blur`/`BlurFFT` and `MRI`/`MultiCoilMRI` duplication the issue flags is a distinct, harder problem left out of scope.
- ~15 leaf physics classes (`Blur`, `Tomography`, `CompressedSensing`, `MultiCoilMRI`, `PET`, `RadioInterferometry`, `BornOperator`, etc.) switched from subclassing `LinearPhysics`/`DecomposablePhysics` to `Physics`/`DecomposablePhysics` directly.
- Internal `isinstance(..., LinearPhysics)` checks (`sampling.py`, `noisy_datafidelity.py`, `data_fidelity.py`, `deal.py`) and `hasattr`-based capability probing (`trainer.py`'s `no_learning_inference`, now `try`/`except`) were rewritten to stop depending on the deprecated class.
- `contributing.rst` and the `demo_custom_physics.py`/`demo_ri_basic.py` tutorials updated to teach the new `Physics(linear=True)` pattern.

## Test plan

- [x] Full `ast.parse` sweep + walk-import of every submodule in `deepinv` -- no import errors.
- [x] Targeted runtime checks: `.linear` dispatch for linear/non-linear `Physics`, auto-derived linearity on `Compose`/`Stack`/`MultiScaler`/`Distributed` variants, `isinstance` shim correctness for mixed linear/non-linear compositions.
- [x] Ran `demo_custom_physics.py` and `demo_ri_basic.py` end-to-end against the edited tree -- both produce correct output.
- [ ] Full `pytest` suite (not run as part of this change -- please run `test_physics.py`, `test_optim.py`, `test_distributed.py`, `test_loss.py` before merging).