### PR TITLE
Faster tests

### DIFF
--- a/deepinv/models/ncsnpp.py
+++ b/deepinv/models/ncsnpp.py
@@ -160,12 +160,21 @@ class NCSNpp(Denoiser):
             else None
         )
         self.map_augment = (
-            Linear(in_features=augment_dim, out_features=noise_channels, bias=False, device=device)
+            Linear(
+                in_features=augment_dim,
+                out_features=noise_channels,
+                bias=False,
+                device=device,
+            )
             if augment_dim
             else None
         )
-        self.map_layer0 = Linear(in_features=noise_channels, out_features=emb_channels, device=device)
-        self.map_layer1 = Linear(in_features=emb_channels, out_features=emb_channels, device=device)
+        self.map_layer0 = Linear(
+            in_features=noise_channels, out_features=emb_channels, device=device
+        )
+        self.map_layer1 = Linear(
+            in_features=emb_channels, out_features=emb_channels, device=device
+        )
 
         # Encoder.
         self.enc = torch.nn.ModuleDict()
@@ -248,10 +257,7 @@ class NCSNpp(Denoiser):
                         resample_filter=resample_filter,
                     )
                 self.dec[f"{res}x{res}_aux_norm"] = GroupNorm(
-                    num_channels=cout,
-                    eps=1e-6,
-                    num_groups=32,
-                    device=device
+                    num_channels=cout, eps=1e-6, num_groups=32, device=device
                 )
                 self.dec[f"{res}x{res}_aux_conv"] = UpDownConv2d(
                     in_channels=cout, out_channels=out_channels, kernel=3, **init_zero

--- a/deepinv/models/ncsnpp.py
+++ b/deepinv/models/ncsnpp.py
@@ -155,17 +155,17 @@ class NCSNpp(Denoiser):
             else FourierEmbedding(num_channels=noise_channels, device=device)
         )
         self.map_label = (
-            Linear(in_features=label_dim, out_features=noise_channels)
+            Linear(in_features=label_dim, out_features=noise_channels, device=device)
             if label_dim
             else None
         )
         self.map_augment = (
-            Linear(in_features=augment_dim, out_features=noise_channels, bias=False)
+            Linear(in_features=augment_dim, out_features=noise_channels, bias=False, device=device)
             if augment_dim
             else None
         )
-        self.map_layer0 = Linear(in_features=noise_channels, out_features=emb_channels)
-        self.map_layer1 = Linear(in_features=emb_channels, out_features=emb_channels)
+        self.map_layer0 = Linear(in_features=noise_channels, out_features=emb_channels, device=device)
+        self.map_layer1 = Linear(in_features=emb_channels, out_features=emb_channels, device=device)
 
         # Encoder.
         self.enc = torch.nn.ModuleDict()
@@ -251,6 +251,7 @@ class NCSNpp(Denoiser):
                     num_channels=cout,
                     eps=1e-6,
                     num_groups=32,
