### PR TITLE
Allow rescale_mode=None in plot to only clip

### DIFF
--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -278,17 +278,16 @@ def test_plot(
         else:
             assert axs is None
 
-@pytest.mark.parametrize("vmin, vmax, expected_clim",
+
+@pytest.mark.parametrize(
+    "vmin, vmax, expected_clim",
     [
-        (0.0,  1.0,  (0.25, 0.75)),
+        (0.0, 1.0, (0.25, 0.75)),
         (0.25, 0.75, (0.0, 1.0)),
     ],
 )
 def test_plot_clip_rescale_mode(vmin, vmax, expected_clim):
-    image = torch.tensor(
-        [[[0.25, 0.5],
-          [0.5, 0.75]]]
-    )
+    image = torch.tensor([[[0.25, 0.5], [0.5, 0.75]]])
 
     axs = deepinv.utils.plotting.plot(
         image,
@@ -303,11 +302,12 @@ def test_plot_clip_rescale_mode(vmin, vmax, expected_clim):
     assert plotted_image.get_clim() == pytest.approx(expected_clim, abs=1e-5)
 
 
-@pytest.mark.parametrize("image",
+@pytest.mark.parametrize(
+    "image",
     [
-        torch.tensor( [[[ 0.25, 0.5], [0.5, 1.25]]] ),
-        torch.tensor( [[[-0.25, 0.5], [0.5, 0.75]]] ),
-    ]
+        torch.tensor([[[0.25, 0.5], [0.5, 1.25]]]),
+        torch.tensor([[[-0.25, 0.5], [0.5, 0.75]]]),
+    ],
 )
 def test_plot_rescale_mode_none(image):
     axs = deepinv.utils.plotting.plot(
@@ -322,12 +322,17 @@ def test_plot_rescale_mode_none(image):
     assert plotted_image.get_clim() == pytest.approx((0.0, 1.0), abs=1e-5)
     assert plotted_image.norm.clip
 
-@pytest.mark.parametrize( "vmin, vmax", [ (0.25, None), (None, 0.75), (0.25, 0.75), ], )
+
+@pytest.mark.parametrize(
+    "vmin, vmax",
+    [
+        (0.25, None),
+        (None, 0.75),
+        (0.25, 0.75),
+    ],
+)
 def test_plot_rescale_mode_none_vmin_vmax_warning(vmin, vmax):
-    image = torch.tensor(
-        [[[0.25, 0.5],
-          [0.5, 0.75]]]
-    )
+    image = torch.tensor([[[0.25, 0.5], [0.5, 0.75]]])
 
     with pytest.warns(
         UserWarning,
@@ -341,11 +346,9 @@ def test_plot_rescale_mode_none_vmin_vmax_warning(vmin, vmax):
             show=False,
         )
 
+
 def test_plot_rescale_mode_none_inset():
-    image = torch.tensor(
-        [[[-0.25, 0.5],
-          [0.75, 1.25]]]
-    )
+    image = torch.tensor([[[-0.25, 0.5], [0.75, 1.25]]])
 
     axs = deepinv.utils.plotting.plot(
         image,

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -229,16 +229,6 @@ def test_dirac_comb(device, shape):
 @pytest.mark.parametrize("with_subtitles", [False, True])
 @pytest.mark.parametrize("batched", [False, True])
 @pytest.mark.parametrize("return_axs", [False, True])
-@pytest.mark.parametrize("rescale_mode", ["min_max", "clip", None])
-@pytest.mark.parametrize(
-    "vmin, vmax",
-    [
-        (None, None),
-        (0.25, 0.75),
-    ],
-)
-@pytest.mark.parametrize("norm_type", [None, "normalize", "power"])
-@pytest.mark.parametrize("plot_inset", [False, True])
 def test_plot(
     tmp_path,
     C,
@@ -251,38 +241,13 @@ def test_plot(
     with_subtitles,
     batched,
     return_axs,
-    rescale_mode,
-    vmin,
-    vmax,
-    norm_type,
-    plot_inset,
 ):
-    reference_image = torch.tensor(
-        [
-            [-0.25, 0.25],
-            [0.75, 1.25],
-        ],
-        dtype=torch.float32,
-    )
-    reference_image = reference_image.unsqueeze(0).repeat(C, 1, 1)
-
     if batched:
-        reference_image = reference_image.unsqueeze(0)
-    img_list = (
-        [reference_image] * n_images
-        if isinstance(reference_image, torch.Tensor)
-        else reference_image
-    )
-
-    from matplotlib.colors import Normalize, PowerNorm
-
-    if norm_type == "normalize":
-        norm = Normalize(0.0, 1.0)
-    elif norm_type == "power":
-        norm = PowerNorm(gamma=2.0, vmin=0.0, vmax=1.0)
+        shape = (1, C, 2, 2)
     else:
-        norm = None
-
+        shape = (C, 2, 2)
+    img_list = torch.ones(shape)
+    img_list = [img_list] * n_images if isinstance(img_list, torch.Tensor) else img_list
     titles = "0" if n_images == 1 else [str(i) for i in range(n_images)]
     subtitles = ["subtitle"] * n_images
     img_list = {k: v for k, v in zip(titles, img_list, strict=True)}
@@ -308,95 +273,130 @@ def test_plot(
             suptitle=suptitle,
             subtitles=subtitles,
             return_axs=return_axs,
-            rescale_mode=rescale_mode,
-            vmin=vmin,
-            vmax=vmax,
-            norm=norm,
-            plot_inset=plot_inset,
         )
-
-        # expected image for rescale_mode choice
-        if rescale_mode == "min_max":
-            expected_image = (reference_image + 0.25) / 1.5
-        elif rescale_mode == "clip":
-            v0 = 0.0 if vmin is None else vmin
-            v1 = 1.0 if vmax is None else vmax
-            expected_image = reference_image.clamp(v0, v1)
-            expected_image = (expected_image - v0) / (v1 - v0)
-        else:  # rescale_mode is None
-            v0 = 0.0 if vmin is None else vmin
-            v1 = 1.0 if vmax is None else vmax
-            expected_image = reference_image.clamp(v0, v1)
-
-        expected_batch = expected_image if batched else expected_image.unsqueeze(0)
-
         if return_axs:
             assert axs is not None
         else:
             assert axs is None
 
-        if return_axs:
-            for i in range(n_images):
-                for r, expected_img in enumerate(expected_batch):
-                    plotted_image = axs[r, i].images[0]
 
-                    expected_array = (
-                        expected_img.permute(1, 2, 0).squeeze().cpu().numpy()
-                    )
-                    np.testing.assert_allclose(
-                        plotted_image.get_array(),
-                        expected_array,
-                        atol=1e-5,
-                    )
+@pytest.mark.parametrize("C", [1, 3])
+@pytest.mark.parametrize("n_images", [1, 2])
+@pytest.mark.parametrize("batched", [False, True])
+@pytest.mark.parametrize(
+    "vmin, vmax",
+    [
+        (None, None),
+        (0.25, 0.75),
+    ],
+)
+@pytest.mark.parametrize("norm_type", [None, "power"])
+@pytest.mark.parametrize("plot_inset", [False, True])
+def test_plot_rescale_mode(
+    tmp_path,
+    C,
+    n_images,
+    batched,
+    vmin,
+    vmax,
+    norm_type,
+    plot_inset,
+):
+    reference_image = torch.tensor(
+        [
+            [-0.25, 0.25],
+            [0.75, 1.25],
+        ],
+        dtype=torch.float32,
+    )
+    reference_image = reference_image.unsqueeze(0).repeat(C, 1, 1)
 
-                    assert plotted_image.get_clim() == pytest.approx(
-                        (0.0, 1.0), abs=1e-5
-                    )
-                    if norm is not None:
-                        assert plotted_image.norm is norm
-                    elif rescale_mode is None:
-                        assert isinstance(plotted_image.norm, Normalize)
-                        assert plotted_image.norm.vmin == pytest.approx(0.0)
-                        assert plotted_image.norm.vmax == pytest.approx(1.0)
-                        assert plotted_image.norm.clip
+    if batched:
+        reference_image = reference_image.unsqueeze(0)
 
-                    if plot_inset:
-                        inset_image = axs[r, i].child_axes[0].images[0]
+    img_list = [reference_image] * n_images
 
-                        if norm is not None:
-                            assert inset_image.norm is norm
-                        elif rescale_mode is None:
-                            assert isinstance(inset_image.norm, Normalize)
-                            assert inset_image.norm is plotted_image.norm
+    from matplotlib.colors import Normalize, PowerNorm
 
-                    if cbar:
-                        assert plotted_image.colorbar is not None
+    if norm_type == "power":
+        norm = PowerNorm(gamma=2.0, vmin=0.0, vmax=1.0, clip=True)
+    else:  # norm_type is None
+        norm = None
 
-                    if save_plot:
-                        saved_path = tmp_path / str(i) / f"{r}.png"
-                        assert saved_path.exists()
+    axs = deepinv.utils.plot(
+        img_list,
+        titles=None,
+        save_dir=tmp_path,
+        cbar=False,
+        suptitle=None,
+        subtitles=None,
+        return_axs=True,
+        rescale_mode=None,
+        vmin=vmin,
+        vmax=vmax,
+        norm=norm,
+        plot_inset=plot_inset,
+    )
 
-                        with PIL.Image.open(saved_path) as saved:
-                            saved_image = np.asarray(saved.convert("RGBA"))
+    v0 = 0.0 if vmin is None else vmin
+    v1 = 1.0 if vmax is None else vmax
+    expected_image = reference_image.clamp(v0, v1)
 
-                        image_array = plotted_image.get_array()
-                        if plotted_image.origin == "lower":
-                            image_array = image_array[::-1]
+    expected_batch = expected_image if batched else expected_image.unsqueeze(0)
 
-                        expected_saved_image = plotted_image.to_rgba(
-                            image_array,
-                            bytes=True,
-                            norm=True,
-                        )
+    for i in range(n_images):
+        for r, expected_img in enumerate(expected_batch):
+            plotted_image = axs[r, i].images[0]
 
-                        np.testing.assert_array_equal(
-                            saved_image,
-                            expected_saved_image,
-                        )
+            expected_array = expected_img.permute(1, 2, 0).squeeze().cpu().numpy()
+            np.testing.assert_allclose(
+                plotted_image.get_array(),
+                expected_array,
+                atol=1e-5,
+            )
 
-        if save_plot:
-            save_name = "inset_images.svg" if plot_inset else "images.svg"
-            assert (tmp_path / save_name).exists()
+            assert plotted_image.get_clim() == pytest.approx((0.0, 1.0), abs=1e-5)
+
+            if norm is not None:
+                assert plotted_image.norm is norm
+            else:
+                assert isinstance(plotted_image.norm, Normalize)
+                assert plotted_image.norm.vmin == pytest.approx(0.0)
+                assert plotted_image.norm.vmax == pytest.approx(1.0)
+                assert plotted_image.norm.clip
+
+            if plot_inset:
+                inset_image = axs[r, i].child_axes[0].images[0]
+
+                assert isinstance(inset_image.norm, Normalize)
+                assert inset_image.norm is plotted_image.norm
+                assert plotted_image.norm.vmin == pytest.approx(0.0)
+                assert plotted_image.norm.vmax == pytest.approx(1.0)
+                assert plotted_image.norm.clip
+
+            saved_path = tmp_path / str(i) / f"{r}.png"
+            assert saved_path.exists()
+
+            with PIL.Image.open(saved_path) as saved:
+                saved_image = np.asarray(saved.convert("RGBA"))
+
+            image_array = plotted_image.get_array()
+            if plotted_image.origin == "lower":
+                image_array = image_array[::-1]
+
+            expected_saved_image = plotted_image.to_rgba(
+                image_array,
+                bytes=True,
+                norm=True,
+            )
+
+            np.testing.assert_array_equal(
+                saved_image,
+                expected_saved_image,
+            )
+
+    save_name = "inset_images.svg" if plot_inset else "images.svg"
+    assert (tmp_path / save_name).exists()
 
 
 @pytest.mark.parametrize("n_plots", [1, 2, 3])

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -228,6 +228,16 @@ def test_dirac_comb(device, shape):
 @pytest.mark.parametrize("with_subtitles", [False, True])
 @pytest.mark.parametrize("batched", [False, True])
 @pytest.mark.parametrize("return_axs", [False, True])
+@pytest.mark.parametrize("rescale_mode", ["min_max", "clip", None])
+@pytest.mark.parametrize(
+    "vmin, vmax",
+    [
+        (None, None),
+        (0.25, 0.75),
+    ],
+)
+@pytest.mark.parametrize("norm_type", [None, "normalize", "power"])
+@pytest.mark.parametrize("plot_inset", [False, True])
 def test_plot(
     tmp_path,
     C,
@@ -240,13 +250,38 @@ def test_plot(
     with_subtitles,
     batched,
     return_axs,
+    rescale_mode,
+    vmin,
+    vmax,
+    norm_type,
+    plot_inset,
 ):
+    reference_image = torch.tensor(
+        [
+            [-0.25, 0.25],
+            [0.75, 1.25],
+        ],
+        dtype=torch.float32,
+    )
+    reference_image = reference_image.unsqueeze(0).repeat(C, 1, 1)
+
     if batched:
-        shape = (1, C, 2, 2)
+        reference_image = reference_image.unsqueeze(0)
+    img_list = (
+        [reference_image] * n_images
+        if isinstance(reference_image, torch.Tensor)
+        else reference_image
+    )
+
+    from matplotlib.colors import Normalize, PowerNorm
+
+    if norm_type == "normalize":
+        norm = Normalize(0.0, 1.0)
+    elif norm_type == "power":
+        norm = PowerNorm(gamma=2.0, vmin=0.0, vmax=1.0)
     else:
-        shape = (C, 2, 2)
-    img_list = torch.ones(shape)
-    img_list = [img_list] * n_images if isinstance(img_list, torch.Tensor) else img_list
+        norm = None
+
     titles = "0" if n_images == 1 else [str(i) for i in range(n_images)]
     subtitles = ["subtitle"] * n_images
     img_list = {k: v for k, v in zip(titles, img_list, strict=True)}
@@ -272,97 +307,95 @@ def test_plot(
             suptitle=suptitle,
             subtitles=subtitles,
             return_axs=return_axs,
+            rescale_mode=rescale_mode,
+            vmin=vmin,
+            vmax=vmax,
+            norm=norm,
+            plot_inset=plot_inset,
         )
+
+        # expected image for rescale_mode choice
+        if rescale_mode == "min_max":
+            expected_image = (reference_image + 0.25) / 1.5
+        elif rescale_mode == "clip":
+            v0 = 0.0 if vmin is None else vmin
+            v1 = 1.0 if vmax is None else vmax
+            expected_image = reference_image.clamp(v0, v1)
+            expected_image = (expected_image - v0) / (v1 - v0)
+        else:  # rescale_mode is None
+            v0 = 0.0 if vmin is None else vmin
+            v1 = 1.0 if vmax is None else vmax
+            expected_image = reference_image.clamp(v0, v1)
+
+        expected_batch = expected_image if batched else expected_image.unsqueeze(0)
+
         if return_axs:
             assert axs is not None
         else:
             assert axs is None
 
+        if return_axs:
+            for i in range(n_images):
+                for r, expected_img in enumerate(expected_batch):
+                    plotted_image = axs[r, i].images[0]
 
-@pytest.mark.parametrize(
-    "vmin, vmax, expected_clip",
-    [
-        (0.0, 1.0, (0.25, 0.75)),
-        (0.25, 0.75, (0.0, 1.0)),
-    ],
-)
-def test_plot_clip_rescale_mode(vmin, vmax, expected_clim):
-    image = torch.tensor([[[0.25, 0.5], [0.5, 0.75]]])
+                    expected_array = (
+                        expected_img.permute(1, 2, 0).squeeze().cpu().numpy()
+                    )
+                    np.testing.assert_allclose(
+                        plotted_image.get_array(),
+                        expected_array,
+                        atol=1e-5,
+                    )
 
-    axs = deepinv.utils.plotting.plot(
-        image,
-        rescale_mode="clip",
-        vmin=vmin,
-        vmax=vmax,
-        cbar=True,
-        show=False,
-        return_axs=True,
-    )
-    plotted_image = axs[0, 0].images[0]
+                    assert plotted_image.get_clim() == pytest.approx(
+                        (0.0, 1.0), abs=1e-5
+                    )
+                    if norm is not None:
+                        assert plotted_image.norm is norm
+                    elif rescale_mode is None:
+                        assert isinstance(plotted_image.norm, Normalize)
+                        assert plotted_image.norm.vmin == pytest.approx(0.0)
+                        assert plotted_image.norm.vmax == pytest.approx(1.0)
+                        assert plotted_image.norm.clip
 
-    assert plotted_image.get_clim() == pytest.approx(expected_clim, abs=1e-5)
+                    if plot_inset:
+                        inset_image = axs[r, i].child_axes[0].images[0]
 
+                        if norm is not None:
+                            assert inset_image.norm is norm
+                        elif rescale_mode is None:
+                            assert isinstance(inset_image.norm, Normalize)
+                            assert inset_image.norm is plotted_image.norm
 
-@pytest.mark.parametrize(
-    "image",
-    [
-        torch.tensor([[[0.25, 0.5], [0.5, 1.25]]]),
-        torch.tensor([[[-0.25, 0.5], [0.5, 0.75]]]),
-    ],
-)
-def test_plot_rescale_mode_none(image):
-    axs = deepinv.utils.plotting.plot(
-        image,
-        rescale_mode=None,
-        cbar=True,
-        show=False,
-        return_axs=True,
-    )
-    plotted_image = axs[0, 0].images[0]
+                    if cbar:
+                        assert plotted_image.colorbar is not None
 
-    assert np.allclose(plotted_image.get_array(), image.squeeze().numpy(), atol=1e-5)
-    assert plotted_image.get_clim() == pytest.approx((0.0, 1.0), abs=1e-5)
-    assert plotted_image.norm.clip
+                    if save_plot:
+                        saved_path = tmp_path / str(i) / f"{r}.png"
+                        assert saved_path.exists()
 
+                        with PIL.Image.open(saved_path) as saved:
+                            saved_image = np.asarray(saved.convert("RGBA"))
 
-@pytest.mark.parametrize(
-    "vmin, vmax",
-    [
-        (0.25, None),
-        (None, 0.75),
-        (0.25, 0.75),
-    ],
-)
-def test_plot_rescale_mode_none_vmin_vmax_warning(vmin, vmax):
-    image = torch.tensor([[[0.25, 0.5], [0.5, 0.75]]])
+                        image_array = plotted_image.get_array()
+                        if plotted_image.origin == "lower":
+                            image_array = image_array[::-1]
 
-    with pytest.warns(
-        UserWarning,
-        match="vmin and vmax arguments are used only when using 'clip' rescaling",
-    ):
-        deepinv.utils.plotting.plot(
-            image,
-            rescale_mode=None,
-            vmin=vmin,
-            vmax=vmax,
-            show=False,
-        )
+                        expected_saved_image = plotted_image.to_rgba(
+                            image_array,
+                            bytes=True,
+                            norm=True,
+                        )
 
+                        np.testing.assert_array_equal(
+                            saved_image,
+                            expected_saved_image,
+                        )
 
-def test_plot_rescale_mode_none_inset():
-    image = torch.tensor([[[-0.25, 0.5], [0.75, 1.25]]])
-
-    axs = deepinv.utils.plotting.plot(
-        image,
-        rescale_mode=None,
-        plot_inset=True,
-        show=False,
-        return_axs=True,
-    )
-    inset_image = axs[0, 0].child_axes[0].images[0]
-
-    assert inset_image.get_clim() == pytest.approx((0.0, 1.0), abs=1e-5)
-    assert inset_image.norm.clip
+        if save_plot:
+            save_name = "inset_images.svg" if plot_inset else "images.svg"
+            assert (tmp_path / save_name).exists()
 
 
 @pytest.mark.parametrize("n_plots", [1, 2, 3])

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -294,6 +294,7 @@ def test_plot_clip_rescale_mode(vmin, vmax, expected_clim):
         rescale_mode="clip",
         vmin=vmin,
         vmax=vmax,
+        cbar=True,
         show=False,
         return_axs=True,
     )
@@ -313,6 +314,7 @@ def test_plot_rescale_mode_none(image):
     axs = deepinv.utils.plotting.plot(
         image,
         rescale_mode=None,
+        cbar=True,
         show=False,
         return_axs=True,
     )

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -278,6 +278,87 @@ def test_plot(
         else:
             assert axs is None
 
+@pytest.mark.parametrize("vmin, vmax, expected_clim",
+    [
+        (0.0,  1.0,  (0.25, 0.75)),
+        (0.25, 0.75, (0.0, 1.0)),
+    ],
+)
+def test_plot_clip_rescale_mode(vmin, vmax, expected_clim):
+    image = torch.tensor(
+        [[[0.25, 0.5],
+          [0.5, 0.75]]]
+    )
+
+    axs = deepinv.utils.plotting.plot(
+        image,
+        rescale_mode="clip",
+        vmin=vmin,
+        vmax=vmax,
+        show=False,
+        return_axs=True,
+    )
+    plotted_image = axs[0, 0].images[0]
+
+    assert plotted_image.get_clim() == pytest.approx(expected_clim, abs=1e-5)
+
+
+@pytest.mark.parametrize("image",
+    [
+        torch.tensor( [[[ 0.25, 0.5], [0.5, 1.25]]] ),
+        torch.tensor( [[[-0.25, 0.5], [0.5, 0.75]]] ),
+    ]
+)
+def test_plot_rescale_mode_none(image):
+    axs = deepinv.utils.plotting.plot(
+        image,
+        rescale_mode=None,
+        show=False,
+        return_axs=True,
+    )
+    plotted_image = axs[0, 0].images[0]
+
+    assert np.allclose(plotted_image.get_array(), image.squeeze().numpy(), atol=1e-5)
+    assert plotted_image.get_clim() == pytest.approx((0.0, 1.0), abs=1e-5)
+    assert plotted_image.norm.clip
+
+@pytest.mark.parametrize( "vmin, vmax", [ (0.25, None), (None, 0.75), (0.25, 0.75), ], )
+def test_plot_rescale_mode_none_vmin_vmax_warning(vmin, vmax):
+    image = torch.tensor(
+        [[[0.25, 0.5],
+          [0.5, 0.75]]]
+    )
+
+    with pytest.warns(
+        UserWarning,
+        match="vmin and vmax arguments are used only when using 'clip' rescaling",
+    ):
+        deepinv.utils.plotting.plot(
+            image,
+            rescale_mode=None,
+            vmin=vmin,
+            vmax=vmax,
+            show=False,
+        )
+
+def test_plot_rescale_mode_none_inset():
+    image = torch.tensor(
+        [[[-0.25, 0.5],
+          [0.75, 1.25]]]
+    )
+
+    axs = deepinv.utils.plotting.plot(
+        image,
+        rescale_mode=None,
+        plot_inset=True,
+        show=False,
+        return_axs=True,
+    )
+    inset_image = axs[0, 0].child_axes[0].images[0]
+
+    assert inset_image.get_clim() == pytest.approx((0.0, 1.0), abs=1e-5)
+    assert inset_image.norm.clip
+
 
 @pytest.mark.parametrize("n_plots", [1, 2, 3])
 @pytest.mark.parametrize("titles", [None, "Dummy plot"])

--- a/deepinv/tests/test_utils.py
+++ b/deepinv/tests/test_utils.py
@@ -280,7 +280,7 @@ def test_plot(
 
 
 @pytest.mark.parametrize(
-    "vmin, vmax, expected_clim",
+    "vmin, vmax, expected_clip",
     [
         (0.0, 1.0, (0.25, 0.75)),
         (0.25, 0.75, (0.0, 1.0)),

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -248,6 +248,8 @@ def preprocess_img(
             scales = list(zip(mins, maxs, strict=True))
         elif rescale_mode in ("clip", None):
             scales = [(v0, v1)] * im.shape[0]
+        else:
+            raise ValueError(f"Unknown rescale_mode: {rescale_mode}")
 
     if rescale_mode is None:
         # clip without rescaling

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -247,7 +247,7 @@ def preprocess_img(
             v0 = vmin if vmin is not None else 0.0
             v1 = vmax if vmax is not None else 1.0
             scales = [(v0, v1)] * im.shape[0]
-        else: # rescale_mode is None
+        else:  # rescale_mode is None
             v0 = 0.0
             v1 = 1.0
             scales = [(v0, v1)] * im.shape[0]
@@ -469,7 +469,10 @@ def plot(
     for i, row_imgs in enumerate(imgs):
         for r, img in enumerate(row_imgs):
             im = axs[r, i].imshow(
-                img, cmap=cmap, interpolation=interpolation, **imshow_kwargs,
+                img,
+                cmap=cmap,
+                interpolation=interpolation,
+                **imshow_kwargs,
             )
             if cbar:
                 from mpl_toolkits.axes_grid1 import make_axes_locatable

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -212,9 +212,9 @@ def preprocess_img(
 
     :param torch.Tensor im: the batch of images to preprocess, it is expected to be of shape (B, C, *).
     :param str, None rescale_mode: the normalization mode, either ``'min_max'``, ``'clip'``, or ``None``.
-        If ``None``, the image values are not rescaled.
-    :param float, None vmin: minimum value for clipping when using 'clip' rescaling.
-    :param float, None vmax: maximum value for clipping when using 'clip' rescaling.
+        With ``None``, image values are clipped to ``[vmin, vmax]`` without being rescaled.
+    :param float, None vmin: minimum clipping bound when using ``'clip'`` or ``None``. Defaults to 0.
+    :param float, None vmax: maximum clipping bound when using ``'clip'`` or ``None``. Defaults to 1.
     :param bool return_scale: if ``True``, also return the per-element ``(vmin_orig, vmax_orig)``
         tuples representing the true data range **before** normalization, as a list of length B.
         For ``'min_max'`` mode these are the per-element min/max values; for ``'clip'`` mode
@@ -231,6 +231,9 @@ def preprocess_img(
     # NOTE: Why is it needed?
     im = im.type(torch.float32)
 
+    v0 = vmin if vmin is not None else 0.0
+    v1 = vmax if vmax is not None else 1.0
+
     # Capture true data range before normalization
     scales = []
     if return_scale:
@@ -243,23 +246,13 @@ def preprocess_img(
             if not isinstance(mins, list):
                 mins, maxs = [mins], [maxs]
             scales = list(zip(mins, maxs, strict=True))
-        elif rescale_mode == "clip":
-            v0 = vmin if vmin is not None else 0.0
-            v1 = vmax if vmax is not None else 1.0
-            scales = [(v0, v1)] * im.shape[0]
-        else:  # rescale_mode is None
-            v0 = 0.0
-            v1 = 1.0
+        elif rescale_mode in ("clip", None):
             scales = [(v0, v1)] * im.shape[0]
 
-    if rescale_mode is None and (vmin is not None or vmax is not None):
-        warn(
-            "The vmin and vmax arguments are used only when using 'clip' rescaling.",
-            UserWarning,
-            stacklevel=2,
-        )
-
-    if rescale_mode is not None:
+    if rescale_mode is None:
+        # clip without rescaling
+        im = im.clamp(min=v0, max=v1)
+    else:
         # Normalize signal between 0 and 1
         im = normalize_signal(im, mode=rescale_mode, vmin=vmin, vmax=vmax)
 
@@ -371,8 +364,9 @@ def plot(
     :param bool tight: use tight layout.
     :param int max_imgs: maximum number of images to plot.
     :param str, None rescale_mode: rescale mode, either ``'min_max'`` (images are linearly rescaled between 0 and 1 using
-        their min and max values), ``'clip'`` (images are clipped and rescaled between 0 and 1),
-        or ``None`` (images are not rescaled and are displayed using a fixed range of 0 to 1).
+        their minimum and maximum values), ``'clip'`` (images are clipped to ``[vmin, vmax]`` and then rescaled between
+        0 and 1), or ``None`` (images are clipped to ``[vmin, vmax]`` without rescaling and displayed using ``norm`` or,
+        by default, a fixed range of ``[0, 1]``).
     :param bool show: show the image plot. Under the hood, this calls the ``plt.show()`` function.
     :param bool close: close the image plot. Under the hood, this calls the ``plt.close()`` function.
     :param tuple[int] figsize: size of the figure. If ``None``, calculated from the size of ``img_list``.
@@ -463,26 +457,32 @@ def plot(
         plt.suptitle(suptitle, wrap=True)
         fig.subplots_adjust(top=0.75)
 
-    if rescale_mode is None:
-        imshow_kwargs.setdefault("norm", Normalize(0.0, 1.0, clip=True))
+    norm = imshow_kwargs.pop("norm", None)
 
+    if rescale_mode is None and norm is None:
+        norm = Normalize(0.0, 1.0, clip=True)
+
+    mpl_images = []
     for i, row_imgs in enumerate(imgs):
+        mpl_row_images = []
         for r, img in enumerate(row_imgs):
-            im = axs[r, i].imshow(
+            mpl_img = axs[r, i].imshow(
                 img,
                 cmap=cmap,
                 interpolation=interpolation,
+                norm=norm,
                 **imshow_kwargs,
             )
+            mpl_row_images.append(mpl_img)
             if cbar:
                 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
                 divider = make_axes_locatable(axs[r, i])
                 cax = divider.append_axes("right", size="5%", pad=0.05)
-                colbar = fig.colorbar(im, cax=cax, orientation="vertical")
+                colbar = fig.colorbar(mpl_img, cax=cax, orientation="vertical")
                 colbar.ax.tick_params(labelsize=8)
                 # Relabel ticks with the true (pre-normalisation) data values
-                if img_scales[i]:
+                if img_scales[i] and rescale_mode is not None:
                     vmin_true, vmax_true = img_scales[i][r]
                     ticks = colbar.get_ticks()
                     true_labels = [
@@ -504,6 +504,8 @@ def plot(
                     spine.set_visible(False)
             else:
                 axs[r, i].axis("off")
+
+        mpl_images.append(mpl_row_images)
 
     if cbar:
         plt.subplots_adjust(hspace=0.2, wspace=0.2)
@@ -548,7 +550,7 @@ def plot(
                     img.squeeze(0).permute(1, 2, 0).cpu().numpy(),
                     cmap=cmap,
                     interpolation=interpolation,
-                    norm=imshow_kwargs.get("norm") if rescale_mode is None else None,
+                    norm=norm,
                 )
 
                 h, w = img.shape[2], img.shape[3]
@@ -606,14 +608,13 @@ def plot(
             plt.savefig(save_dir / "images.svg", dpi=dpi)
 
         # Save individual images for each column
-        for i, row_imgs in enumerate(imgs):
+        for i, mpl_row_images in enumerate(mpl_images):
             row_dirname = titles[i] if titles is not None else str(i)
             save_dir_i = Path(save_dir) / Path(row_dirname)
             save_dir_i.mkdir(parents=True, exist_ok=True)
-            for r, img in enumerate(row_imgs):
-                # plt.imsave fails if img is not C-contiguous
-                img = np.ascontiguousarray(img)
-                plt.imsave(save_dir_i / (str(r) + ".png"), img, cmap=cmap)
+            for r, mpl_image in enumerate(mpl_row_images):
+                mpl_image.write_png(save_dir_i / (str(r) + ".png"))
+
     if show:
         plt.show()
     if close:

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -14,6 +14,7 @@ import torchvision.transforms as T
 import torchvision.transforms.functional as F
 
 from PIL import Image
+import matplotlib.pyplot as plt
 
 from deepinv.utils.signals import normalize_signal, complex_abs
 
@@ -213,8 +214,8 @@ def preprocess_img(
     :param torch.Tensor im: the batch of images to preprocess, it is expected to be of shape (B, C, *).
     :param str, None rescale_mode: the normalization mode, either ``'min_max'``, ``'clip'``, or ``None``.
         With ``None``, image values are clipped to ``[vmin, vmax]`` without being rescaled.
-    :param float, None vmin: minimum clipping bound when using `rescale_mode=`'clip'`` or ``rescale_mode=None``. Defaults to 0.
-    :param float, None vmax: maximum clipping bound when using ``rescale_mode='clip'`` or ``rescale_mode=None``. Defaults to 1.
+    :param float, None vmin: minimum clipping bound when using ``'clip'`` or ``None``. Defaults to 0.
+    :param float, None vmax: maximum clipping bound when using ``'clip'`` or ``None``. Defaults to 1.
     :param bool return_scale: if ``True``, also return the per-element ``(vmin_orig, vmax_orig)``
         tuples representing the true data range **before** normalization, as a list of length B.
         For ``'min_max'`` mode these are the per-element min/max values; for ``'clip'`` mode
@@ -320,6 +321,7 @@ def plot(
     extract_size: float = 0.2,
     inset_loc: tuple | list = (0.0, 0.5),
     inset_size: float = 0.4,
+    norm: plt.colors.Norm | None = None,
     **imshow_kwargs,
 ):
     r"""
@@ -366,7 +368,7 @@ def plot(
     :param str, None rescale_mode: rescale mode, either ``'min_max'`` (images are linearly rescaled between 0 and 1 using
         their minimum and maximum values), ``'clip'`` (images are clipped to ``[vmin, vmax]`` and then rescaled between
         0 and 1), or ``None`` (images are clipped to ``[vmin, vmax]`` without rescaling and displayed using ``norm`` or,
-        by default, a fixed range of ``[0, 1]``).
+        by default, if norm is also ``None``, a fixed range of ``[0, 1]``).
     :param bool show: show the image plot. Under the hood, this calls the ``plt.show()`` function.
     :param bool close: close the image plot. Under the hood, this calls the ``plt.close()`` function.
     :param tuple[int] figsize: size of the figure. If ``None``, calculated from the size of ``img_list``.
@@ -395,8 +397,9 @@ def plot(
     :param float inset_size: size of inset to be plotted on image. Defaults to 0.4.
     :param imshow_kwargs: keyword args to pass to the matplotlib `imshow` calls. See
         `imshow docs <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_ for possible kwargs.
+    :param plt.colors.Norm, None norm: Map the colormap from norm object passed as argument. When `rescale_mode=None`
+        and `norm=None`, defaults to `Normalize(0.0, 1.0, clip=True)`.
     """
-    import matplotlib.pyplot as plt
     from matplotlib.colors import Normalize
 
     # Use the matplotlib config from deepinv
@@ -456,8 +459,6 @@ def plot(
     if suptitle:
         plt.suptitle(suptitle, wrap=True)
         fig.subplots_adjust(top=0.75)
-
-    norm = imshow_kwargs.pop("norm", None)
 
     if rescale_mode is None and norm is None:
         norm = Normalize(0.0, 1.0, clip=True)

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -213,7 +213,7 @@ def preprocess_img(
     :param torch.Tensor im: the batch of images to preprocess, it is expected to be of shape (B, C, *).
     :param str, None rescale_mode: the normalization mode, either ``'min_max'``, ``'clip'``, or ``None``.
         With ``None``, image values are clipped to ``[vmin, vmax]`` without being rescaled.
-    :param float, None vmin: minimum clipping bound when using ``'clip'`` or ``None``. Defaults to 0.
+    :param float, None vmin: minimum clipping bound when using `rescale_mode=`'clip'`` or ``rescale_mode=None``. Defaults to 0.
     :param float, None vmax: maximum clipping bound when using ``'clip'`` or ``None``. Defaults to 1.
     :param bool return_scale: if ``True``, also return the per-element ``(vmin_orig, vmax_orig)``
         tuples representing the true data range **before** normalization, as a list of length B.

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -396,7 +396,7 @@ def plot(
     :param float inset_size: size of inset to be plotted on image. Defaults to 0.4.
     :param imshow_kwargs: keyword args to pass to the matplotlib `imshow` calls. See
         `imshow docs <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_ for possible kwargs.
-    :param matplotlib.pyplot.colors.Normalize, None norm: Map the colormap from norm object passed as argument. When `rescale_mode=None` and `norm=None`, defaults to `Normalize(0.0, 1.0, clip=True)`.
+    :param matplotlib.colors.Normalize, None norm: Map the colormap from norm object passed as argument. When `rescale_mode=None` and `norm=None`, defaults to `Normalize(0.0, 1.0, clip=True)`.
     """
     import matplotlib.pyplot as plt
     from matplotlib.colors import Normalize

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -14,7 +14,6 @@ import torchvision.transforms as T
 import torchvision.transforms.functional as F
 
 from PIL import Image
-import matplotlib.pyplot as plt
 
 from deepinv.utils.signals import normalize_signal, complex_abs
 

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -191,7 +191,7 @@ def prepare_images(x=None, y=None, x_net=None, x_nl=None, rescale_mode="min_max"
 @torch.no_grad()
 def preprocess_img(
     im,
-    rescale_mode="min_max",
+    rescale_mode: str | None = "min_max",
     *,
     vmin: float | None = None,
     vmax: float | None = None,
@@ -202,8 +202,8 @@ def preprocess_img(
 
     Real and complex images are transformed into images with values between
     zero and one by first applying the modulus function for complex images, and
-    then by normalizing the resulting images between zero and one using min-max
-    normalization ``min_max`` or clipping ``clip``.
+    then, when ``rescale_mode`` is not ``None``, by normalizing the resulting images
+    between zero and one using min-max normalization ``min_max`` or clipping ``clip``.
 
     .. note::
 
@@ -211,7 +211,8 @@ def preprocess_img(
         representation of complex images and are processed accordingly.
 
     :param torch.Tensor im: the batch of images to preprocess, it is expected to be of shape (B, C, *).
-    :param str rescale_mode: the normalization mode, either 'min_max' or 'clip'.
+    :param str, None rescale_mode: the normalization mode, either ``'min_max'``, ``'clip'``, or ``None``.
+        If ``None``, the image values are not rescaled.
     :param float, None vmin: minimum value for clipping when using 'clip' rescaling.
     :param float, None vmax: maximum value for clipping when using 'clip' rescaling.
     :param bool return_scale: if ``True``, also return the per-element ``(vmin_orig, vmax_orig)``
@@ -242,13 +243,25 @@ def preprocess_img(
             if not isinstance(mins, list):
                 mins, maxs = [mins], [maxs]
             scales = list(zip(mins, maxs, strict=True))
-        else:  # clip
+        elif rescale_mode == "clip":
             v0 = vmin if vmin is not None else 0.0
             v1 = vmax if vmax is not None else 1.0
             scales = [(v0, v1)] * im.shape[0]
+        else: # rescale_mode is None
+            v0 = 0.0
+            v1 = 1.0
+            scales = [(v0, v1)] * im.shape[0]
 
-    # Normalize signal between 0 and 1
-    im = normalize_signal(im, mode=rescale_mode, vmin=vmin, vmax=vmax)
+    if rescale_mode is None and (vmin is not None or vmax is not None):
+        warn(
+            "The vmin and vmax arguments are used only when using 'clip' rescaling.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    if rescale_mode is not None:
+        # Normalize signal between 0 and 1
+        im = normalize_signal(im, mode=rescale_mode, vmin=vmin, vmax=vmax)
 
     if return_scale:
         return im, scales
@@ -290,7 +303,7 @@ def plot(
     save_dir: str | Path | None = None,
     tight: bool = True,
     max_imgs: int = 4,
-    rescale_mode: str = "min_max",
+    rescale_mode: str | None = "min_max",
     show: bool = True,
     close: bool = False,
     figsize: tuple[int, int] | None = None,
@@ -357,8 +370,9 @@ def plot(
     :param None, str, pathlib.Path save_dir: path to save the plots as individual images.
     :param bool tight: use tight layout.
     :param int max_imgs: maximum number of images to plot.
-    :param str rescale_mode: rescale mode, either ``'min_max'`` (images are linearly rescaled between 0 and 1 using
-        their min and max values) or ``'clip'`` (images are clipped between 0 and 1).
+    :param str, None rescale_mode: rescale mode, either ``'min_max'`` (images are linearly rescaled between 0 and 1 using
+        their min and max values), ``'clip'`` (images are clipped and rescaled between 0 and 1),
+        or ``None`` (images are not rescaled and are displayed using a fixed range of 0 to 1).
     :param bool show: show the image plot. Under the hood, this calls the ``plt.show()`` function.
     :param bool close: close the image plot. Under the hood, this calls the ``plt.close()`` function.
     :param tuple[int] figsize: size of the figure. If ``None``, calculated from the size of ``img_list``.
@@ -389,6 +403,7 @@ def plot(
         `imshow docs <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_ for possible kwargs.
     """
     import matplotlib.pyplot as plt
+    from matplotlib.colors import Normalize
 
     # Use the matplotlib config from deepinv
     config_matplotlib(fontsize=fontsize)
@@ -448,10 +463,13 @@ def plot(
         plt.suptitle(suptitle, wrap=True)
         fig.subplots_adjust(top=0.75)
 
+    if rescale_mode is None:
+        imshow_kwargs.setdefault("norm", Normalize(0.0, 1.0, clip=True))
+
     for i, row_imgs in enumerate(imgs):
         for r, img in enumerate(row_imgs):
             im = axs[r, i].imshow(
-                img, cmap=cmap, interpolation=interpolation, **imshow_kwargs
+                img, cmap=cmap, interpolation=interpolation, **imshow_kwargs,
             )
             if cbar:
                 from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -527,6 +545,7 @@ def plot(
                     img.squeeze(0).permute(1, 2, 0).cpu().numpy(),
                     cmap=cmap,
                     interpolation=interpolation,
+                    norm=imshow_kwargs.get("norm") if rescale_mode is None else None,
                 )
 
                 h, w = img.shape[2], img.shape[3]

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -396,7 +396,7 @@ def plot(
     :param float inset_size: size of inset to be plotted on image. Defaults to 0.4.
     :param imshow_kwargs: keyword args to pass to the matplotlib `imshow` calls. See
         `imshow docs <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_ for possible kwargs.
-    :param matplotlib.pyplot.colors.Norm, None norm: Map the colormap from norm object passed as argument. When `rescale_mode=None` and `norm=None`, defaults to `Normalize(0.0, 1.0, clip=True)`.
+    :param matplotlib.pyplot.colors.Normalize, None norm: Map the colormap from norm object passed as argument. When `rescale_mode=None` and `norm=None`, defaults to `Normalize(0.0, 1.0, clip=True)`.
     """
     import matplotlib.pyplot as plt
     from matplotlib.colors import Normalize

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -320,7 +320,7 @@ def plot(
     extract_size: float = 0.2,
     inset_loc: tuple | list = (0.0, 0.5),
     inset_size: float = 0.4,
-    norm: plt.colors.Norm | None = None,
+    norm=None,
     **imshow_kwargs,
 ):
     r"""
@@ -396,9 +396,9 @@ def plot(
     :param float inset_size: size of inset to be plotted on image. Defaults to 0.4.
     :param imshow_kwargs: keyword args to pass to the matplotlib `imshow` calls. See
         `imshow docs <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html>`_ for possible kwargs.
-    :param plt.colors.Norm, None norm: Map the colormap from norm object passed as argument. When `rescale_mode=None`
-        and `norm=None`, defaults to `Normalize(0.0, 1.0, clip=True)`.
+    :param matplotlib.pyplot.colors.Norm, None norm: Map the colormap from norm object passed as argument. When `rescale_mode=None` and `norm=None`, defaults to `Normalize(0.0, 1.0, clip=True)`.
     """
+    import matplotlib.pyplot as plt
     from matplotlib.colors import Normalize
 
     # Use the matplotlib config from deepinv

--- a/deepinv/utils/plotting.py
+++ b/deepinv/utils/plotting.py
@@ -214,7 +214,7 @@ def preprocess_img(
     :param str, None rescale_mode: the normalization mode, either ``'min_max'``, ``'clip'``, or ``None``.
         With ``None``, image values are clipped to ``[vmin, vmax]`` without being rescaled.
     :param float, None vmin: minimum clipping bound when using `rescale_mode=`'clip'`` or ``rescale_mode=None``. Defaults to 0.
-    :param float, None vmax: maximum clipping bound when using ``'clip'`` or ``None``. Defaults to 1.
+    :param float, None vmax: maximum clipping bound when using ``rescale_mode='clip'`` or ``rescale_mode=None``. Defaults to 1.
     :param bool return_scale: if ``True``, also return the per-element ``(vmin_orig, vmax_orig)``
         tuples representing the true data range **before** normalization, as a list of length B.
         For ``'min_max'`` mode these are the per-element min/max values; for ``'clip'`` mode

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ New Features
 ^^^^^^^^^^^^
 - Add :func:`deepinv.physics.TomographyWithAstra.from_astra_geometry` to build the operator directly from pre-created ``astra`` geometries (:gh:`1102` by `Margaret Duff`_)
 - Add downloadable pretrained weights to :class:`deepinv.models.FFDNet` (:gh:`1357` by `Vicky De Ridder`_)
+- Add :func:`deepinv.utils.plot` to disable image rescaling with ``rescale_mode=None``. (:gh:`1339` by `Delphine Doutsas`_)
 
 Changed
 ^^^^^^^
@@ -42,7 +43,6 @@ New Features
 - Add :class:`deepinv.datasets.BrainWebPET` (:gh:`1286` by `Thibaut Modrzyk`_)
 - Add ``mask_first`` option to :class:`deepinv.physics.SpaceVaryingBlur` and :func:`deepinv.physics.functional.product_convolution2d` (:gh:`1347` by `Julian Tachella`_)
 - Add ``use_dict_output`` option to every dataset class, returning a dict ``{"x", "y", "params"}`` instead of a tuple; propagate support to all deepinv internals (:gh:`1244` by `Romain Vo`_)
-- Add :func:`deepinv.utils.plot` to disable image rescaling with ``rescale_mode=None``. (:gh:`1339` by dldou)
 
 Changed
 ^^^^^^^
@@ -68,7 +68,9 @@ Fixed
 - (Breaking) Have `x_shift` represent horizontal shifts and `y_shift` vertical shifts in :class:`deepinv.transform.Shift` (:gh:`1236` by `Sarra Amiri`_)
 - Force trainer non_blocking_transfers=False on MPS and CPU (:gh:`1311` by `Andrew Wang`_)
 - Fix :class:`deepinv.physics.PET` incorrect device attribution of attenuation and background on update and incorrect handling of batched attenuation  (:gh:`1331` by `Thibaut Modrzyk`_)
-- Fix the channel description in NBUDataset documentation (:gh:`` by dldou)
+
+
+
 
 v0.4.1
 ------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,7 +22,7 @@ New Features
 - Add espirit_crop parameter to control ESPIRiT multicoil MRI map estimation (:gh:`1263` by `Andrew Wang`_)
 - Add :class:`deepinv.loss.metric.BRISQUE` and :class:`deepinv.loss.metric.NIMA` no-reference image quality metrics (:gh:`1310` by `Julian Tachella`_)
 - Add :class:`deepinv.datasets.BrainWebPET` (:gh:`1286` by `Thibaut Modrzyk`_)
-- Add :func:`deepinv.utils.plot` to disable image rescaling with ``rescale_mode=None``. (:gh:`#1339` by `dldou`)
+- Add :func:`deepinv.utils.plot` to disable image rescaling with ``rescale_mode=None``. (:gh:`1339` by dldou)
 
 Changed
 ^^^^^^^

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -704,3 +704,4 @@ Changed
 .. _Irène Waldspurger: https://github.com/IWalds
 .. _Kushagra Shukla: https://github.com/Kushagra481
 .. _Sarra Amiri: https://github.com/amirisarra18-jpg
+.. _Delphine Doutsas: https://github.com/dldou

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -61,9 +61,7 @@ Fixed
 - (Breaking) Have `x_shift` represent horizontal shifts and `y_shift` vertical shifts in :class:`deepinv.transform.Shift` (:gh:`1236` by `Sarra Amiri`_)
 - Force trainer non_blocking_transfers=False on MPS and CPU (:gh:`1311` by `Andrew Wang`_)
 - Fix :class:`deepinv.physics.PET` incorrect device attribution of attenuation and background on update and incorrect handling of batched attenuation  (:gh:`1331` by `Thibaut Modrzyk`_)
-
-
-
+- Fix the channel description in NBUDataset documentation (:gh:`` by dldou)
 
 v0.4.1
 ------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,6 +22,7 @@ New Features
 - Add espirit_crop parameter to control ESPIRiT multicoil MRI map estimation (:gh:`1263` by `Andrew Wang`_)
 - Add :class:`deepinv.loss.metric.BRISQUE` and :class:`deepinv.loss.metric.NIMA` no-reference image quality metrics (:gh:`1310` by `Julian Tachella`_)
 - Add :class:`deepinv.datasets.BrainWebPET` (:gh:`1286` by `Thibaut Modrzyk`_)
+- Add :func:`deepinv.utils.plot` to disable image rescaling with ``rescale_mode=None``. (:gh:`#1339` by `dldou`)
 
 Changed
 ^^^^^^^


### PR DESCRIPTION
Fixes #1280.

This PR:
- adds `rescale_mode=None` to `deepinv.utils.plot`, keeping image values unchanged while displaying them over `[0, 1]` with `Normalize(0, 1, clip=True)`;
- preserves the existing `vmin`/`vmax` warning behavior;
- applies the same normalization to plot insets.

Tests cover the existing `"clip"` behavior and the new `None` mode.



Thank you for contributing to DeepInverse!

Please read our [contributing guidelines](https://deepinv.org/contributing.html) for instructions on how to contribute, including writing tests, documentation and code style.

Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/docs_cpu.yml). Look for the workflow run corresponding to your pull request.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [X] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [X] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [X] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.

### Notes on tests and make html
The local documentation build could not complete because of the MPS backend. Some operations  are unsupported by the MPS backend (for instance ,`float64`, `torch.poisson`, and `nan_to_num` on complex tensors). 

Some tests of the suite failed because of my MPS backend but the 8 targeted test cases for this PR all pass:
```
python -m pytest \
  deepinv/tests/test_utils.py::test_plot_clip_rescale_mode \
  deepinv/tests/test_utils.py::test_plot_rescale_mode_none \
  deepinv/tests/test_utils.py::test_plot_rescale_mode_none_vmin_vmax_warning \
  deepinv/tests/test_utils.py::test_plot_rescale_mode_none_inset
```