### PR TITLE
better adjointness test

### DIFF
--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -723,17 +723,17 @@ class LinearPhysics(Physics):
         )
 
         if u is not None:
-            u_in = randn_like(u)
-        else:
-            if img_size is None:
-                if self.img_size is not None:
-                    img_size = self.img_size
-                else:
-                    raise ValueError(
-                        "Either img_size or u must be provided for the adjointness test."
-                    )
-            # note: this does not support tensor lists
-            u_in = torch.randn((num_samples,) + img_size, device=device)
+            img_size = u.shape[1:]
+        elif img_size is None:
+            if self.img_size is not None:
+                img_size = self.img_size
+            else:
+                raise ValueError(
+                    "Either img_size or u must be provided for the adjointness test."
+                )
+
+        # note: this does not support tensor lists
+        u_in = torch.randn((num_samples,) + img_size, device=device)
 
         Au = self.A(u_in, **kwargs)
 

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -693,16 +693,50 @@ class LinearPhysics(Physics):
             **kwargs,
         )
 
-    def adjointness_test(self, u, **kwargs):
+    def adjointness_test(
+        self, u=None, img_size=None, num_samples=1, device=None, **kwargs
+    ):
         r"""
-        Numerically check that :math:`A^{\top}` is indeed the adjoint of :math:`A`.
+        Numerically check that :math:`B:=A^{\top}` is indeed the adjoint of :math:`A`.`.
 
-        :param torch.Tensor u: initialization point of the adjointness test method
+        Computes a Monte Carlo estimate of
 
-        :return: (float) a quantity that should be theoretically 0. In practice, it should be of the order of the chosen dtype precision (i.e. single or double).
+        .. math::
+                `\| AB - (AB)^{\top}\|_F`
+
+        as :math:`\sqrt{\mathbb{E}_{u,v} \left(u(AB - (AB)^{\top})v \right)^2}`
+        where :math:`u` and :math:`v` are standard Gaussian random vectors.
+
+        :param tuple img_size: Size of the signal/image `x`, e.g. `(C, ...)` where `C` is the number of channels and `...` are the spatial dimensions,
+        :param torch.Tensor, None u: (optional, only required if img_size is not provided) input tensor to the physics, only used to extract the `img_size`
+        :param int num_samples: number of random samples to use for the estimate. The more samples, the more accurate the estimate.
+        :param torch.device, str, None device: device to use for the computation. If `None`, uses the device of the u (if provided), otherwise sets to `cpu`.
+
+        :return: a scalar quantity that should be theoretically 0. For exact adjointness, it should be of the order of the chosen dtype precision (i.e. single or double).
 
         """
-        u_in = u  # .type(self.dtype)
+        if u is not None:
+            img_size = u.shape[1:]
+        elif img_size is None:
+            if self.img_size is not None:
+                img_size = self.img_size
+            else:
+                raise ValueError(
+                    "Either img_size or u must be provided for the adjointness test."
+                )
+
+        device = (
+            device
+            if device is not None
+            else (u.device if u is not None else torch.device("cpu"))
+        )
+
+        if u is not None:
+            u_in = randn_like(u)
+        else:
+            # note: this does not support tensor lists
+            u_in = torch.randn((num_samples,) + img_size, device=device)
+
         Au = self.A(u_in, **kwargs)
 
         if isinstance(Au, tuple) or isinstance(Au, list):
@@ -720,7 +754,7 @@ class LinearPhysics(Physics):
 
         s2 = (Atv * u_in.conj()).flatten().sum()
 
-        return s1.conj() - s2
+        return (s1.conj() - s2).abs().pow(2).mean().sqrt()
 
     def condition_number(self, x, max_iter=500, tol=1e-6, verbose=False, **kwargs):
         r"""

--- a/deepinv/physics/forward.py
+++ b/deepinv/physics/forward.py
@@ -715,15 +715,6 @@ class LinearPhysics(Physics):
         :return: a scalar quantity that should be theoretically 0. For exact adjointness, it should be of the order of the chosen dtype precision (i.e. single or double).
 
         """
-        if u is not None:
-            img_size = u.shape[1:]
-        elif img_size is None:
-            if self.img_size is not None:
-                img_size = self.img_size
-            else:
-                raise ValueError(
-                    "Either img_size or u must be provided for the adjointness test."
-                )
 
         device = (
             device
@@ -734,6 +725,13 @@ class LinearPhysics(Physics):
         if u is not None:
             u_in = randn_like(u)
         else:
+            if img_size is None:
+                if self.img_size is not None:
+                    img_size = self.img_size
+                else:
+                    raise ValueError(
+                        "Either img_size or u must be provided for the adjointness test."
+                    )
             # note: this does not support tensor lists
             u_in = torch.randn((num_samples,) + img_size, device=device)
 

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -726,7 +726,7 @@ def test_operators_adjointness(name, device, rng):
         dtype = torch.cfloat
 
     x = torch.randn(imsize, device=device, dtype=dtype, generator=rng).unsqueeze(0)
-    error = physics.adjointness_test(x).abs()
+    error = physics.adjointness_test(x)
     assert error < 1e-3
 
     if (
@@ -1451,7 +1451,7 @@ def test_tomography(
     ).unsqueeze(0)
 
     if adjoint_via_backprop:
-        assert physics.adjointness_test(x).abs() < 1e-3
+        assert physics.adjointness_test(x) < 1e-3
 
     if normalize:
         assert abs(physics.compute_sqnorm(x) - 1.0) < 1e-3
@@ -1565,7 +1565,7 @@ def test_downsampling_imsize(imsize, channels, device, factor, downsampling):
         imsize[0] * factor,
         imsize[1] * factor,
     )
-    assert physics.adjointness_test(x).abs() < 1e-3
+    assert physics.adjointness_test(x) < 1e-3
 
 
 def test_mri_fft():

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -741,6 +741,26 @@ def test_operators_adjointness(name, device, rng):
     assert error2 < 1e-3
 
 
+@pytest.mark.parametrize("num_samples", [1, 3])
+@pytest.mark.parametrize("name", ["deblur_valid", "pansharpen_valid"])
+def test_adjointness_test(name, num_samples, device, rng):
+    # test that the adjointness test works for multiple samples
+    physics, imsize, _, dtype = find_operator(name, device)
+
+    x = torch.randn((1,) + imsize, device=device, dtype=dtype, generator=rng)
+
+    # test with x input
+    assert physics.adjointness_test(x, num_samples=num_samples, device=device) < 1e-3
+
+    # test with img_size input
+    assert (
+        physics.adjointness_test(
+            img_size=imsize, num_samples=num_samples, device=device
+        )
+        < 1e-3
+    )
+
+
 LIST_DOWN_OP = [
     "down_resolution_circular",
     "down_resolution_reflect",


### PR DESCRIPTION
Small PR improving the meaning of `physics.adjointness_test`

It modifies the definition such that we compute $\|A A^{\top} - (AA^{\top})^{\top}\|_F$, which is always positive and can be related to the operator norm: if the error is much smaller than the norm, the lack of adjointness is less severe.

Keeps backwards compatibility with the previous API, but offers a new way of computing the adjointness error by passing `img_size` only

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.