### PR TITLE
Fix gpu trigger workflow

### DIFF
--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -11,7 +11,11 @@ on:
       pr_number:
         description: "PR number to test"
         required: true
-        type: number
+        type: string
+      pr_sha:
+        description: "Exact PR commit to test"
+        required: true
+        type: string
 
 jobs:
   gpu-docs:
@@ -29,11 +33,10 @@ jobs:
       HOME: "/local/jtachell"
 
     steps:
-      - uses: actions/checkout@v5
+      - name: Check out exact PR commit
+        uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha
-                  || (inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number))
-                  || github.sha }}
+            ref: ${{ inputs.pr_sha }}
 
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3

--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check out exact PR commit
         uses: actions/checkout@v5
         with:
-            ref: ${{ inputs.pr_sha }}
+          ref: ${{ inputs.pr_sha }}
 
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3

--- a/.github/workflows/docs_gpu.yml
+++ b/.github/workflows/docs_gpu.yml
@@ -33,10 +33,11 @@ jobs:
       HOME: "/local/jtachell"
 
     steps:
-      - name: Check out exact PR commit
+      - name: Check out main or PR commit
         uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.pr_sha }}
+          # `github.sha` is the commit that triggered the workflow, which is the latest commit on main for schedule/push events
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_sha || github.sha }}
 
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.3

--- a/.github/workflows/gpu_trigger.yml
+++ b/.github/workflows/gpu_trigger.yml
@@ -25,15 +25,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    #   - name: Get PR number
-    #     id: pr
-    #     run: |
-    #       if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-    #         echo "pr_number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
-    #       else
-    #         echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
-    #       fi
-
       - name: Get PR metadata
         id: pr
         uses: actions/github-script@v7

--- a/.github/workflows/gpu_trigger.yml
+++ b/.github/workflows/gpu_trigger.yml
@@ -25,14 +25,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get PR number
+    #   - name: Get PR number
+    #     id: pr
+    #     run: |
+    #       if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+    #         echo "pr_number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+    #       else
+    #         echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+    #       fi
+
+      - name: Get PR metadata
         id: pr
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "pr_number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
-          else
-            echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
-          fi
+        uses: actions/github-script@v7
+        env:
+            MANUAL_PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+            script: |
+                const pullNumber =
+                    context.eventName === "workflow_dispatch"
+                    ? Number(process.env.MANUAL_PR_NUMBER)
+                    : context.issue.number;
+
+                const { data: pr } = await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pullNumber
+                });
+
+                core.info(`PR number: ${pullNumber}`);
+                core.info(`PR head branch: ${pr.head.ref}`);
+                core.info(`PR head SHA: ${pr.head.sha}`);
+                core.info(`PR head repository: ${pr.head.repo.full_name}`);
+
+                core.setOutput("number", String(pullNumber));
+                core.setOutput("head_ref", pr.head.ref);
+                core.setOutput("head_sha", pr.head.sha);
+                core.setOutput("head_repo", pr.head.repo.full_name);
 
       - name: Verify commenter permissions
         if: github.event_name == 'issue_comment'
@@ -62,19 +90,27 @@ jobs:
           comment-id: ${{ github.event.comment.id }}
           reactions: rocket
 
-      - name: Trigger GPU Tests
+      - name: Trigger GPU Tests from PR branch
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: test_gpu.yml
-          ref: ${{ github.event.pull_request.head.ref }}
-          inputs: '{ "pr_number": "${{ steps.pr.outputs.pr_number }}" }'
+          ref: ${{ steps.pr.outputs.head_ref }}
+          inputs: >-
+            {
+                "pr_number": "${{ steps.pr.outputs.number }}",
+                "pr_sha": "${{ steps.pr.outputs.head_sha }}"
+            }
 
       - name: Trigger GPU Docs Check
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: docs_gpu.yml
-          ref: main
-          inputs: '{ "pr_number": "${{ steps.pr.outputs.pr_number }}" }'
+          ref: ${{ steps.pr.outputs.head_ref }}
+          inputs: >-
+            {
+              "pr_number": "${{ steps.pr.outputs.number }}",
+              "pr_sha": "${{ steps.pr.outputs.head_sha }}"
+            }
 
   post-comment:
     needs: trigger-gpu-workflows

--- a/.github/workflows/gpu_trigger.yml
+++ b/.github/workflows/gpu_trigger.yml
@@ -49,9 +49,7 @@ jobs:
                 core.info(`PR head repository: ${pr.head.repo.full_name}`);
 
                 core.setOutput("number", String(pullNumber));
-                core.setOutput("head_ref", pr.head.ref);
                 core.setOutput("head_sha", pr.head.sha);
-                core.setOutput("head_repo", pr.head.repo.full_name);
 
       - name: Verify commenter permissions
         if: github.event_name == 'issue_comment'