+                    device=device
                 )
                 self.dec[f"{res}x{res}_aux_conv"] = UpDownConv2d(
                     in_channels=cout, out_channels=out_channels, kernel=3, **init_zero

--- a/deepinv/models/ncsnpp.py
+++ b/deepinv/models/ncsnpp.py
@@ -152,7 +152,7 @@ class NCSNpp(Denoiser):
         self.map_noise = (
             PositionalEmbedding(num_channels=noise_channels, endpoint=True)
             if embedding_type == "positional"
-            else FourierEmbedding(num_channels=noise_channels)
+            else FourierEmbedding(num_channels=noise_channels, device=device)
         )
         self.map_label = (
             Linear(in_features=label_dim, out_features=noise_channels)

--- a/deepinv/models/utils.py
+++ b/deepinv/models/utils.py
@@ -438,9 +438,16 @@ class PositionalEmbedding(torch.nn.Module):
 
 
 class FourierEmbedding(torch.nn.Module):
-    def __init__(self, num_channels: int, scale: int = 16, device: torch.device | str = "cpu",):
+    def __init__(
+        self,
+        num_channels: int,
+        scale: int = 16,
+        device: torch.device | str = "cpu",
+    ):
         super().__init__()
-        self.register_buffer("freqs", torch.randn(num_channels // 2, device=device) * scale)
+        self.register_buffer(
+            "freqs", torch.randn(num_channels // 2, device=device) * scale
+        )
 
     def forward(self, x: Tensor):
         x = x.outer((2 * np.pi * self.freqs).to(x.dtype))

--- a/deepinv/models/utils.py
+++ b/deepinv/models/utils.py
@@ -438,9 +438,9 @@ class PositionalEmbedding(torch.nn.Module):
 
 
 class FourierEmbedding(torch.nn.Module):
-    def __init__(self, num_channels: int, scale: int = 16):
+    def __init__(self, num_channels: int, scale: int = 16, device: torch.device | str = "cpu",):
         super().__init__()
-        self.register_buffer("freqs", torch.randn(num_channels // 2) * scale)
+        self.register_buffer("freqs", torch.randn(num_channels // 2, device=device) * scale)
 
     def forward(self, x: Tensor):
         x = x.outer((2 * np.pi * self.freqs).to(x.dtype))

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -1043,7 +1043,12 @@ class PosteriorDiffusion(Reconstructor):
             ):
                 # For EDM, we can compute the score from model output directly, avoid redundant computation
                 data_fid_grad, model_output = self.data_fidelity.grad(
-                    (x / scale), y, physics=physics, sigma=sigma, get_model_outputs=True
+                    (x / scale),
+                    y,
+                    physics=physics,
+                    sigma=sigma,
+                    get_model_outputs=True,
+                    **kwargs,
                 )
                 score = self.sde._score_from_model_output(
                     x, model_output, sigma, scale

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -531,9 +531,9 @@ def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST_1_CHANNEL)
-@pytest.mark.parametrize("batch_size", [1, 2, 3])
-def test_denoiser_sigma_gray(batch_size, denoiser, device):
-    img_size = (1, 64, 64)
+def test_denoiser_sigma_gray(denoiser, device):
+    batch_size = 2
+    img_size = (1, 32, 32)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
 
@@ -560,9 +560,9 @@ def test_denoiser_sigma_gray(batch_size, denoiser, device):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST)
-@pytest.mark.parametrize("batch_size", [1, 2, 3])
-def test_denoiser_sigma_color(batch_size, denoiser, device):
-    img_size = (3, 64, 64)
+def test_denoiser_sigma_color(denoiser, device):
+    batch_size = 2
+    img_size = (3, 32, 32)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
     x = torch.ones((batch_size,) + img_size, device=device, dtype=torch.float32)

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -531,9 +531,9 @@ def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST_1_CHANNEL)
-def test_denoiser_sigma_gray(denoiser, device):
-    batch_size = 2
-    img_size = (1, 32, 32)
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+def test_denoiser_sigma_gray(batch_size, denoiser, device):
+    img_size = (1, 64, 64)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
 
@@ -560,9 +560,9 @@ def test_denoiser_sigma_gray(denoiser, device):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST)
-def test_denoiser_sigma_color(denoiser, device):
-    batch_size = 2
-    img_size = (3, 32, 32)
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+def test_denoiser_sigma_color(batch_size, denoiser, device):
+    img_size = (3, 64, 64)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
     x = torch.ones((batch_size,) + img_size, device=device, dtype=torch.float32)

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -531,9 +531,9 @@ def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST_1_CHANNEL)
-@pytest.mark.parametrize("batch_size", [1, 2, 3])
+@pytest.mark.parametrize("batch_size", [1, 2])
 def test_denoiser_sigma_gray(batch_size, denoiser, device):
-    img_size = (1, 64, 64)
+    img_size = (1, 16, 16)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
 
@@ -560,9 +560,9 @@ def test_denoiser_sigma_gray(batch_size, denoiser, device):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST)
-@pytest.mark.parametrize("batch_size", [1, 2, 3])
+@pytest.mark.parametrize("batch_size", [1, 2])
 def test_denoiser_sigma_color(batch_size, denoiser, device):
-    img_size = (3, 64, 64)
+    img_size = (3, 16, 16)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
     x = torch.ones((batch_size,) + img_size, device=device, dtype=torch.float32)

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1265,7 +1265,6 @@ def test_correct_global_phase(device):
         ), f"correct_global_phase failed for shape {shape}"
 
 
-@pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize(
     "physics_name",
     [
@@ -1274,12 +1273,12 @@ def test_correct_global_phase(device):
     ],
 )
 @pytest.mark.parametrize("solver", solvers)
-def test_least_squares_implicit_backward(device, solver, physics_name, batch_size):
+def test_least_squares_implicit_backward(device, solver, physics_name):
     # Check that the backward gradient matches the finite difference gradient
-    prev_deterministic = torch.are_deterministic_algorithms_enabled()
-    torch.use_deterministic_algorithms(True)
-
+    batch_size = 2
     dtype = torch.float64
+    torch.manual_seed(2341)
+
     physics, img_size, _, _, params = find_operator(
         physics_name, device=device, get_physics_param=True
     )

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1378,7 +1378,7 @@ def test_least_squares_implicit_backward(device, solver, physics_name, batch_siz
                 expected_grad[idx_flat],
                 rtol=5e-2,
                 atol=5e-2,
-                msg=f"Gradient w.r.t physics parameter {k} does not match finite difference gradient. Between {implicit_grad.view(-1)[idx_flat]} and {expected_grad[idx_flat]}.",
+                msg=lambda default: f"Gradient w.r.t physics parameter {k} does not match finite difference gradient. " + default,
             )
 
     torch.use_deterministic_algorithms(prev_deterministic)

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -17,7 +17,6 @@ from deepinv.optim.optim_iterators import GDIteration
 from deepinv.tests.test_physics import find_operator
 from deepinv.optim.linear import least_squares, least_squares_implicit_backward
 
-from functools import partial
 import copy
 
 
@@ -1302,10 +1301,21 @@ def test_least_squares_implicit_backward(device, solver, physics_name):
     gamma_ = gamma.detach().clone().requires_grad_(True)
 
     with torch.enable_grad():
-        res_implicit = least_squares_implicit_backward(physics, y, z, init, gamma, eps=1e-6, tol=1e-3, max_iter=50).sum()
+        res_implicit = least_squares_implicit_backward(
+            physics, y, z, init, gamma, eps=1e-6, tol=1e-3, max_iter=50
+        ).sum()
         res_implicit.backward()
 
-        res = least_squares(A=physics.A, AT=physics.A_adjoint, y=y_, z=z_, init=init, gamma=gamma_, tol=1e-3, max_iter=50).sum()
+        res = least_squares(
+            A=physics.A,
+            AT=physics.A_adjoint,
+            y=y_,
+            z=z_,
+            init=init,
+            gamma=gamma_,
+            tol=1e-3,
+            max_iter=50,
+        ).sum()
         res.backward()
 
         assert z_.grad is not None and y_.grad is not None and gamma_.grad is not None
@@ -1385,7 +1395,8 @@ def test_least_squares_implicit_backward(device, solver, physics_name):
                 expected_grad[idx_flat],
                 rtol=5e-2,
                 atol=5e-2,
-                msg=lambda default: f"Gradient w.r.t physics parameter {k} does not match finite difference gradient. " + default,
+                msg=lambda default: f"Gradient w.r.t physics parameter {k} does not match finite difference gradient. "
+                + default,
             )
 
 

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -15,7 +15,7 @@ from deepinv.optim.data_fidelity import (
 from deepinv.optim.prior import Prior, PnP, RED
 from deepinv.optim.optim_iterators import GDIteration
 from deepinv.tests.test_physics import find_operator
-from deepinv.optim.utils import least_squares_implicit_backward
+from deepinv.optim.linear import least_squares, least_squares_implicit_backward
 
 from functools import partial
 import copy
@@ -1294,17 +1294,25 @@ def test_least_squares_implicit_backward(device, solver, physics_name):
     gamma = (
         torch.rand((batch_size,), dtype=dtype, device=device, requires_grad=True) + 0.1
     )
+    gamma.retain_grad()
     init = torch.zeros_like(z).requires_grad_(False)
 
-    # This check can be quite slow since it needs to compute finite differences in all directions
-    # So we limit the number of iterations and allow a higher tolerance
-    assert torch.autograd.gradcheck(
-        partial(least_squares_implicit_backward, max_iter=20),
-        (physics, y, z, init, gamma),
-        eps=1e-6,
-        atol=1e-2,
-        rtol=1e-2,
-    )
+    y_ = y.detach().clone().requires_grad_(True)
+    z_ = z.detach().clone().requires_grad_(True)
+    gamma_ = gamma.detach().clone().requires_grad_(True)
+
+    with torch.enable_grad():
+        res_implicit = least_squares_implicit_backward(physics, y, z, init, gamma, eps=1e-6, tol=1e-3, max_iter=50).sum()
+        res_implicit.backward()
+
+        res = least_squares(A=physics.A, AT=physics.A_adjoint, y=y_, z=z_, init=init, gamma=gamma_, tol=1e-3, max_iter=50).sum()
+        res.backward()
+
+        assert z_.grad is not None and y_.grad is not None and gamma_.grad is not None
+        assert z.grad is not None and y.grad is not None and gamma.grad is not None
+        torch.testing.assert_close(z.grad, z_.grad, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(y.grad, y_.grad, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(gamma.grad, gamma_.grad, rtol=5e-2, atol=5e-2)
 
     # ------------------------------------------------------------
     # Check gradients physics parameters
@@ -1379,8 +1387,6 @@ def test_least_squares_implicit_backward(device, solver, physics_name):
                 atol=5e-2,
                 msg=lambda default: f"Gradient w.r.t physics parameter {k} does not match finite difference gradient. " + default,
             )
-
-    torch.use_deterministic_algorithms(prev_deterministic)
 
 
 def test_least_squares_implicit_backward_nonleaf_buffer_grad(device):

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -395,13 +395,14 @@ def test_diffusion_reproducibility(load_example_image, device, rng, sde_class):
 
     sigma_t = lambda t: 100 * t**2
     scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
+    kwargs = (
+        {"sigma_t": sigma_t, "scale_t": scale_t} if sde_class == EDMDiffusionSDE else {}
+    )
     sde = sde_class(
         denoiser=denoiser,
         solver=solver,
         device=device,
-        **(
-            {"sigma_t": sigma_t, "scale_t": scale_t} if sde_class == EDMDiffusionSDE else {}
-        ),
+        **kwargs,
     )
     x = load_example_image(
         "celeba_example.jpg",

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -355,8 +355,8 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
         posterior = PosteriorDiffusion(
             data_fidelity=DPSDataFidelity(denoiser=denoiser),
             sde=sde,
-            denoiser=NCSNpp(device=device),
-            solver=EulerSolver(timesteps=timesteps, rng=rng),
+            denoiser=denoiser,
+            solver=solver,
             dtype=torch.float64,
             device=device,
         )
@@ -368,6 +368,7 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
             physics,
             x_init=(2, 3, 64, 64),
             seed=111,
+            **kwargs,
         )
         # Test output shape
         assert x_hat.shape == (2, 3, 64, 64)

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -438,7 +438,7 @@ def test_diffusion_reproducibility(load_example_image, device, rng, sde_class):
         x_init=(2, 3, 64, 64),
         seed=111,
     )
-    assert torch.nn.functional.mse_loss(x_hat_1, x_hat_2, reduction="mean") < 1e-2
+    torch.testing.assert_close(x_hat_1, x_hat_2, rtol=1e-2, atol=1e-2)
 
 
 @torch.no_grad()

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -304,78 +304,78 @@ def test_build_algo(algo, imsize, device):
 @pytest.mark.parametrize("solver_class", [EulerSolver, HeunSolver])
 @pytest.mark.parametrize("denoiser_class", [NCSNpp, ADMUNet, DRUNet])
 def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class):
+    try:
+        if denoiser_class == ADMUNet:
+            kwargs = dict(class_labels=torch.eye(1000, device=device)[0:1])
+        else:
+            kwargs = dict()
+        denoiser = denoiser_class(pretrained="download").to(device)
+        x = load_example_image(
+            "celeba_example.jpg",
+            img_size=64,
+            resize_mode="resize",
+        ).to(device)
 
-    if denoiser_class == ADMUNet:
-        kwargs = dict(class_labels=torch.eye(1000, device=device)[0:1])
-    else:
-        kwargs = dict()
-    denoiser = denoiser_class(pretrained="download").to(device)
-    x = load_example_image(
-        "celeba_example.jpg",
-        img_size=64,
-        resize_mode="resize",
-    ).to(device)
+        # Set up the SDEs
+        num_steps = 2
+        rng = torch.Generator(device)
+        # Set up solvers
+        timesteps = torch.linspace(0.99, 0.001, num_steps, device=device)
+        solver = solver_class(
+            timesteps=timesteps,
+            rng=rng,
+        )
 
-    # Set up the SDEs
-    num_steps = 2
-    rng = torch.Generator(device)
-    # Set up solvers
-    timesteps = torch.linspace(0.99, 0.001, num_steps, device=device)
-    solver = solver_class(
-        timesteps=timesteps,
-        rng=rng,
-    )
+        if sde_class == EDMDiffusionSDE:
+            sigma_t = lambda t: 100 * t**2
+            scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
+            sde = sde_class(
+                sigma_t=sigma_t,
+                scale_t=scale_t,
+                denoiser=denoiser,
+                solver=solver,
+                device=device,
+            )
+        else:
+            sde = sde_class(
+                denoiser=denoiser,
+                solver=solver,
+                device=device,
+            )
+        # Test generation
+        sample, _trajectory = sde.sample(
+            (2, 3, 64, 64),
+            seed=10,
+            get_trajectory=True,
+            **kwargs,
+        )
+        assert sample.shape == (2, 3, 64, 64)
 
-    if sde_class == EDMDiffusionSDE:
-        sigma_t = lambda t: 100 * t**2
-        scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
-        sde = sde_class(
-            sigma_t=sigma_t,
-            scale_t=scale_t,
-            denoiser=denoiser,
-            solver=solver,
+        # Test posterior sampling
+        posterior = PosteriorDiffusion(
+            data_fidelity=DPSDataFidelity(denoiser=denoiser),
+            sde=sde,
+            denoiser=NCSNpp(device=device),
+            solver=EulerSolver(timesteps=timesteps, rng=rng),
+            dtype=torch.float64,
             device=device,
         )
-    else:
-        sde = sde_class(
-            denoiser=denoiser,
-            solver=solver,
-            device=device,
+        physics = dinv.physics.Inpainting(img_size=x.shape[1:], mask=0.5, device=device)
+        y = physics(x)
+
+        x_hat = posterior(
+            y,
+            physics,
+            x_init=(2, 3, 64, 64),
+            seed=111,
         )
-    # Test generation
-    sample, _trajectory = sde.sample(
-        (2, 3, 64, 64),
-        seed=10,
-        get_trajectory=True,
-        **kwargs,
-    )
-    assert sample.shape == (2, 3, 64, 64)
-
-    # Test posterior sampling
-    posterior = PosteriorDiffusion(
-        data_fidelity=DPSDataFidelity(denoiser=denoiser),
-        sde=sde,
-        denoiser=NCSNpp(device=device),
-        solver=EulerSolver(timesteps=timesteps, rng=rng),
-        dtype=torch.float64,
-        device=device,
-    )
-    physics = dinv.physics.Inpainting(img_size=x.shape[1:], mask=0.5, device=device)
-    y = physics(x)
-
-    x_hat = posterior(
-        y,
-        physics,
-        x_init=(2, 3, 64, 64),
-        seed=111,
-    )
-    # Test output shape
-    assert x_hat.shape == (2, 3, 64, 64)
-
-    # pytest seems to not clean objects properly, which can cause OOM errors.
-    del denoiser
-    gc.collect()
-    torch.cuda.empty_cache()
+        # Test output shape
+        assert x_hat.shape == (2, 3, 64, 64)
+    finally:
+        # pytest seems to not clean objects properly, which can cause OOM errors.
+        del denoiser, sde, posterior
+        gc.collect()
+        torch.cuda.empty_cache()
 
 
 @torch.no_grad()

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -372,6 +372,7 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     # Test output shape
     assert x_hat.shape == (2, 3, 64, 64)
 
+    # pytest seems to not clean objects properly, which can cause OOM errors.
     del denoiser
     gc.collect()
     torch.cuda.empty_cache()

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -317,7 +317,7 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     ).to(device)
 
     # Set up the SDEs
-    num_steps = 2
+    num_steps = 3
     rng = torch.Generator(device)
     # Set up solvers
     timesteps = torch.linspace(0.99, 0.001, num_steps)

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -1,3 +1,4 @@
+import gc
 import pytest
 import torch.nn
 import numpy as np
@@ -290,7 +291,6 @@ def test_build_algo(algo, imsize, device):
     assert f.mean_has_converged and f.var_has_converged and mean_ok and var_ok
 
 
-@pytest.mark.slow
 @torch.no_grad()
 @pytest.mark.parametrize(
     "sde_class",
@@ -317,7 +317,7 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     ).to(device)
 
     # Set up the SDEs
-    num_steps = 3
+    num_steps = 2
     rng = torch.Generator(device)
     # Set up solvers
     timesteps = torch.linspace(0.99, 0.001, num_steps, device=device)
@@ -368,6 +368,10 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     )
     # Test output shape
     assert x_hat.shape == (2, 3, 64, 64)
+
+    del denoiser
+    gc.collect()
+    torch.cuda.empty_cache()
 
 
 @torch.no_grad()

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -321,7 +321,10 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     rng = torch.Generator(device)
     # Set up solvers
     timesteps = torch.linspace(0.99, 0.001, num_steps, device=device)
-    solver = solver_class(timesteps=timesteps, rng=rng, )
+    solver = solver_class(
+        timesteps=timesteps,
+        rng=rng,
+    )
 
     if sde_class == EDMDiffusionSDE:
         sigma_t = lambda t: 100 * t**2

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -310,9 +310,14 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     else:
         kwargs = dict()
     denoiser = denoiser_class(pretrained="download").to(device)
+    x = load_example_image(
+        "celeba_example.jpg",
+        img_size=64,
+        resize_mode="resize",
+    ).to(device)
 
     # Set up the SDEs
-    num_steps = 10
+    num_steps = 2
     rng = torch.Generator(device)
     # Set up solvers
     timesteps = torch.linspace(0.99, 0.001, num_steps)
@@ -335,26 +340,13 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
             device=device,
         )
     # Test generation
