### PR TITLE
DEAL: cleaning, more parametrization and faster testing

### DIFF
--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -103,7 +103,6 @@ class DEAL(Reconstructor):
         pretrained: str = "pretrained",
         inner_iter: int = 200,
         outer_iter: int = 60,
-
     ) -> None:
         super().__init__()
 
@@ -116,7 +115,9 @@ class DEAL(Reconstructor):
         self.inner_iter = inner_iter
         self.outer_iter = outer_iter
 
-        self.model = _DEALImpl(color=color, inner_iter=self.inner_iter, outer_iter=self.outer_iter).to(device)
+        self.model = _DEALImpl(
+            color=color, inner_iter=self.inner_iter, outer_iter=self.outer_iter
+        ).to(device)
 
         if pretrained is None:
             state = None
@@ -815,7 +816,9 @@ class _DEALImpl(nn.Module):
     :class:`DEAL` wrapper.
     """
 
-    def __init__(self, color: bool, inner_iter: int = 200, outer_iter: int = 60) -> None:
+    def __init__(
+        self, color: bool, inner_iter: int = 200, outer_iter: int = 60
+    ) -> None:
         super().__init__()
 
         self.kernel_size = 9
@@ -1037,7 +1040,7 @@ class _DEALImpl(nn.Module):
         if self.training:
             self.c_k_list = []
             grad_steps = 1
-            n_out = int(torch.randint(14, self.outer_iter-1, (1, 1)).item())
+            n_out = int(torch.randint(14, self.outer_iter - 1, (1, 1)).item())
             n_in = self.inner_iter // 4
             eps_in = 1e-4
             eps_out = 1e-4

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -85,6 +85,8 @@ class DEAL(Reconstructor):
         ``'pretrained'``, or ``None``. If ``None``, no pretrained weights are
         loaded. If ``'download'`` or ``'pretrained'``, the official DEAL
         pretrained weights are downloaded and loaded.
+    :param int cg_max_iter: maximum number of inner fixed-point iterations and conjugate gradient
+        algorithm.
     """
 
     def __init__(
@@ -98,6 +100,8 @@ class DEAL(Reconstructor):
         device: str | None = None,
         clamp_output: bool = True,
         pretrained: str = "pretrained",
+        cg_max_iter: int = 200,
+
     ) -> None:
         super().__init__()
 
@@ -109,7 +113,7 @@ class DEAL(Reconstructor):
         self.clamp_output = clamp_output
         self.cg_max_iter = cg_max_iter
 
-        self.model = _DEALImpl(color=color).to(device)
+        self.model = _DEALImpl(color=color, max_iter=self.cg_max_iter).to(device)
 
         if pretrained is None:
             state = None
@@ -808,7 +812,7 @@ class _DEALImpl(nn.Module):
     :class:`DEAL` wrapper.
     """
 
-    def __init__(self, color: bool, max_iter: int = 1000) -> None:
+    def __init__(self, color: bool, max_iter: int = 200) -> None:
         super().__init__()
 
         self.kernel_size = 9
@@ -1037,7 +1041,7 @@ class _DEALImpl(nn.Module):
         else:
             grad_steps = 0
             n_out = 60
-            n_in = 200
+            n_in = self.max_iter
             eps_in = 1e-6
             eps_out = 1e-5
 
@@ -1114,7 +1118,7 @@ class _DEALImpl(nn.Module):
                 c_k = Ht(y) * 0
             c_k_old = c_k.clone()
 
-            for m in range(self.max_iter):
+            for m in range(1000):
                 if path:
                     c_ks.append(c_k)
 
@@ -1125,7 +1129,7 @@ class _DEALImpl(nn.Module):
                     A=A_op,
                     b=b,
                     init=c_k_old,
-                    max_iter=self.max_iter,
+                    max_iter=1000,
                     tol=eps_in,
                     eps=1e-8,
                 )
@@ -1138,7 +1142,7 @@ class _DEALImpl(nn.Module):
                         "CG Number:",
                         m,
                         "CG iterations:",
-                        self.max_iter,
+                        1000,
                         "Outer residual:",
                         res,
                     )

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -85,8 +85,9 @@ class DEAL(Reconstructor):
         ``'pretrained'``, or ``None``. If ``None``, no pretrained weights are
         loaded. If ``'download'`` or ``'pretrained'``, the official DEAL
         pretrained weights are downloaded and loaded.
-    :param int cg_max_iter: maximum number of inner fixed-point iterations and conjugate gradient
+    :param int inner_iter: maximum number of iterations of the conjugate gradient
         algorithm.
+    :param int outer_iter: maximum number of inner fixed-point iterations and conjugate gradient
     """
 
     def __init__(
@@ -100,7 +101,8 @@ class DEAL(Reconstructor):
         device: str | None = None,
         clamp_output: bool = True,
         pretrained: str = "pretrained",
-        cg_max_iter: int = 200,
+        inner_iter: int = 200,
+        outer_iter: int = 60,
 
     ) -> None:
         super().__init__()
