### PR TITLE
Do not count failed backtracking checks as global iterations in FixedPoint

### DIFF
--- a/deepinv/optim/fixed_point.py
+++ b/deepinv/optim/fixed_point.py
@@ -321,10 +321,19 @@ class FixedPoint(nn.Module):
         if self.anderson_acceleration_config is not None:
             self.init_anderson_acceleration(X)
 
-        for it in tqdm(
-            range(self.max_iter),
+        # ``it`` counts accepted iterations only. A failed backtracking check
+        # rejects the trial iterate and adjusts the stepsize instead, so it is
+        # part of the search for one iteration rather than an iteration in its
+        # own right. Counting it against ``max_iter`` both stops the algorithm
+        # early and hands ``single_iteration`` an index that runs ahead of the
+        # iterate it labels. Consecutive failures remain bounded by
+        # ``backtracking_config.max_iter``, so the loop still terminates.
+        it = 0
+        progress_bar = tqdm(
+            total=self.max_iter,
             disable=(not self.verbose or not self.show_progress_bar),
-        ):
+        )
+        while it < self.max_iter:
             X_prev = X
             X = self.single_iteration(X, it, *args, **kwargs)
 
@@ -337,13 +346,17 @@ class FixedPoint(nn.Module):
                     else None
                 )
 
-                # Convergence check
-                if (
+                # Convergence check, evaluated at the index of the iteration
+                # that has just been accepted.
+                converged = (
                     self.early_stop
                     and self.check_conv_fn is not None
                     and it > 1
                     and self.check_conv_fn(it, X_prev, X)
-                ):
+                )
+                it += 1
+                progress_bar.update(1)
+                if converged:
                     break
 
             else:
@@ -354,9 +367,10 @@ class FixedPoint(nn.Module):
                     if self.verbose:
                         print(
                             f"[Stopping] Reached maximum number of failed backtracking checks "
-                            f"({self.max_iter_backtracking})."
+                            f"({self.backtracking_config.max_iter})."
                         )
                     break
+        progress_bar.close()
 
         return X, metrics
 

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -1524,3 +1524,45 @@ def test_sirt(device):
 
         assert sirt.has_converged
         assert x_sirt is not None
+
+
+def test_backtracking_does_not_consume_global_iterations():
+    """Rejected backtracking trials must not count against ``max_iter``.
+
+    A failed sufficient-decrease check discards the trial iterate and shrinks
+    the stepsize, so it belongs to the search for one iteration rather than
+    being an iteration itself. Counting it stops the algorithm before it has
+    taken ``max_iter`` steps: on this problem the iterate never leaves its
+    initialisation. See https://github.com/deepinv/deepinv/issues/1272.
+    """
+    physics = dinv.physics.LinearPhysics(A=lambda x: x, A_adjoint=lambda x: x)
+    y = torch.ones(1, 1, 1, 1)
+    model = dinv.optim.GD(
+        data_fidelity=dinv.optim.L2(),
+        stepsize=4.0,
+        max_iter=2,
+        backtracking=dinv.optim.BacktrackingConfig(gamma=0.1, eta=0.5, max_iter=20),
+    )
+    x = model(y, physics, init=torch.zeros_like(y))
+    # Two accepted iterations at the backtracked stepsize reach the minimiser
+    # of 0.5 ||x - y||^2, which is y itself.
+    assert torch.allclose(x, y), f"iterate never advanced, got {x.item()}"
+
+
+def test_backtracking_failure_limit_reports_cleanly():
+    """Exhausting the backtracking budget must stop, not raise.
+
+    The stopping message previously interpolated an attribute that is never
+    defined, so this path raised AttributeError instead of terminating.
+    """
+    physics = dinv.physics.LinearPhysics(A=lambda x: x, A_adjoint=lambda x: x)
+    y = torch.ones(1, 1, 1, 1)
+    model = dinv.optim.GD(
+        data_fidelity=dinv.optim.L2(),
+        stepsize=1e6,
+        max_iter=50,
+        backtracking=dinv.optim.BacktrackingConfig(gamma=0.1, eta=0.5, max_iter=2),
+        verbose=True,
+    )
+    x = model(y, physics, init=torch.zeros_like(y))
+    assert torch.isfinite(x).all()

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -47,7 +47,7 @@ Fixed
 - (Breaking) Have `x_shift` represent horizontal shifts and `y_shift` vertical shifts in :class:`deepinv.transform.Shift` (:gh:`1236` by `Sarra Amiri`_)
 - Force trainer non_blocking_transfers=False on MPS and CPU (:gh:`1311` by `Andrew Wang`_)
 - Fix :class:`deepinv.physics.PET` incorrect device attribution of attenuation and background on update and incorrect handling of batched attenuation 
