### PR TITLE
Fix handling of unbatched PET attenuation

### DIFF
--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -347,6 +347,9 @@ class PET(LinearPhysics):
             n = len(self.img_size)
             is_image_space = tuple(attenuation.shape[-n:]) == tuple(self.img_size)
             if is_image_space:
+                # Add missing batch and channel dimensions before projection.
+                while attenuation.ndim < n + 2:
+                    attenuation = attenuation.unsqueeze(0)
                 if self.is_2d:
                     attenuation = attenuation.unsqueeze(-1)
 

--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -356,9 +356,9 @@ class PET(LinearPhysics):
                 proj_att = LinearSingleChannelOperator.apply(attenuation, self.proj)
                 if self.is_2d:
                     proj_att = proj_att.squeeze(-1)
-                self.attenuation = torch.exp(-proj_att)
+                self.attenuation = torch.exp(-proj_att).to(self.scanner.dev)
             else:
-                self.attenuation = attenuation
+                self.attenuation = attenuation.to(self.scanner.dev)
 
             if self.normalize:
                 self.operator_norm = torch.ones(1, device=self.attenuation.device)
@@ -368,7 +368,7 @@ class PET(LinearPhysics):
                     verbose=False,
                 )
         if background is not None:
-            self.background = background
+            self.background = background.to(self.scanner.dev)
 
 
 class LinearSingleChannelOperator(torch.autograd.Function):

--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -344,6 +344,7 @@ class PET(LinearPhysics):
         :param torch.Tensor background: If not `None`, update the background :math:`b`.
         """
         if attenuation is not None:
+            attenuation = attenuation.to(self.scanner.dev)
             n = len(self.img_size)
             is_image_space = tuple(attenuation.shape[-n:]) == tuple(self.img_size)
             if is_image_space:
@@ -356,9 +357,9 @@ class PET(LinearPhysics):
                 proj_att = LinearSingleChannelOperator.apply(attenuation, self.proj)
                 if self.is_2d:
                     proj_att = proj_att.squeeze(-1)
-                self.attenuation = torch.exp(-proj_att).to(self.scanner.dev)
+                self.attenuation = torch.exp(-proj_att)
             else:
-                self.attenuation = attenuation.to(self.scanner.dev)
+                self.attenuation = attenuation
 
             if self.normalize:
                 self.operator_norm = torch.ones(1, device=self.attenuation.device)

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -236,11 +236,14 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
             "installed with `conda install -c conda-forge parallelproj`",
         )
         img_size = (1, 16, 16) if imsize is None else imsize  # C,H,W
+        attenuation = torch.full(img_size, 0.01, device=device)
         p = dinv.physics.PET(
             img_size,
             normalize=True,
             device=device,
+            attenuation=attenuation,
         )
+        assert not torch.allclose(p.attenuation, torch.ones_like(p.attenuation))
         p.noise_model = dinv.physics.ZeroNoise()
         p.normalize = False  # stop auto-normalize to compute gradients wrt to attn
         params = ["background", "attenuation"]

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -244,6 +244,7 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
             attenuation=attenuation,
         )
         assert not torch.allclose(p.attenuation, torch.ones_like(p.attenuation))
+        p.update(attenuation=torch.ones_like(p.attenuation))
         p.noise_model = dinv.physics.ZeroNoise()
         p.normalize = False  # stop auto-normalize to compute gradients wrt to attn
         params = ["background", "attenuation"]

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -43,6 +43,7 @@ Fixed
 - Fix :func:`deepinv.transform.rotate_via_shear` for angles outside :math:`[0, 2pi)` (:gh:`1236` by `Sarra Amiri`_)
 - Fix inversion in :class:`deepinv.transform.Reflect` (:gh:`1236` by `Sarra Amiri`_)
 - (Breaking) Have `x_shift` represent horizontal shifts and `y_shift` vertical shifts in :class:`deepinv.transform.Shift` (:gh:`1236` by `Sarra Amiri`_)
+- Fix :class:`deepinv.physics.PET` incorrect device attribution of attenuation and background on update and incorrect handling of batched attenuation 
 
 
 v0.4.1


### PR DESCRIPTION
Closes #1330 + fixes device attribution for attenuation and background

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.