@@ -111,9 +113,10 @@ class DEAL(Reconstructor):
         self.auto_scale = auto_scale
         self.target_y_std = target_y_std
         self.clamp_output = clamp_output
-        self.cg_max_iter = cg_max_iter
+        self.inner_iter = inner_iter
+        self.outer_iter = outer_iter
 
-        self.model = _DEALImpl(color=color, max_iter=self.cg_max_iter).to(device)
+        self.model = _DEALImpl(color=color, inner_iter=self.inner_iter, outer_iter=self.outer_iter).to(device)
 
         if pretrained is None:
             state = None
@@ -812,7 +815,7 @@ class _DEALImpl(nn.Module):
     :class:`DEAL` wrapper.
     """
 
-    def __init__(self, color: bool, max_iter: int = 200) -> None:
+    def __init__(self, color: bool, inner_iter: int = 200, outer_iter: int = 60) -> None:
         super().__init__()
 
         self.kernel_size = 9
@@ -885,7 +888,8 @@ class _DEALImpl(nn.Module):
             clamp=False,
         )
 
-        self.max_iter = max_iter
+        self.inner_iter = inner_iter
+        self.outer_iter = outer_iter
 
     def cal_lambda(self, sigma: torch.Tensor) -> None:
         """Compute the regularization parameter from the noise level."""
@@ -1033,15 +1037,15 @@ class _DEALImpl(nn.Module):
         if self.training:
             self.c_k_list = []
             grad_steps = 1
-            n_out = int(torch.randint(14, 59, (1, 1)).item())
-            n_in = 50
+            n_out = int(torch.randint(14, self.outer_iter-1, (1, 1)).item())
+            n_in = self.inner_iter // 4
             eps_in = 1e-4
             eps_out = 1e-4
             eps_bck = 1e-4
         else:
             grad_steps = 0
-            n_out = 60
-            n_in = self.max_iter
+            n_out = self.outer_iter
+            n_in = self.inner_iter
             eps_in = 1e-6
             eps_out = 1e-5
 

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -909,18 +909,6 @@ class _DEALImpl(nn.Module):
         x = self.spline3(self.scaling * x)
         return torch.clip(x, 1e-2, 1)
 
-    def K(self, x: torch.Tensor, idx: list[int] | None = None) -> torch.Tensor:
-        """Apply the weighted regularization operator."""
-        return torch.sqrt(self.lmbda) * self.W1(x) * self.mask[idx]
-
-    def Kt(self, y: torch.Tensor, idx: list[int] | None = None) -> torch.Tensor:
-        """Apply the adjoint of the weighted regularization operator."""
-        return torch.sqrt(self.lmbda) * self.W1.transpose(y * self.mask[idx])
-
-    def KtK(self, x: torch.Tensor, idx: list[int] | None = None) -> torch.Tensor:
-        """Apply the normal operator associated with the regularizer."""
-        return self.Kt(self.K(x, idx), idx)
-
     def cal_mask(self, x: torch.Tensor) -> torch.Tensor:
         """Compute the spatially varying DEAL mask."""
         x1 = self.M1(x)

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -226,9 +226,6 @@ class DEAL(Reconstructor):
 
         x_init = physics.A_adjoint(y)
 
-        if hasattr(self.model, "max_iter"):
-            self.model.max_iter = max(int(self.max_iter), 1)
-
         x_hat = self.model.solve_inverse_problem(
             y,
             H=physics.A,
@@ -1109,9 +1106,6 @@ class _DEALImpl(nn.Module):
         if path:
             c_ks: list[torch.Tensor] = []
 
-        max_iters = getattr(self, "max_iter", 1000)
-        max_cg_iters = getattr(self, "max_iter", 1000)
-
         with torch.no_grad():
             if x_init is not None:
                 c_k = x_init
@@ -1119,7 +1113,7 @@ class _DEALImpl(nn.Module):
                 c_k = Ht(y) * 0
             c_k_old = c_k.clone()
 
-            for m in range(max_iters):
+            for m in range(self.max_iter):
                 if path:
                     c_ks.append(c_k)
 
@@ -1130,11 +1124,10 @@ class _DEALImpl(nn.Module):
                     A=A_op,
                     b=b,
                     init=c_k_old,
-                    max_iter=max_cg_iters,
+                    max_iter=self.max_iter,
                     tol=eps_in,
                     eps=1e-8,
                 )
-                cg_iters = max_cg_iters
 
                 res = torch.linalg.norm(c_k - c_k_old) / torch.linalg.norm(c_k_old)
                 c_k_old = c_k.clone()
@@ -1144,7 +1137,7 @@ class _DEALImpl(nn.Module):
                         "CG Number:",
                         m,
                         "CG iterations:",
-                        cg_iters,
+                        self.max_iter,
                         "Outer residual:",
                         res,
                     )

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -101,12 +101,13 @@ class DEAL(Reconstructor):
     ) -> None:
         super().__init__()
 
-        self.sigma_denoiser = float(sigma_denoiser)
-        self.lambda_reg = float(lambda_reg)
-        self.max_iter = int(max_iter)
-        self.auto_scale = bool(auto_scale)
-        self.target_y_std = float(target_y_std)
-        self.clamp_output = bool(clamp_output)
+        self.sigma_denoiser = sigma_denoiser
+        self.lambda_reg = lambda_reg
+        self.max_iter = max_iter
+        self.auto_scale = auto_scale
+        self.target_y_std = target_y_std
+        self.clamp_output = clamp_output
+        self.cg_max_iter = cg_max_iter
 
         self.model = _DEALImpl(color=color).to(device)
 

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -891,6 +891,7 @@ class _DEALImpl(nn.Module):
             clamp=False,
         )
 
+        self.max_iter = 1000
         self.inner_iter = inner_iter
         self.outer_iter = outer_iter
 
@@ -1113,7 +1114,7 @@ class _DEALImpl(nn.Module):
                 c_k = Ht(y) * 0
             c_k_old = c_k.clone()
 
-            for m in range(1000):
+            for m in range(self.max_iter):
                 if path:
                     c_ks.append(c_k)
 
@@ -1124,7 +1125,7 @@ class _DEALImpl(nn.Module):
                     A=A_op,
                     b=b,
                     init=c_k_old,
-                    max_iter=1000,
+                    max_iter=self.max_iter,
                     tol=eps_in,
                     eps=1e-8,
                 )
@@ -1137,7 +1138,7 @@ class _DEALImpl(nn.Module):
                         "CG Number:",
                         m,
                         "CG iterations:",
-                        1000,
+                        self.max_iter,
                         "Outer residual:",
                         res,
                     )

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -810,7 +810,7 @@ class _DEALImpl(nn.Module):
     :class:`DEAL` wrapper.
     """
 