-    sample_1, trajectory = sde.sample(
+    sample, _trajectory = sde.sample(
         (2, 3, 64, 64),
         seed=10,
         get_trajectory=True,
         **kwargs,
     )
-    x_init_1 = trajectory[0]
-
-    # Test output shape
-    assert sample_1.shape == (2, 3, 64, 64)
-    sample_2, trajectory = sde.sample(
-        (2, 3, 64, 64),
-        seed=10,
-        get_trajectory=True,
-        **kwargs,
-    )
-    x_init_2 = trajectory[0]
-    # Test reproducibility
-    assert torch.allclose(x_init_1, x_init_2, atol=1e-5, rtol=1e-5)
-    assert torch.nn.functional.mse_loss(sample_1, sample_2, reduction="mean") < 1e-2
+    assert sample.shape == (2, 3, 64, 64)
 
     # Test posterior sampling
     posterior = PosteriorDiffusion(
@@ -365,11 +357,6 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
         dtype=torch.float64,
         device=device,
     )
-    x = load_example_image(
-        "celeba_example.jpg",
-        img_size=64,
-        resize_mode="resize",
-    ).to(device)
     physics = dinv.physics.Inpainting(img_size=x.shape[1:], mask=0.5, device=device)
     y = physics(x)
 
@@ -381,14 +368,6 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     )
     # Test output shape
     assert x_hat_1.shape == (2, 3, 64, 64)