-- Stop failed backtracking checks from consuming global iterations in :class:`deepinv.optim.FixedPoint`, and report the backtracking limit instead of an undefined attribute when it is reached (:gh:`PRNUM` by `Mohammad Sadegh Salehi`_)
+- Stop failed backtracking checks from consuming global iterations in :class:`deepinv.optim.FixedPoint`, and report the backtracking limit instead of an undefined attribute when it is reached (:gh:`1340` by `Mohammad Sadegh Salehi`_)
 
 
 v0.4.1

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -47,6 +47,7 @@ Fixed
 - (Breaking) Have `x_shift` represent horizontal shifts and `y_shift` vertical shifts in :class:`deepinv.transform.Shift` (:gh:`1236` by `Sarra Amiri`_)
 - Force trainer non_blocking_transfers=False on MPS and CPU (:gh:`1311` by `Andrew Wang`_)
 - Fix :class:`deepinv.physics.PET` incorrect device attribution of attenuation and background on update and incorrect handling of batched attenuation 
+- Stop failed backtracking checks from consuming global iterations in :class:`deepinv.optim.FixedPoint`, and report the backtracking limit instead of an undefined attribute when it is reached (:gh:`PRNUM` by `Mohammad Sadegh Salehi`_)
 
 
 v0.4.1
@@ -677,6 +678,7 @@ Changed
 .. _Chaithya G R: https://github.com/chaithyagr
 .. _Alexander Skorikov: https://github.com/askorikov
 .. _Thibaut Modrzyk: https://github.com/Tmodrzyk
+.. _Mohammad Sadegh Salehi: https://github.com/MohammadSadeghSalehi
 .. _Avithal Lautman: https://github.com/avithal
 .. _Thomas Boulanger: https://github.com/LeRatonLaveurSolitaire
 .. _Tiberiu Sabau: https://github.com/tibisabau


### PR DESCRIPTION
Closes #1272.

### The reported bug

`FixedPoint` iterates over `range(self.max_iter)`, so a rejected backtracking trial spends a global iteration. A failed sufficient-decrease check discards the trial iterate and shrinks the stepsize, which is part of the search for one iteration rather than an iteration in its own right.

The example from the issue returns `0.0`:

```
Backtracking : new stepsize = 2.000000
Backtracking : new stepsize = 1.000000
Returned x: 0.0
```

Both iterations of `max_iter=2` go on backtracking and the iterate never leaves its initialisation. With this change it returns `1.0`, the minimiser of `0.5 ||x - y||^2` at `y = 1`.

This also fixes the second point in the issue, which was untested there: `single_iteration` was receiving an index running ahead of the iterate it labels, so any algorithm keying internal state off `it` reads the wrong entry.

`it` now counts accepted iterations only. Consecutive failures remain bounded by `backtracking_config.max_iter`, so the loop still terminates, and the convergence check is still evaluated at the index of the iteration just accepted, leaving `check_conv_fn` semantics unchanged.

### A second bug in the same block

The message printed on exhausting the backtracking budget interpolates `self.max_iter_backtracking`. That attribute is defined nowhere in the codebase, so with `verbose=True` the path raised `AttributeError` instead of stopping:

```python
model = dinv.optim.GD(
    data_fidelity=dinv.optim.L2(), stepsize=1e6, max_iter=50,
    backtracking=dinv.optim.BacktrackingConfig(gamma=0.1, eta=0.5, max_iter=2),
    verbose=True,
)
model(y, physics, init=x0)
# AttributeError: 'FixedPoint' object has no attribute 'max_iter_backtracking'
```

It now reports `backtracking_config.max_iter` and returns normally.

### Tests

Two regression tests in `test_optim.py`, one per bug. Both fail on `main` and pass here:

```
without the fix: 2 failed
with the fix:    2 passed
```

`pytest deepinv/tests/test_optim.py -k "not device1"` gives 123 passed, 28 skipped, no failures. The `device1` (MPS) cases are excluded because they fail identically on unmodified `main` on this machine, unrelated to this change.