-    def __init__(self, color: bool) -> None:
+    def __init__(self, color: bool, max_iter: int = 1000) -> None:
         super().__init__()
 
         self.kernel_size = 9
@@ -885,7 +885,7 @@ class _DEALImpl(nn.Module):
 
         self.number_of_cgs = 0
         self.last_cg_iter = 0
-        self.max_iter = 1000
+        self.max_iter = max_iter
 
     def cal_lambda(self, sigma: torch.Tensor) -> None:
         """Compute the regularization parameter from the noise level."""

--- a/deepinv/models/deal.py
+++ b/deepinv/models/deal.py
@@ -883,8 +883,6 @@ class _DEALImpl(nn.Module):
             clamp=False,
         )
 
-        self.number_of_cgs = 0
-        self.last_cg_iter = 0
         self.max_iter = max_iter
 
     def cal_lambda(self, sigma: torch.Tensor) -> None:
@@ -916,11 +914,10 @@ class _DEALImpl(nn.Module):
 
     def cal_mask(self, x: torch.Tensor) -> torch.Tensor:
         """Compute the spatially varying DEAL mask."""
-        self.mask = self.last_act(
-            self.M3(
-                self.spline2(torch.abs(self.M2(self.spline1(torch.abs(self.M1(x))))))
-            )
-        )
+        x1 = self.M1(x)
+        x2 = self.M2(self.spline1(torch.abs(x1)))
+        x3 = self.M3(self.spline2(torch.abs(x2)))
+        self.mask = self.last_act(x3)
         return self.mask
 
     def L(self, x: torch.Tensor, idx: list[int] | None = None) -> torch.Tensor:
@@ -1015,7 +1012,7 @@ class _DEALImpl(nn.Module):
             beta = r_norm / r_norm_old
             p = r + beta * p
 
-        return output, i
+        return output
 
     def denoise(self, y: torch.Tensor, sigma: torch.Tensor) -> torch.Tensor:
         """Run DEAL in denoising mode."""
@@ -1067,7 +1064,6 @@ class _DEALImpl(nn.Module):
                     tol=eps_in,
                     eps=1e-8,
                 )
-                self.last_cg_iter = n_in
                 res = torch.linalg.norm(c_k - c_k_old) / torch.linalg.norm(c_k_old)
                 c_k_old = c_k.clone()
                 if (res < eps_out).all():
@@ -1083,7 +1079,7 @@ class _DEALImpl(nn.Module):
             self.cal_mask(d_k)
             self.c_k_list.append(d_k)
             with torch.no_grad():
-                c_k, self.last_cg_iter = self.cg(y, c_k, n_in, eps=eps_bck)
+                c_k = self.cg(y, c_k, n_in, eps=eps_bck)
             idx = [i for i in range(y.size(0))]
             c_k1 = y - self.lmbda * self.Lt(self.L(c_k.detach(), idx), idx)
             c_k1.register_hook(backward_hook1)
@@ -1091,7 +1087,6 @@ class _DEALImpl(nn.Module):
         else:
             c_k1 = c_k
 
-        self.number_of_cgs = i + grad_steps
         return c_k1
 
     def solve_inverse_problem(

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -157,7 +157,7 @@ def choose_denoiser(name, imsize):
             auto_scale=False,
             color=(imsize[0] == 3),
             pretrained=None,
-            cg_max_iter=50,
+            inner_iter=3,  # no performance test, so we can keep that value low
         )
     elif name == "ram":
         out = dinv.models.RAM()

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -532,8 +532,8 @@ def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST_1_CHANNEL)
-@pytest.mark.parametrize("batch_size", [1, 2])
-def test_denoiser_sigma_gray(batch_size, denoiser, device):
+def test_denoiser_sigma_gray(denoiser, device):
+    batch_size = 2
     img_size = (1, 32, 32)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