-    # Test reproducibility
-    x_hat_2 = posterior(
-        y,
-        physics,
-        x_init=(2, 3, 64, 64),
-        seed=111,
-    )
-    assert torch.nn.functional.mse_loss(x_hat_1, x_hat_2, reduction="mean") < 1e-2
 
 
 @torch.no_grad()

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -379,6 +379,67 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
 
 
 @torch.no_grad()
+@pytest.mark.parametrize(
+    "sde_class",
+    [
+        FlowMatching,
+        VarianceExplodingDiffusion,
+        VariancePreservingDiffusion,
+        EDMDiffusionSDE,
+    ],
+)
+def test_diffusion_reproducibility(load_example_image, device, rng, sde_class):
+    timesteps = torch.linspace(0.99, 0.001, 2, device=device)
+    denoiser = NCSNpp(pretrained="download").to(device)
+    solver = EulerSolver(timesteps=timesteps, rng=rng)
+
+    sigma_t = lambda t: 100 * t**2
+    scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
+    sde = sde_class(
+        denoiser=denoiser,
+        solver=solver,
+        device=device,
+        **(
+            {"sigma_t": sigma_t, "scale_t": scale_t} if sde_class == EDMDiffusionSDE else {}
+        ),
+    )
+    x = load_example_image(
+        "celeba_example.jpg",
+        img_size=64,
+        resize_mode="resize",
+    ).to(device)
+    physics = dinv.physics.Inpainting(img_size=x.shape[1:], mask=0.5, device=device)
+    y = physics(x)
+
+    # Test posterior sampling
+    posterior = PosteriorDiffusion(
+        data_fidelity=DPSDataFidelity(denoiser=denoiser),
+        sde=sde,
+        denoiser=denoiser,
+        solver=solver,
+        dtype=torch.float64,
+        device=device,
+    )
+
+    x_hat_1 = posterior(
+        y,
+        physics,
+        x_init=(2, 3, 64, 64),
+        seed=111,
+    )
+    # Test output shape
+    assert x_hat_1.shape == (2, 3, 64, 64)
+    # Test reproducibility
+    x_hat_2 = posterior(
+        y,
+        physics,
+        x_init=(2, 3, 64, 64),
+        seed=111,
+    )
+    assert torch.nn.functional.mse_loss(x_hat_1, x_hat_2, reduction="mean") < 1e-2
+
+
+@torch.no_grad()
 def test_noisy_data_fidelity(device):
     from deepinv.sampling import DPSDataFidelity, NoisyDataFidelity
     import itertools

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -320,8 +320,8 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     num_steps = 3
     rng = torch.Generator(device)
     # Set up solvers
