### PR TITLE
HOTFIX: Use main as ref for workflow dispatch

### DIFF
--- a/.github/workflows/gpu_trigger.yml
+++ b/.github/workflows/gpu_trigger.yml
@@ -83,7 +83,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: test_gpu.yml
-          ref: ${{ steps.pr.outputs.head_sha }}
+          ref: main
           inputs: >-
             {
                 "pr_number": "${{ steps.pr.outputs.number }}",
@@ -94,7 +94,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: docs_gpu.yml
-          ref: ${{ steps.pr.outputs.head_sha }}
+          ref: main
           inputs: >-
             {
               "pr_number": "${{ steps.pr.outputs.number }}",


### PR DESCRIPTION
The CI broke in #1291 while trying to select the workflow file on the PR branch for the workflow dispatch. We tried to fix it in #1327 but it seems that this issue is a limitation of the github API, i.e. github does not authorize running workflows on external repositories (without fine grained PAT for each external repo):
- https://github.com/benc-uk/workflow-dispatch/issues/15
- https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow

I am reverting to the old setup, where `docs/test_gpu.yml` are read from `main` when running `/gpu-tests`, which means no easy debugging of these workflows.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.