@@ -561,8 +561,8 @@ def test_denoiser_sigma_gray(batch_size, denoiser, device):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST)
-@pytest.mark.parametrize("batch_size", [1, 2])
-def test_denoiser_sigma_color(batch_size, denoiser, device):
+def test_denoiser_sigma_color(denoiser, device):
+    batch_size = 2
     img_size = (3, 32, 32)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -532,9 +532,9 @@ def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST_1_CHANNEL)
-def test_denoiser_sigma_gray(denoiser, device):
-    batch_size = 2
-    img_size = (1, 32, 32)
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+def test_denoiser_sigma_gray(batch_size, denoiser, device):
+    img_size = (1, 64, 64)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
 
@@ -561,9 +561,9 @@ def test_denoiser_sigma_gray(denoiser, device):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST)
-def test_denoiser_sigma_color(denoiser, device):
-    batch_size = 2
-    img_size = (3, 32, 32)
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+def test_denoiser_sigma_color(batch_size, denoiser, device):
+    img_size = (3, 64, 64)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
     x = torch.ones((batch_size,) + img_size, device=device, dtype=torch.float32)

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -157,6 +157,7 @@ def choose_denoiser(name, imsize):
             auto_scale=False,
             color=(imsize[0] == 3),
             pretrained=None,
+            cg_max_iter=50,
         )
     elif name == "ram":
         out = dinv.models.RAM()
@@ -531,9 +532,9 @@ def test_denoiser_1_channel(imsize_1_channel, device, denoiser):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST_1_CHANNEL)
-@pytest.mark.parametrize("batch_size", [1, 2, 3])
+@pytest.mark.parametrize("batch_size", [1, 2])
 def test_denoiser_sigma_gray(batch_size, denoiser, device):
-    img_size = (1, 64, 64)
+    img_size = (1, 32, 32)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
 
@@ -560,9 +561,9 @@ def test_denoiser_sigma_gray(batch_size, denoiser, device):
 
 
 @pytest.mark.parametrize("denoiser", MODEL_LIST)
-@pytest.mark.parametrize("batch_size", [1, 2, 3])
+@pytest.mark.parametrize("batch_size", [1, 2])
 def test_denoiser_sigma_color(batch_size, denoiser, device):
-    img_size = (3, 64, 64)
+    img_size = (3, 32, 32)
     model = choose_denoiser(denoiser, img_size).to(device)
     noiser = dinv.physics.GaussianNoise()
     x = torch.ones((batch_size,) + img_size, device=device, dtype=torch.float32)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -29,6 +29,7 @@ Changed
 - Extend :func:`DST-I <deepinv.physics.functional.dst1>` to make it n-dimensional and add an option to have it compute the regular DST-I instead of the non-standard sign-flipped orthogonal variant (:gh:`934` by `Jérémy Scanvic`_)
 - Extend: :class:`deepinv.optim.MLEM` now supports :class:`deepinv.physics.PET` (:gh:`1255` by `Thibaut Modrzyk`_)
 - (Breaking) Make :class:`deepinv.optim.TVPrior()` compute an explicit choice of subgradient instead of using autodiff. (:gh:`1271` by `Thibaut Modrzyk`_)
+- Extend: :class:`deepinv.models.DEAL` now accepts two new arguments: `inner_iter` and `outer_iter`. (:gh:`1335` by `PAUL BERNARD`)
 
 Fixed
 ^^^^^


### PR DESCRIPTION
One of the slowest test is due to DEAL ( https://github.com/deepinv/deepinv/actions/runs/31991013911/job/95274487263#step:8:999 ). This PR removes some unused variables and methods that are not exposed by the deepinv API, adds two new parameters: `inner_iter` and `outer_iter` and use those parameters to drastically reduce the test execution time.

Related to #1334


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.