-    timesteps = torch.linspace(0.99, 0.001, num_steps)
-    solver = solver_class(timesteps=timesteps, rng=rng)
+    timesteps = torch.linspace(0.99, 0.001, num_steps, device=device)
+    solver = solver_class(timesteps=timesteps, rng=rng, )
 
     if sde_class == EDMDiffusionSDE:
         sigma_t = lambda t: 100 * t**2
@@ -352,7 +352,7 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     posterior = PosteriorDiffusion(
         data_fidelity=DPSDataFidelity(denoiser=denoiser),
         sde=sde,
-        denoiser=NCSNpp(),
+        denoiser=NCSNpp(device=device),
         solver=EulerSolver(timesteps=timesteps, rng=rng),
         dtype=torch.float64,
         device=device,
@@ -360,14 +360,14 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
     physics = dinv.physics.Inpainting(img_size=x.shape[1:], mask=0.5, device=device)
     y = physics(x)
 
-    x_hat_1 = posterior(
+    x_hat = posterior(
         y,
         physics,
         x_init=(2, 3, 64, 64),
         seed=111,
     )
     # Test output shape
-    assert x_hat_1.shape == (2, 3, 64, 64)
+    assert x_hat.shape == (2, 3, 64, 64)
 
 
 @torch.no_grad()

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -4,7 +4,23 @@ import numpy as np
 
 import deepinv as dinv
 from deepinv.optim.data_fidelity import L2
-from deepinv.sampling import ULA, SKRock, DiffPIR, DPS, sampling_builder, DDRM
+from deepinv.sampling import (
+    ULA,
+    SKRock,
+    DiffPIR,
+    DPS,
+    sampling_builder,
+    DDRM,
+    VarianceExplodingDiffusion,
+    VariancePreservingDiffusion,
+    EDMDiffusionSDE,
+    FlowMatching,
+    PosteriorDiffusion,
+    DPSDataFidelity,
+    EulerSolver,
+    HeunSolver,
+)
+from deepinv.models import NCSNpp, ADMUNet, DRUNet
 
 SAMPLING_ALGOS = ["DDRM", "ULA", "SKRock"]
 
@@ -276,18 +292,16 @@ def test_build_algo(algo, imsize, device):
 
 @pytest.mark.slow
 @torch.no_grad()
-def test_sde(device, load_example_image):
-    from deepinv.sampling import (
+@pytest.parametrize(
+    "sde_class",
+    [
+        FlowMatching,
         VarianceExplodingDiffusion,
         VariancePreservingDiffusion,
         EDMDiffusionSDE,
-        FlowMatching,
-        PosteriorDiffusion,
-        DPSDataFidelity,
-        EulerSolver,
-        HeunSolver,
-    )
-    from deepinv.models import NCSNpp, ADMUNet, DRUNet
+    ],
+)
+def test_sde(device, load_example_image, sde_class):
 
     # Set up all denoisers
     denoisers = []
@@ -310,94 +324,86 @@ def test_sde(device, load_example_image):
         EulerSolver(timesteps=timesteps, rng=rng),
         HeunSolver(timesteps=timesteps, rng=rng),
     ]
-    sde_classes = [
-        FlowMatching,
-        VarianceExplodingDiffusion,
-        VariancePreservingDiffusion,
-        EDMDiffusionSDE,
-    ]
     for denoiser, kwargs in zip(denoisers, list_kwargs, strict=True):
         for solver in solvers:
-            for sde_class in sde_classes:
-                if sde_class == EDMDiffusionSDE:
-                    sigma_t = lambda t: 100 * t**2
-                    scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
-                    sde = sde_class(
-                        sigma_t=sigma_t,
-                        scale_t=scale_t,
-                        denoiser=denoiser,
-                        solver=solver,
-                        device=device,
-                    )
-                else:
-                    sde = sde_class(
-                        denoiser=denoiser,
-                        solver=solver,
-                        device=device,
-                    )
-                # Test generation
-                sample_1, trajectory = sde.sample(
-                    (2, 3, 64, 64),
-                    seed=10,
-                    get_trajectory=True,
-                    **kwargs,
-                )
-                x_init_1 = trajectory[0]
-
-                # Test output shape
-                assert sample_1.shape == (2, 3, 64, 64)
-                sample_2, trajectory = sde.sample(
-                    (2, 3, 64, 64),
-                    seed=10,
-                    get_trajectory=True,
-                    **kwargs,
-                )
-                x_init_2 = trajectory[0]
-                # Test reproducibility
-                assert torch.allclose(x_init_1, x_init_2, atol=1e-5, rtol=1e-5)
-                assert (
-                    torch.nn.functional.mse_loss(sample_1, sample_2, reduction="mean")
-                    < 1e-2
-                )
-
-                # Test posterior sampling
-                posterior = PosteriorDiffusion(
-                    data_fidelity=DPSDataFidelity(denoiser=denoiser),
-                    sde=sde,
-                    denoiser=denoisers[0],
-                    solver=solvers[0],
-                    dtype=torch.float64,
+            if sde_class == EDMDiffusionSDE:
+                sigma_t = lambda t: 100 * t**2
+                scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
+                sde = sde_class(
+                    sigma_t=sigma_t,
+                    scale_t=scale_t,
+                    denoiser=denoiser,
+                    solver=solver,
                     device=device,
                 )
-                x = load_example_image(
-                    "celeba_example.jpg",
-                    img_size=64,
-                    resize_mode="resize",
-                ).to(device)
-                physics = dinv.physics.Inpainting(
-                    img_size=x.shape[1:], mask=0.5, device=device
+            else:
+                sde = sde_class(
+                    denoiser=denoiser,
+                    solver=solver,
+                    device=device,
                 )
-                y = physics(x)
+            # Test generation
+            sample_1, trajectory = sde.sample(
+                (2, 3, 64, 64),
+                seed=10,
+                get_trajectory=True,
+                **kwargs,
+            )
+            x_init_1 = trajectory[0]
 
-                x_hat_1 = posterior(
-                    y,
-                    physics,
-                    x_init=(2, 3, 64, 64),
-                    seed=111,
-                )
-                # Test output shape
-                assert x_hat_1.shape == (2, 3, 64, 64)
-                # Test reproducibility
-                x_hat_2 = posterior(
-                    y,
-                    physics,
-                    x_init=(2, 3, 64, 64),
-                    seed=111,
-                )
-                assert (
-                    torch.nn.functional.mse_loss(x_hat_1, x_hat_2, reduction="mean")
-                    < 1e-2
-                )
+            # Test output shape
+            assert sample_1.shape == (2, 3, 64, 64)
+            sample_2, trajectory = sde.sample(
+                (2, 3, 64, 64),
+                seed=10,
+                get_trajectory=True,
+                **kwargs,
+            )
+            x_init_2 = trajectory[0]
+            # Test reproducibility
+            assert torch.allclose(x_init_1, x_init_2, atol=1e-5, rtol=1e-5)
+            assert (
+                torch.nn.functional.mse_loss(sample_1, sample_2, reduction="mean")
+                < 1e-2
+            )
+
+            # Test posterior sampling
+            posterior = PosteriorDiffusion(
+                data_fidelity=DPSDataFidelity(denoiser=denoiser),
+                sde=sde,
+                denoiser=denoisers[0],
+                solver=solvers[0],
+                dtype=torch.float64,
+                device=device,
+            )
+            x = load_example_image(
+                "celeba_example.jpg",
+                img_size=64,
+                resize_mode="resize",
+            ).to(device)
+            physics = dinv.physics.Inpainting(
+                img_size=x.shape[1:], mask=0.5, device=device
+            )
+            y = physics(x)
+
+            x_hat_1 = posterior(
+                y,
+                physics,
+                x_init=(2, 3, 64, 64),
+                seed=111,
+            )
+            # Test output shape
+            assert x_hat_1.shape == (2, 3, 64, 64)
+            # Test reproducibility
+            x_hat_2 = posterior(
+                y,
+                physics,
+                x_init=(2, 3, 64, 64),
+                seed=111,
+            )
+            assert (
+                torch.nn.functional.mse_loss(x_hat_1, x_hat_2, reduction="mean") < 1e-2
+            )
 
 
 @torch.no_grad()

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -292,7 +292,7 @@ def test_build_algo(algo, imsize, device):
 
 @pytest.mark.slow
 @torch.no_grad()
-@pytest.parametrize(
+@pytest.mark.parametrize(
     "sde_class",
     [
         FlowMatching,
@@ -301,7 +301,8 @@ def test_build_algo(algo, imsize, device):
         EDMDiffusionSDE,
     ],
 )
-def test_sde(device, load_example_image, sde_class):
+@pytest.mark.parametrize("solver_class", [EulerSolver, HeunSolver])
+def test_sde(device, load_example_image, sde_class, solver_class):
 
     # Set up all denoisers
     denoisers = []
@@ -320,90 +321,86 @@ def test_sde(device, load_example_image, sde_class):
     rng = torch.Generator(device)
     # Set up solvers
     timesteps = torch.linspace(0.99, 0.001, num_steps)
-    solvers = [
-        EulerSolver(timesteps=timesteps, rng=rng),
-        HeunSolver(timesteps=timesteps, rng=rng),
-    ]
+    solver = solver_class(timesteps=timesteps, rng=rng)
     for denoiser, kwargs in zip(denoisers, list_kwargs, strict=True):
-        for solver in solvers:
-            if sde_class == EDMDiffusionSDE:
-                sigma_t = lambda t: 100 * t**2
-                scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
-                sde = sde_class(
-                    sigma_t=sigma_t,
-                    scale_t=scale_t,
-                    denoiser=denoiser,
-                    solver=solver,
-                    device=device,
-                )
-            else:
-                sde = sde_class(
-                    denoiser=denoiser,
-                    solver=solver,
-                    device=device,
-                )
-            # Test generation
-            sample_1, trajectory = sde.sample(
-                (2, 3, 64, 64),
-                seed=10,
-                get_trajectory=True,
-                **kwargs,
-            )
-            x_init_1 = trajectory[0]
-
-            # Test output shape
-            assert sample_1.shape == (2, 3, 64, 64)
-            sample_2, trajectory = sde.sample(
-                (2, 3, 64, 64),
-                seed=10,
-                get_trajectory=True,
-                **kwargs,
-            )
-            x_init_2 = trajectory[0]
-            # Test reproducibility
-            assert torch.allclose(x_init_1, x_init_2, atol=1e-5, rtol=1e-5)
-            assert (
-                torch.nn.functional.mse_loss(sample_1, sample_2, reduction="mean")
-                < 1e-2
-            )
-
-            # Test posterior sampling
-            posterior = PosteriorDiffusion(
-                data_fidelity=DPSDataFidelity(denoiser=denoiser),
-                sde=sde,
-                denoiser=denoisers[0],
-                solver=solvers[0],
-                dtype=torch.float64,
+        if sde_class == EDMDiffusionSDE:
+            sigma_t = lambda t: 100 * t**2
+            scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
+            sde = sde_class(
+                sigma_t=sigma_t,
+                scale_t=scale_t,
+                denoiser=denoiser,
+                solver=solver,
                 device=device,
             )
-            x = load_example_image(
-                "celeba_example.jpg",
-                img_size=64,
-                resize_mode="resize",
-            ).to(device)
-            physics = dinv.physics.Inpainting(
-                img_size=x.shape[1:], mask=0.5, device=device
+        else:
+            sde = sde_class(
+                denoiser=denoiser,
+                solver=solver,
+                device=device,
             )
-            y = physics(x)
+        # Test generation
+        sample_1, trajectory = sde.sample(
+            (2, 3, 64, 64),
+            seed=10,
+            get_trajectory=True,
+            **kwargs,
+        )
+        x_init_1 = trajectory[0]
 
-            x_hat_1 = posterior(
-                y,
-                physics,
-                x_init=(2, 3, 64, 64),
-                seed=111,
-            )
-            # Test output shape
-            assert x_hat_1.shape == (2, 3, 64, 64)
-            # Test reproducibility
-            x_hat_2 = posterior(
-                y,
-                physics,
-                x_init=(2, 3, 64, 64),
-                seed=111,
-            )
-            assert (
-                torch.nn.functional.mse_loss(x_hat_1, x_hat_2, reduction="mean") < 1e-2
-            )
+        # Test output shape
+        assert sample_1.shape == (2, 3, 64, 64)
+        sample_2, trajectory = sde.sample(
+            (2, 3, 64, 64),
+            seed=10,
+            get_trajectory=True,
+            **kwargs,
+        )
+        x_init_2 = trajectory[0]
+        # Test reproducibility
+        assert torch.allclose(x_init_1, x_init_2, atol=1e-5, rtol=1e-5)
+        assert (
+            torch.nn.functional.mse_loss(sample_1, sample_2, reduction="mean")
+            < 1e-2
+        )
+
+        # Test posterior sampling
+        posterior = PosteriorDiffusion(
+            data_fidelity=DPSDataFidelity(denoiser=denoiser),
+            sde=sde,
+            denoiser=denoisers[0],
+            solver=EulerSolver(timesteps=timesteps, rng=rng),
+            dtype=torch.float64,
+            device=device,
+        )
+        x = load_example_image(
+            "celeba_example.jpg",
+            img_size=64,
+            resize_mode="resize",
+        ).to(device)
+        physics = dinv.physics.Inpainting(
+            img_size=x.shape[1:], mask=0.5, device=device
+        )
+        y = physics(x)
+
+        x_hat_1 = posterior(
+            y,
+            physics,
+            x_init=(2, 3, 64, 64),
+            seed=111,
+        )
+        # Test output shape
+        assert x_hat_1.shape == (2, 3, 64, 64)
+        # Test reproducibility
+        x_hat_2 = posterior(
+            y,
+            physics,
+            x_init=(2, 3, 64, 64),
+            seed=111,
+        )
+        assert (
+            torch.nn.functional.mse_loss(x_hat_1, x_hat_2, reduction="mean") < 1e-2
+        )
 
 
 @torch.no_grad()

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -302,19 +302,14 @@ def test_build_algo(algo, imsize, device):
     ],
 )
 @pytest.mark.parametrize("solver_class", [EulerSolver, HeunSolver])
-def test_sde(device, load_example_image, sde_class, solver_class):
+@pytest.mark.parametrize("denoiser_class", [NCSNpp, ADMUNet, DRUNet])
+def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class):
 
-    # Set up all denoisers
-    denoisers = []
-    list_kwargs = []
-    denoisers.append(NCSNpp(pretrained="download").to(device))
-    list_kwargs.append(dict())
-
-    denoisers.append(ADMUNet(pretrained="download").to(device))
-    list_kwargs.append(dict(class_labels=torch.eye(1000, device=device)[0:1]))
-
-    denoisers.append(DRUNet(pretrained="download").to(device))
-    list_kwargs.append(dict())
+    if denoiser_class == ADMUNet:
+        kwargs = dict(class_labels=torch.eye(1000, device=device)[0:1])
+    else:
+        kwargs = dict()
+    denoiser = denoiser_class(pretrained="download").to(device)
 
     # Set up the SDEs
     num_steps = 10
@@ -322,85 +317,78 @@ def test_sde(device, load_example_image, sde_class, solver_class):
     # Set up solvers
     timesteps = torch.linspace(0.99, 0.001, num_steps)
     solver = solver_class(timesteps=timesteps, rng=rng)
-    for denoiser, kwargs in zip(denoisers, list_kwargs, strict=True):
-        if sde_class == EDMDiffusionSDE:
-            sigma_t = lambda t: 100 * t**2
-            scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
-            sde = sde_class(
-                sigma_t=sigma_t,
-                scale_t=scale_t,
-                denoiser=denoiser,
-                solver=solver,
-                device=device,
-            )
-        else:
-            sde = sde_class(
-                denoiser=denoiser,
-                solver=solver,
-                device=device,
-            )
-        # Test generation
-        sample_1, trajectory = sde.sample(
-            (2, 3, 64, 64),
-            seed=10,
-            get_trajectory=True,
-            **kwargs,
-        )
-        x_init_1 = trajectory[0]
 
-        # Test output shape
-        assert sample_1.shape == (2, 3, 64, 64)
-        sample_2, trajectory = sde.sample(
-            (2, 3, 64, 64),
-            seed=10,
-            get_trajectory=True,
-            **kwargs,
-        )
-        x_init_2 = trajectory[0]
-        # Test reproducibility
-        assert torch.allclose(x_init_1, x_init_2, atol=1e-5, rtol=1e-5)
-        assert (
-            torch.nn.functional.mse_loss(sample_1, sample_2, reduction="mean")
-            < 1e-2
-        )
-
-        # Test posterior sampling
-        posterior = PosteriorDiffusion(
-            data_fidelity=DPSDataFidelity(denoiser=denoiser),
-            sde=sde,
-            denoiser=denoisers[0],
-            solver=EulerSolver(timesteps=timesteps, rng=rng),
-            dtype=torch.float64,
+    if sde_class == EDMDiffusionSDE:
+        sigma_t = lambda t: 100 * t**2
+        scale_t = lambda t: 1 / (1 + sigma_t(t) ** 2) ** 0.5
+        sde = sde_class(
+            sigma_t=sigma_t,
+            scale_t=scale_t,
+            denoiser=denoiser,
+            solver=solver,
             device=device,
         )
-        x = load_example_image(
-            "celeba_example.jpg",
-            img_size=64,
-            resize_mode="resize",
-        ).to(device)
-        physics = dinv.physics.Inpainting(
-            img_size=x.shape[1:], mask=0.5, device=device
+    else:
+        sde = sde_class(
+            denoiser=denoiser,
+            solver=solver,
+            device=device,
         )
-        y = physics(x)
+    # Test generation
+    sample_1, trajectory = sde.sample(
+        (2, 3, 64, 64),
+        seed=10,
+        get_trajectory=True,
+        **kwargs,
+    )
+    x_init_1 = trajectory[0]
 
-        x_hat_1 = posterior(
-            y,
-            physics,
-            x_init=(2, 3, 64, 64),
-            seed=111,
-        )
-        # Test output shape
-        assert x_hat_1.shape == (2, 3, 64, 64)
-        # Test reproducibility
-        x_hat_2 = posterior(
-            y,
-            physics,
-            x_init=(2, 3, 64, 64),
-            seed=111,
-        )
-        assert (
-            torch.nn.functional.mse_loss(x_hat_1, x_hat_2, reduction="mean") < 1e-2
-        )
+    # Test output shape
+    assert sample_1.shape == (2, 3, 64, 64)
+    sample_2, trajectory = sde.sample(
+        (2, 3, 64, 64),
+        seed=10,
+        get_trajectory=True,
+        **kwargs,
+    )
+    x_init_2 = trajectory[0]
+    # Test reproducibility
+    assert torch.allclose(x_init_1, x_init_2, atol=1e-5, rtol=1e-5)
+    assert torch.nn.functional.mse_loss(sample_1, sample_2, reduction="mean") < 1e-2
+
+    # Test posterior sampling
+    posterior = PosteriorDiffusion(
+        data_fidelity=DPSDataFidelity(denoiser=denoiser),
+        sde=sde,
+        denoiser=NCSNpp(),
+        solver=EulerSolver(timesteps=timesteps, rng=rng),
+        dtype=torch.float64,
+        device=device,
+    )
+    x = load_example_image(
+        "celeba_example.jpg",
+        img_size=64,
+        resize_mode="resize",
+    ).to(device)
+    physics = dinv.physics.Inpainting(img_size=x.shape[1:], mask=0.5, device=device)
+    y = physics(x)
+
+    x_hat_1 = posterior(
+        y,
+        physics,
+        x_init=(2, 3, 64, 64),
+        seed=111,
+    )
+    # Test output shape
+    assert x_hat_1.shape == (2, 3, 64, 64)
+    # Test reproducibility
+    x_hat_2 = posterior(
+        y,
+        physics,
+        x_init=(2, 3, 64, 64),
+        seed=111,
+    )
+    assert torch.nn.functional.mse_loss(x_hat_1, x_hat_2, reduction="mean") < 1e-2
 
 
 @torch.no_grad()


### PR DESCRIPTION
This PR targets [3 of the slowest tests](https://github.com/deepinv/deepinv/actions/runs/31991013911/job/95274487263#step:8:999).
Time comparisons are done on my machine, on CPU and GPU.


#### `test_sampling::test_sde`
Before: 2300s
After: 360s
`test_diffusion_reproducibility`: 27s

- Parametrization to avoid big nested loops
- Reduction of number of steps (10 -> 2) since we don't test performances
- Moved seed reproducibility test to a new test: `test_diffusion_reproducibility`
- Added a `device` argument to `FourierEmbedding` since I got an error about tensors being on different devices

#### `test_models::test_denoiser_sigma_{gray, color}`

Before: 630s for gray, 1140s for color
After: 97s for gray, 190s for color

- Only test with `batch_size=1 and 2` (not 3)
- Image size from 64x64 -> 16x16
Note: this test is slow especially because of DEAL. I'm opening a separate PR for this.

#### `test_optim::test_least_squares_implicit_backward`

Before: 5400s
After: 8s

- Removed call to `torch.gradcheck`
- Compare gradient of `least_squares_implicit_backward` and `least_squares`
- Use of a manual seed (this was a flaky tests that would regularly fail the CI, this seed seems to work on my machine). See #1168 

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [-] Updated docstrings related to the changes (as applicable).
- [-] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.