### PR TITLE
Fix Blur and BlurFFT physics (#1303, #1253)

### DIFF
--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -454,7 +454,7 @@ class Blur(LinearPhysics):
     where :math:`*` denotes convolution and :math:`w` is a filter.
 
     :param torch.Tensor filter: Tensor of size (b, 1, h, w) or (b, c, h, w) in 2D; (b, 1, d, h, w) or (b, c, d, h, w) in 3D,
-        containing the blur filter, e.g., :func:`deepinv.physics.functional.gaussian_blur`.
+        containing the blur filter, e.g., :func:`deepinv.physics.functional.gaussian_blur`. If ``None``, a filter must be passed to the physics before calling it . (default is ``None``)
     :param str padding: options are ``'valid'``, ``'circular'``, ``'replicate'`` and ``'reflect'``.
         If ``padding='valid'`` the blurred output is smaller than the image (no padding)
         otherwise the blurred output has the same size as the image. (default is ``'valid'``).
@@ -501,8 +501,7 @@ class Blur(LinearPhysics):
         device: torch.device = torch.device("cpu"),
         **kwargs,
     ):
-        super().__init__(**kwargs)
-        self.device = device
+        super().__init__(**kwargs, device=device)
         self.padding = padding
         assert (
             isinstance(filter, Tensor) or filter is None
@@ -532,6 +531,9 @@ class Blur(LinearPhysics):
         """
         self.update_parameters(filter=filter, **kwargs)
 
+        if self.filter is None:
+            raise ValueError("self.filter is None, provide a filter when calling A.")
+
         dim = (
             x.dim() - 2
         )  # get the spatial dimensions to select the right convolution function
@@ -551,6 +553,11 @@ class Blur(LinearPhysics):
         :raises ValueError: if the input tensor does not have 4 or 5 dimensions.
         """
         self.update_parameters(filter=filter, **kwargs)
+
+        if self.filter is None:
+            raise ValueError(
+                "self.filter is None, provide a filter when calling A_adjoint."
+            )
 
         dim = (
             y.dim() - 2
@@ -583,7 +590,7 @@ class BlurFFT(DecomposablePhysics):
 
     :param tuple img_size: Input image size in the form `(C, H, W)`.
     :param torch.Tensor filter: torch.Tensor of size `(1, c, h, w)` containing the blur filter with h<=H, w<=W and c=1 or c=C e.g.,
-        :func:`deepinv.physics.functional.gaussian_blur`.
+        :func:`deepinv.physics.functional.gaussian_blur`. If ``None``, a filter must be passed to the physics before calling it . (default is ``None``)
     :param torch.device, str device: Device on which the physics' buffers will be created. If a buffer is updated via ``physics.update_parameters()``, if not None, it will be automatically casted to the device of the replaced buffer, else, use the device of the provided value. To change the device of all buffers, please use ``physics.to(device)``.
 
     |sep|
@@ -629,10 +636,20 @@ class BlurFFT(DecomposablePhysics):
         self.to(device)
 
     def A(self, x: Tensor, filter: Tensor | None = None, **kwargs) -> Tensor:
+
+        if self.filter is None and filter is None:
+            raise ValueError("self.filter is None, provide a filter when calling A.")
+
         # updating the parameters is already handled in DecomposablePhysics.A
         return super().A(x, filter=filter)
 
     def A_adjoint(self, x: Tensor, filter: Tensor | None = None, **kwargs) -> Tensor:
+
+        if self.filter is None and filter is None:
+            raise ValueError(
+                "self.filter is None, provide a filter when calling A_adjoint."
+            )
+
         # updating the parameters is already handled in DecomposablePhysics.A_adjoint
         return super().A_adjoint(x, filter=filter)
 
@@ -697,6 +714,8 @@ class BlurFFT(DecomposablePhysics):
 
         :param torch.Tensor filter: New filter to be applied to the input image.
         """
+
+        device = None
 
         # self.filter can be None after initialization
         if self.filter is None:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -45,7 +45,7 @@ Fixed
 - (Breaking) Have `x_shift` represent horizontal shifts and `y_shift` vertical shifts in :class:`deepinv.transform.Shift` (:gh:`1236` by `Sarra Amiri`_)
 - Force trainer non_blocking_transfers=False on MPS and CPU (:gh:`1311` by `Andrew Wang`_)
 - Fix :class:`deepinv.physics.PET` incorrect device attribution of attenuation and background on update and incorrect handling of batched attenuation 
-
+- Raise informative error when filter is not set in :class:`deepinv.physics.Blur` and :class:`deepinv.physics.BlurFFT` (:gh:`1337` by `Romain Vo`_)
 
 v0.4.1
 ------


### PR DESCRIPTION
I am removing the legacy `self.device` from the `Blur` physics (#1303). I am also cleaning the error mentioned in #1253.

I chose to raise an error in `BlurFFT` , when `self.filter` is None (not provided during initialization) and `filter` is not passed when calling the physics, in order to keep things consistent (`Blur` behaves the same way). I'm also raising a more user-friendly error in `A` and `A_adjoint`.

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.