@@ -85,7 +83,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: test_gpu.yml
-          ref: ${{ steps.pr.outputs.head_ref }}
+          ref: ${{ steps.pr.outputs.head_sha }}
           inputs: >-
             {
                 "pr_number": "${{ steps.pr.outputs.number }}",
@@ -96,7 +94,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: docs_gpu.yml
-          ref: ${{ steps.pr.outputs.head_ref }}
+          ref: ${{ steps.pr.outputs.head_sha }}
           inputs: >-
             {
               "pr_number": "${{ steps.pr.outputs.number }}",

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check out exact PR commit
         uses: actions/checkout@v5
         with:
-            ref: ${{ inputs.pr_sha }}
+          ref: ${{ inputs.pr_sha }}
 
       # When testing a PR, restore the pixi.lock + .testmondata + .coverage triple solved on
       # main as a SINGLE cache entry (atomic, no lock/testmondata mismatch) so

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -9,9 +9,13 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to test"
+        description: "PR number"
         required: true
-        type: number
+        type: string
+      pr_sha:
+        description: "Exact PR commit to test"
+        required: true
+        type: string
 
 jobs:
   test:
@@ -28,11 +32,10 @@ jobs:
       TORCH_HOME: "/local/jtachell/.cache/torch"
 
     steps:
-      - uses: actions/checkout@v5
+      - name: Check out exact PR commit
+        uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.sha
-                  || (inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number))
-                  || github.sha }}
+            ref: ${{ inputs.pr_sha }}
 
       # When testing a PR, restore the pixi.lock + .testmondata + .coverage triple solved on
       # main as a SINGLE cache entry (atomic, no lock/testmondata mismatch) so

--- a/.github/workflows/test_gpu.yml
+++ b/.github/workflows/test_gpu.yml
@@ -32,10 +32,11 @@ jobs:
       TORCH_HOME: "/local/jtachell/.cache/torch"
 
     steps:
-      - name: Check out exact PR commit
+      - name: Check out main or PR commit
         uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.pr_sha }}
+          # `github.sha` is the commit that triggered the workflow, which is the latest commit on main for schedule/push events
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_sha || github.sha }}
 
       # When testing a PR, restore the pixi.lock + .testmondata + .coverage triple solved on
       # main as a SINGLE cache entry (atomic, no lock/testmondata mismatch) so

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Introduction
 ------------
 `DeepInverse <https://deepinv.org>`_ is an open-source PyTorch-based library for solving imaging inverse problems with deep learning.
 The library is part of the `official PyTorch Ecosystem <https://pytorch.landscape2.io/?item=modeling--computer-vision--deepinverse>`_.
-``deepinv`` accelerates deep learning research across imaging domains, enhances research reproducibility via a common modular framework of problems and algorithms, and lowers the entrance bar to new practitioners. 
+``deepinv`` accelerates deep learning research across imaging domains, enhances research reproducibility via a common modular framework of problems and algorithms, and lowers the entrance bar to new practitioners.
 
 
 .. image:: https://github.com/deepinv/deepinv/raw/main/docs/source/figures/deepinv_schematic.png

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Introduction
 ------------
 `DeepInverse <https://deepinv.org>`_ is an open-source PyTorch-based library for solving imaging inverse problems with deep learning.
 The library is part of the `official PyTorch Ecosystem <https://pytorch.landscape2.io/?item=modeling--computer-vision--deepinverse>`_.
-``deepinv`` accelerates deep learning research across imaging domains, enhances research reproducibility via a common modular framework of problems and algorithms, and lowers the entrance bar to new practitioners.
+``deepinv`` accelerates deep learning research across imaging domains, enhances research reproducibility via a common modular framework of problems and algorithms, and lowers the entrance bar to new practitioners. 
 
 
 .. image:: https://github.com/deepinv/deepinv/raw/main/docs/source/figures/deepinv_schematic.png


### PR DESCRIPTION
Changes to `gpu_trigger.yml` in #1291 broke the comment trigger workflow ("`/gpu-tests`"):
- https://github.com/deepinv/deepinv/actions/runs/31576473279
- https://github.com/deepinv/deepinv/actions/runs/31703242458

The goal in #1291 was to update the trigger workflow to choose the `test_gpu.yml` version located in the PR branch instead of `main`. We tried to do it by feeding `${{ github.event.pull_request.head.ref }}` which is only available on workflow triggered by[ `pull_request`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request) while the gpu workflow is triggered by an [`issue_comment`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#issue_comment). 

Instead of using  `${{ github.event.pull_request.head.ref }}` I'm retrieving the PR's metadata throug the github rest api.

This PR fixes this, hopefully :). There is no easy way to test trigger workflows as they run on `main`, I've merged and tested the update on my fork https://github.com/romainvo/deepinv/pull/3, should be good.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.