### PR TITLE
Fix VP SDE bugs

### DIFF
--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -528,7 +528,12 @@ class SongDiffusionSDE(EDMDiffusionSDE):
     Compared to the EDM formulation in :class:`deepinv.sampling.EDMDiffusionSDE`, the scale :math:`s(t)` and noise :math:`\sigma(t)` schedulers are defined with respect to :math:`\beta(t)` and :math:`\xi(t)` as follows:
 
     .. math::
-        s(t) = \exp\left(-\int_0^t \beta(s) ds\right), \quad \sigma(t) = \sqrt{2 \int_0^t \frac{\xi(s)}{s(s)^2} ds}.
+        s(t) = \exp\left(-\int_0^t \beta(s) ds\right), \quad \sigma(t) = \sqrt{\int_0^t \frac{\xi(s)}{s(s)^2} ds}.
+
+    These are the schedules for which the EDM diffusion coefficient :math:`s(t) \sqrt{2 \sigma(t) \sigma'(t)}`
+    reduces to :math:`\sqrt{\xi(t)}`, i.e. for which the process above is the one that is realised.
+    On the variance-preserving branch the integral has the closed form :math:`\sigma(t)^2 = 1/s(t)^2 - 1`,
+    which is the DDPM noise level :math:`\sqrt{1 - \bar\alpha(t)} / \sqrt{\bar\alpha(t)}` for :math:`\bar\alpha = s^2`.
 
     Common choices include the variance-preserving formulation :math:`\beta(t) = \xi(t)` and the variance-exploding formulation :math:`\beta(t) = 0`.
 
@@ -611,17 +616,11 @@ class SongDiffusionSDE(EDMDiffusionSDE):
                 integral = trapz_torch(
                     integrand, torch.tensor(0.0, device=t.device), t, n_steps
                 )
-                return (2 * integral).sqrt()
+                return integral.sqrt()
 
         def sigma_prime_t(t: Tensor | float) -> Tensor:
             t = self._handle_time_step(t)
-            if variance_preserving:
-                # sigma = sqrt(1 / s^2 - 1)
-                # sigma' = beta / (2 s^2 sigma).
-                return xi_t(t) / (2 * scale_t(t) ** 2 * sigma_t(t))
-            # sigma = sqrt(2 \int_0^t xi / s^2)
-            # sigma' = xi / (s^2 sigma).
-            return xi_t(t) / (scale_t(t) ** 2 * sigma_t(t))
+            return xi_t(t) / (2 * scale_t(t) ** 2 * sigma_t(t))
 
         super().__init__(
             sigma_t=sigma_t,

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -14,15 +14,7 @@ from deepinv.models.wrapper import MinusOneOneDenoiserWrapper
 
 
 def _first_time_step(solver: BaseSDESolver, timesteps=None):
-    r"""
-    The time at which the solver starts, i.e. the time the initial state must be drawn at.
-
-    :param deepinv.sampling.BaseSDESolver solver: the solver used for sampling.
-    :param torch.Tensor, numpy.ndarray, list timesteps: the time steps given to the solver, if any.
-        If `None`, the solver's own time steps are used.
-
-    :return: the first time step, or `None` if it cannot be determined.
-    """
+    """The time at which the solver starts"""
     if timesteps is None:
         timesteps = getattr(solver, "timesteps", None)
     if timesteps is None or len(timesteps) == 0:

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -530,10 +530,8 @@ class SongDiffusionSDE(EDMDiffusionSDE):
     .. math::
         s(t) = \exp\left(-\int_0^t \beta(s) ds\right), \quad \sigma(t) = \sqrt{\int_0^t \frac{\xi(s)}{s(s)^2} ds}.
 
-    These are the schedules for which the EDM diffusion coefficient :math:`s(t) \sqrt{2 \sigma(t) \sigma'(t)}`
-    reduces to :math:`\sqrt{\xi(t)}`, i.e. for which the process above is the one that is realised.
-    On the variance-preserving branch the integral has the closed form :math:`\sigma(t)^2 = 1/s(t)^2 - 1`,
-    which is the DDPM noise level :math:`\sqrt{1 - \bar\alpha(t)} / \sqrt{\bar\alpha(t)}` for :math:`\bar\alpha = s^2`.
+    These are the schedules for which the EDM diffusion coefficient :math:`s(t) \sqrt{2 \sigma(t) \sigma'(t)}` reduces to :math:`\sqrt{\xi(t)}`.
+    For variance-preserving, it has the closed form :math:`\sigma(t)^2 = 1/s(t)^2 - 1`, which is the DDPM noise level :math:`\sqrt{1 - \bar\alpha(t)} / \sqrt{\bar\alpha(t)}` for :math:`\bar\alpha = s^2`.
 
     Common choices include the variance-preserving formulation :math:`\beta(t) = \xi(t)` and the variance-exploding formulation :math:`\beta(t) = 0`.
 

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -13,6 +13,23 @@ from deepinv.sampling.utils import trapz_torch
 from deepinv.models.wrapper import MinusOneOneDenoiserWrapper
 
 
+def _first_time_step(solver: BaseSDESolver, timesteps=None):
+    r"""
+    The time at which the solver starts, i.e. the time the initial state must be drawn at.
+
+    :param deepinv.sampling.BaseSDESolver solver: the solver used for sampling.
+    :param torch.Tensor, numpy.ndarray, list timesteps: the time steps given to the solver, if any.
+        If `None`, the solver's own time steps are used.
+
+    :return: the first time step, or `None` if it cannot be determined.
+    """
+    if timesteps is None:
+        timesteps = getattr(solver, "timesteps", None)
+    if timesteps is None or len(timesteps) == 0:
+        return None
+    return timesteps[0]
+
+
 class BaseSDE(nn.Module):
     r"""
     Base class for Stochastic Differential Equation (SDE):
@@ -68,7 +85,11 @@ class BaseSDE(nn.Module):
         """
         self.solver.rng_manual_seed(seed)
         if isinstance(x_init, (tuple, list, torch.Size)):
-            x_init = self.sample_init(x_init, rng=self.solver.rng)
+            x_init = self.sample_init(
+                x_init,
+                rng=self.solver.rng,
+                t=_first_time_step(self.solver, kwargs.get("timesteps", None)),
+            )
         solution = self.solver.sample(
             self, x_init, *args, **kwargs, get_trajectory=get_trajectory
         )
@@ -93,12 +114,18 @@ class BaseSDE(nn.Module):
         return self.drift(x, t, *args, **kwargs), self.diffusion(t)
 
     def sample_init(
-        self, shape: list | tuple | torch.Size, rng: torch.Generator = None
+        self,
+        shape: list | tuple | torch.Size,
+        rng: torch.Generator = None,
+        t: Tensor | float = None,
     ) -> torch.Tensor:
         r"""
-        Sample from the end-time distribution of the forward diffusion.
+        Sample from the distribution of the forward diffusion at time `t`.
 
         :param shape: The shape of the the sample, of the form `(B, C, H, W)`.
+        :param torch.Generator rng: Random number generator for reproducibility.
+        :param torch.Tensor, float t: the time at which the state is drawn, which should be the
+            time the solver starts from. If `None`, defaults to the end time `T` of the forward SDE.
         """
         raise NotImplementedError
 
@@ -457,19 +484,33 @@ class EDMDiffusionSDE(DiffusionSDE):
         score = (denoised - x.to(self.dtype)) / (scale * sigma).pow(2)
         return score
 
-    def sample_init(self, shape, rng: torch.Generator) -> torch.Tensor:
+    def sample_init(
+        self, shape, rng: torch.Generator = None, t: Tensor | float = None
+    ) -> torch.Tensor:
         r"""
-        Sample from the initial distribution of the reverse-time diffusion SDE, which is a Gaussian with zero mean and covariance matrix :math:` s(T)^2 \sigma(T)^2 \operatorname{Id}`.
+        Sample from the initial distribution of the reverse-time diffusion SDE, which is a Gaussian with zero mean and covariance matrix :math:` s(t)^2 \sigma(t)^2 \operatorname{Id}`.
+
+        .. note::
+
+            The state must be drawn at the time the solver starts from, which is not necessarily
+            the end time :math:`T` of the forward SDE: solving from `timesteps[0] < T` while
+            drawing at :math:`T` silently starts the trajectory from a mis-scaled state.
+            The samplers pass the solver's first time step here; when calling this method
+            directly, set `t` accordingly.
 
         :param tuple shape: The shape of the sample to generate
         :param torch.Generator rng: Random number generator for reproducibility
+        :param torch.Tensor, float t: the time at which the state is drawn. If `None`, defaults to
+            the end time `T` of the forward SDE.
         :return: A sample from the prior distribution
         :rtype: torch.Tensor
         """
+        if t is None:
+            t = self.T
         init = (
             torch.randn(shape, generator=rng, device=self.device, dtype=self.dtype)
-            * self.sigma_t(self.T)
-            * self.scale_t(self.T)
+            * self.sigma_t(t)
+            * self.scale_t(t)
         )
         return init
 
@@ -581,7 +622,13 @@ class SongDiffusionSDE(EDMDiffusionSDE):
 
         def sigma_prime_t(t: Tensor | float) -> Tensor:
             t = self._handle_time_step(t)
-            return (xi_t(t) / (scale_t(t) ** 2)) * (1 / sigma_t(t))
+            if variance_preserving:
+                # sigma = sqrt(1 / s^2 - 1)
+                # sigma' = beta / (2 s^2 sigma).
+                return xi_t(t) / (2 * scale_t(t) ** 2 * sigma_t(t))
+            # sigma = sqrt(2 \int_0^t xi / s^2)
+            # sigma' = xi / (s^2 sigma).
+            return xi_t(t) / (scale_t(t) ** 2 * sigma_t(t))
 
         super().__init__(
             sigma_t=sigma_t,
@@ -706,6 +753,7 @@ class VarianceExplodingDiffusion(EDMDiffusionSDE):
         sigma_min: float = 0.001,
         sigma_max: float = 80,
         alpha: Callable | float = 0.25,
+        T: float = 1.0,
         solver: BaseSDESolver = None,
         dtype=torch.float64,
         device=torch.device("cpu"),
@@ -724,7 +772,7 @@ class VarianceExplodingDiffusion(EDMDiffusionSDE):
             sigma_t=sigma_t,
             sigma_prime_t=sigma_prime_t,
             variance_exploding=True,
-            T=1,
+            T=T,
             alpha=alpha,
             denoiser=denoiser,
             solver=solver,
@@ -763,6 +811,7 @@ class VariancePreservingDiffusion(SongDiffusionSDE):
     :param float beta_min: the minimum noise level.
     :param float beta_max: the maximum noise level.
     :param Callable, float alpha: a (possibly time-dependent) positive scalar weighting the diffusion term. A  constant function :math:`\alpha(t) = 0` corresponds to ODE sampling and :math:`\alpha(t) > 0` corresponds to SDE sampling.
+    :param float T: the end time of the forward SDE. Default to `1.0`.
     :param bool scaled_linear: whether to use the scaled linear beta schedule. If `False`, uses the more standard linear schedule. Default to `False`.
     :param deepinv.sampling.BaseSDESolver solver: the solver for solving the SDE.
     :param torch.dtype dtype: data type of the computation, except for the ``denoiser`` which will use ``torch.float32``.
@@ -780,6 +829,7 @@ class VariancePreservingDiffusion(SongDiffusionSDE):
         beta_min: float = 0.1,
         beta_max: float = 20.0,
         alpha: Callable | float = 0.0,
+        T: float = 1.0,
         scaled_linear: bool = False,
         solver: BaseSDESolver = None,
         dtype=torch.float64,
@@ -812,7 +862,7 @@ class VariancePreservingDiffusion(SongDiffusionSDE):
             B_t=B_t,
             variance_preserving=True,
             alpha=alpha,
-            T=1,
+            T=T,
             denoiser=denoiser,
             solver=solver,
             dtype=dtype,
@@ -945,7 +995,7 @@ class PosteriorDiffusion(Reconstructor):
 
         :param torch.Tensor y: the data measurement.
         :param deepinv.physics.Physics physics: the forward operator.
-        :param torch.Tensor, tuple x_init: the initial value for the sampling, can be a :class:`torch.Tensor` or a tuple `(B, C, H, W)`, indicating the shape of the initial point, matching the shape of `physics` and `y`. In this case, the initial value is taken randomly following the end-point distribution of the `sde`.
+        :param torch.Tensor, tuple x_init: the initial value for the sampling, can be a :class:`torch.Tensor` or a tuple `(B, C, H, W)`, indicating the shape of the initial point, matching the shape of `physics` and `y`. In this case, the initial value is taken randomly following the distribution of the `sde` at the first time step of the solver.
         :param int seed: the random seed for reproducibility, the same samples will be generated for the same seed. Default to `None`.
         :param torch.Tensor timesteps: the time steps for the solver. If `None`, the default time steps in the solver will be used. Default to `None`.
         :param bool denoise_output: whether to perform an additional denoising step at the end of the sampling process, which can improve the quality of the generated samples. Default to `True`.
@@ -956,15 +1006,16 @@ class PosteriorDiffusion(Reconstructor):
         :return: the generated sample (:class:`torch.Tensor` of shape `(B, C, H, W)`) if `get_trajectory` is `False`. Otherwise, returns a tuple (:class:`torch.Tensor`, :class:`torch.Tensor`) of shape `(B, C, H, W)` and `(N, B, C, H, W)` where `N` is the number of steps.
         """
         self.solver.rng_manual_seed(seed)
+        t_init = _first_time_step(self.solver, timesteps)
         if isinstance(x_init, (tuple, list, torch.Size)):
-            x_init = self.sde.sample_init(x_init, rng=self.solver.rng)
+            x_init = self.sde.sample_init(x_init, rng=self.solver.rng, t=t_init)
         elif x_init is None:
             if physics is not None:
                 x_init = self.sde.sample_init(
-                    physics.A_dagger(y).shape, rng=self.solver.rng
+                    physics.A_dagger(y).shape, rng=self.solver.rng, t=t_init
                 )
             elif y is not None:
-                x_init = self.sde.sample_init(y.shape, rng=self.solver.rng)
+                x_init = self.sde.sample_init(y.shape, rng=self.solver.rng, t=t_init)
             else:
                 raise ValueError("Either `x_init` or `physics` must be specified.")
         solution = self.solver.sample(

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -112,7 +112,7 @@ class BaseSDE(nn.Module):
         t: Tensor | float = None,
     ) -> torch.Tensor:
         r"""
-        Sample from the distribution of the forward diffusion at time `t`.
+        Sample from the initial distribution of the SDE.
 
         :param shape: The shape of the the sample, of the form `(B, C, H, W)`.
         :param torch.Generator rng: Random number generator for reproducibility.
@@ -486,11 +486,8 @@ class EDMDiffusionSDE(DiffusionSDE):
 
         .. note::
 
-            The state must be drawn at the time the solver starts from, which is not necessarily
-            the end time :math:`T` of the forward SDE: solving from `timesteps[0] < T` while
-            drawing at :math:`T` silently starts the trajectory from a mis-scaled state.
-            The samplers pass the solver's first time step here; when calling this method
-            directly, set `t` accordingly.
+            The state is drawn at the time the solver starts from, which is `timestep[0]` of the solver, which is not necessarily the end time :math:`T` of the forward SDE.
+            The `timesteps` of the solver must be decreasing.
 
         :param tuple shape: The shape of the sample to generate
         :param torch.Generator rng: Random number generator for reproducibility
@@ -528,7 +525,7 @@ class SongDiffusionSDE(EDMDiffusionSDE):
     Compared to the EDM formulation in :class:`deepinv.sampling.EDMDiffusionSDE`, the scale :math:`s(t)` and noise :math:`\sigma(t)` schedulers are defined with respect to :math:`\beta(t)` and :math:`\xi(t)` as follows:
 
     .. math::
-        s(t) = \exp\left(-\int_0^t \beta(s) ds\right), \quad \sigma(t) = \sqrt{\int_0^t \frac{\xi(s)}{s(s)^2} ds}.
+        s(t) = \exp\left(-0.5 \int_0^t \beta(s) ds\right), \quad \sigma(t) = \sqrt{\int_0^t \frac{\xi(s)}{s(s)^2} ds}.
 
     These are the schedules for which the EDM diffusion coefficient :math:`s(t) \sqrt{2 \sigma(t) \sigma'(t)}` reduces to :math:`\sqrt{\xi(t)}`.
     For variance-preserving, it has the closed form :math:`\sigma(t)^2 = 1/s(t)^2 - 1`, which is the DDPM noise level :math:`\sqrt{1 - \bar\alpha(t)} / \sqrt{\bar\alpha(t)}` for :math:`\bar\alpha = s^2`.

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -124,8 +124,7 @@ class BaseSDE(nn.Module):
 
         :param shape: The shape of the the sample, of the form `(B, C, H, W)`.
         :param torch.Generator rng: Random number generator for reproducibility.
-        :param torch.Tensor, float t: the time at which the state is drawn, which should be the
-            time the solver starts from. If `None`, defaults to the end time `T` of the forward SDE.
+        :param torch.Tensor, float t: the time at which the state is drawn. If `None`, defaults to the end time `T`.
         """
         raise NotImplementedError
 
@@ -485,7 +484,10 @@ class EDMDiffusionSDE(DiffusionSDE):
         return score
 
     def sample_init(
-        self, shape, rng: torch.Generator = None, t: Tensor | float = None
+        self,
+        shape: list | tuple | torch.Size,
+        rng: torch.Generator = None,
+        t: Tensor | float = None,
     ) -> torch.Tensor:
         r"""
         Sample from the initial distribution of the reverse-time diffusion SDE, which is a Gaussian with zero mean and covariance matrix :math:` s(t)^2 \sigma(t)^2 \operatorname{Id}`.
@@ -500,8 +502,7 @@ class EDMDiffusionSDE(DiffusionSDE):
 
         :param tuple shape: The shape of the sample to generate
         :param torch.Generator rng: Random number generator for reproducibility
-        :param torch.Tensor, float t: the time at which the state is drawn. If `None`, defaults to
-            the end time `T` of the forward SDE.
+        :param torch.Tensor, float t: the time at which the state is drawn. If `None`, defaults to end time `T`
         :return: A sample from the prior distribution
         :rtype: torch.Tensor
         """

--- a/deepinv/sampling/diffusion_sde.py
+++ b/deepinv/sampling/diffusion_sde.py
@@ -13,12 +13,12 @@ from deepinv.sampling.utils import trapz_torch
 from deepinv.models.wrapper import MinusOneOneDenoiserWrapper
 
 
-def _first_time_step(solver: BaseSDESolver, timesteps=None):
+def _first_time_step(sde: BaseSDE, solver: BaseSDESolver, timesteps=None):
     """The time at which the solver starts"""
     if timesteps is None:
         timesteps = getattr(solver, "timesteps", None)
     if timesteps is None or len(timesteps) == 0:
-        return None
+        return getattr(sde, "T", None)
     return timesteps[0]
 
 
@@ -80,7 +80,7 @@ class BaseSDE(nn.Module):
             x_init = self.sample_init(
                 x_init,
                 rng=self.solver.rng,
-                t=_first_time_step(self.solver, kwargs.get("timesteps", None)),
+                t=_first_time_step(self, self.solver, kwargs.get("timesteps", None)),
             )
         solution = self.solver.sample(
             self, x_init, *args, **kwargs, get_trajectory=get_trajectory
@@ -993,7 +993,7 @@ class PosteriorDiffusion(Reconstructor):
         :return: the generated sample (:class:`torch.Tensor` of shape `(B, C, H, W)`) if `get_trajectory` is `False`. Otherwise, returns a tuple (:class:`torch.Tensor`, :class:`torch.Tensor`) of shape `(B, C, H, W)` and `(N, B, C, H, W)` where `N` is the number of steps.
         """
         self.solver.rng_manual_seed(seed)
-        t_init = _first_time_step(self.solver, timesteps)
+        t_init = _first_time_step(self.sde, self.solver, timesteps)
         if isinstance(x_init, (tuple, list, torch.Size)):
             x_init = self.sde.sample_init(x_init, rng=self.solver.rng, t=t_init)
         elif x_init is None:

--- a/deepinv/sampling/sde_solver.py
+++ b/deepinv/sampling/sde_solver.py
@@ -56,17 +56,34 @@ class BaseSDESolver(nn.Module):
 
     Currently only supported for fixed time steps for numerical integration.
 
-    :param torch.Tensor, numpy.ndarray, list timesteps: time steps at which the SDE will be discretized.e.
+    :param torch.Tensor, numpy.ndarray, list timesteps: time steps at which the SDE will be discretized.
+    :param float t_start: the starting time of the SDE, optional. If not provided, it will be inferred from the `timesteps` argument.
+    :param float t_end: the ending time of the SDE, optional. If not provided, it will be inferred from the `timesteps` argument.
+    :param int num_steps: the number of time steps for the SDE, optional. If not provided, it will be inferred from the `timesteps` argument.
     :param torch.Generator rng: a random number generator for reproducibility, optional.
     :param bool verbose: whether to display a progress bar during the sampling process, optional. Default to False.
+
+
+    .. note::
+
+        You can either provide the `timesteps` argument directly, or specify `t_start`, `t_end`, and `num_steps` to generate the time steps automatically. If both are provided, the `timesteps` argument will take precedence.
     """
 
     def __init__(
         self,
-        timesteps: Tensor | ndarray,
+        timesteps: Tensor | ndarray = None,
+        t_start: float | None = None,
+        t_end: float | None = None,
+        num_steps: int | None = None,
         rng: torch.Generator | None = None,
     ):
         super().__init__()
+        if timesteps is None:
+            if t_start is None or t_end is None or num_steps is None:
+                raise ValueError(
+                    "If timesteps is not provided, t_start, t_end, and num_steps must be specified."
+                )
+            timesteps = torch.linspace(t_start, t_end, num_steps)
         if isinstance(timesteps, ndarray):
             self.timesteps = torch.from_numpy(timesteps.copy())
         elif isinstance(timesteps, Tensor):
@@ -213,11 +230,26 @@ class EulerSolver(BaseSDESolver):
     where :math:`W_t` is a Gaussian random variable with mean 0 and variance dt.
 
     :param torch.Tensor timesteps: The time steps at which to evaluate the solution.
+    :param torch.Tensor, numpy.ndarray, list timesteps: time steps at which the SDE will be discretized.
+    :param float t_start: the starting time of the SDE, optional. If not provided, it will be inferred from the `timesteps` argument.
+    :param float t_end: the ending time of the SDE, optional. If not provided, it will be inferred from the `timesteps` argument.
+    :param int num_steps: the number of time steps for the SDE, optional. If not provided, it will be inferred from the `timesteps` argument.
     :param torch.Generator rng: A random number generator for reproducibility.
+
+    .. note::
+
+        You can either provide the `timesteps` argument directly, or specify `t_start`, `t_end`, and `num_steps` to generate the time steps automatically. If both are provided, the `timesteps` argument will take precedence.
     """
 
-    def __init__(self, timesteps: Tensor | ndarray, rng: torch.Generator = None):
-        super().__init__(timesteps, rng=rng)
+    def __init__(
+        self,
+        timesteps: Tensor | ndarray = None,
+        t_start: float | None = None,
+        t_end: float | None = None,
+        num_steps: int | None = None,
+        rng: torch.Generator = None,
+    ):
+        super().__init__(timesteps, t_start, t_end, num_steps, rng=rng)
 
     def step(
         self, sde: BaseSDE, t0: float, t1: float, x0: torch.Tensor, *args, **kwargs
@@ -241,15 +273,26 @@ class HeunSolver(BaseSDESolver):
     where :math:`W_t` is a Gaussian random variable with mean 0 and variance dt.
 
     :param torch.Tensor timesteps: The time steps at which to evaluate the solution.
+    :param torch.Tensor, numpy.ndarray, list timesteps: time steps at which the SDE will be discretized.
+    :param float t_start: the starting time of the SDE, optional. If not provided, it will be inferred from the `timesteps` argument.
+    :param float t_end: the ending time of the SDE, optional. If not provided, it will be inferred from the `timesteps` argument.
+    :param int num_steps: the number of time steps for the SDE, optional. If not provided, it will be inferred from the `timesteps` argument.
     :param torch.Generator rng: A random number generator for reproducibility.
+    
+    .. note::
+    
+        You can either provide the `timesteps` argument directly, or specify `t_start`, `t_end`, and `num_steps` to generate the time steps automatically. If both are provided, the `timesteps` argument will take precedence.
     """
 
     def __init__(
         self,
-        timesteps: Tensor | ndarray,
+        timesteps: Tensor | ndarray = None,
+        t_start: float | None = None,
+        t_end: float | None = None,
+        num_steps: int | None = None,
         rng: torch.Generator = None,
     ):
-        super().__init__(timesteps, rng=rng)
+        super().__init__(timesteps, t_start, t_end, num_steps, rng=rng)
 
     def step(
         self,

--- a/deepinv/sampling/sde_solver.py
+++ b/deepinv/sampling/sde_solver.py
@@ -281,7 +281,7 @@ class HeunSolver(BaseSDESolver):
     
     .. note::
     
-        You can either provide the `timesteps` argument directly, or specify `t_start`, `t_end`, and `num_steps` to generate the time steps automatically. If both are provided, the `timesteps` argument will take precedence.
+        You can either provide the `timesteps` argument directly, or specify `t_start`, `t_end`, and `num_steps` to generate the time steps automatically (linearly with constant stepsize). If both are provided, the `timesteps` argument will take precedence.
     """
 
     def __init__(

--- a/deepinv/sampling/sde_solver.py
+++ b/deepinv/sampling/sde_solver.py
@@ -66,7 +66,7 @@ class BaseSDESolver(nn.Module):
 
     .. note::
 
-        You can either provide the `timesteps` argument directly, or specify `t_start`, `t_end`, and `num_steps` to generate the time steps automatically. If both are provided, the `timesteps` argument will take precedence.
+        You can either provide the `timesteps` argument directly, or specify `t_start`, `t_end`, and `num_steps` to generate the time steps automatically (linearly with constant stepsize). If both are provided, the `timesteps` argument will take precedence.
     """
 
     def __init__(

--- a/deepinv/sampling/sde_solver.py
+++ b/deepinv/sampling/sde_solver.py
@@ -238,7 +238,7 @@ class EulerSolver(BaseSDESolver):
 
     .. note::
 
-        You can either provide the `timesteps` argument directly, or specify `t_start`, `t_end`, and `num_steps` to generate the time steps automatically. If both are provided, the `timesteps` argument will take precedence.
+        You can either provide the `timesteps` argument directly, or specify `t_start`, `t_end`, and `num_steps` to generate the time steps automatically (linearly with constant stepsize). If both are provided, the `timesteps` argument will take precedence.
     """
 
     def __init__(

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -16,6 +16,7 @@ from deepinv.sampling import (
     VariancePreservingDiffusion,
     EDMDiffusionSDE,
     FlowMatching,
+    SongDiffusionSDE,
     PosteriorDiffusion,
     DPSDataFidelity,
     EulerSolver,
@@ -394,6 +395,42 @@ def test_sigma_scale_prime_matches_finite_difference(sde_class, t):
     # For scale
     fd = (float(sde.scale_t(t + h)) - float(sde.scale_t(t - h))) / (2 * h)
     assert float(sde.scale_prime_t(t)) == pytest.approx(fd, rel=1e-4, abs=1e-9)
+
+
+@pytest.mark.parametrize("t", [0.2, 0.5, 0.8, 0.95])
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(beta_t=lambda t: 1.0 + 0 * t, B_t=lambda t: t, xi_t=lambda t: 2 * t),
+        dict(xi_t=lambda t: 2 * t, variance_exploding=True),
+        dict(beta_t=lambda t: 0.1 + 19.9 * t, variance_preserving=True),
+    ],
+    ids=["general", "variance_exploding", "variance_preserving"],
+)
+def test_song_sde_realises_its_own_sde(kwargs, t):
+    """`SongDiffusionSDE` must realise `dx = -beta/2 x dt + sqrt(xi) dw`, on every branch.
+
+    EDM realises the diffusion as `g = s sqrt(2 sigma sigma')`, so `g^2` must come back as
+    `xi(t)`; that holds only if `sigma^2 = int_0^t xi/s^2` and `sigma' = xi / (2 s^2 sigma)`.
+    """
+    sde = SongDiffusionSDE(dtype=torch.float64, **kwargs)
+    xi_t = kwargs["xi_t"] if "xi_t" in kwargs else kwargs["beta_t"]
+
+    h = 1e-6
+    fd = (float(sde.sigma_t(t + h)) - float(sde.sigma_t(t - h))) / (2 * h)
+    assert float(sde.sigma_prime_t(t)) == pytest.approx(fd, rel=1e-4)
+
+    g_squared = float(sde.forward_diffusion(t) ** 2)
+    assert g_squared == pytest.approx(float(xi_t(torch.tensor(t))), rel=1e-3)
+
+
+@pytest.mark.parametrize("t", [0.2, 0.5, 0.8, 0.95])
+def test_song_vp_matches_ddpm_noise_level(t):
+    """On the VP branch, `sigma_t` must be the DDPM noise level of `alpha_bar = scale_t^2`."""
+    sde = VariancePreservingDiffusion(dtype=torch.float64)
+    alpha_bar = float(sde.scale_t(t)) ** 2
+    ddpm_sigma = ((1 - alpha_bar) / alpha_bar) ** 0.5
+    assert float(sde.sigma_t(t)) == pytest.approx(ddpm_sigma, rel=1e-9)
 
 
 @pytest.mark.parametrize("sde_class", VE_VP_SDE_CLASSES)

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -397,42 +397,6 @@ def test_sigma_scale_prime_matches_finite_difference(sde_class, t):
     assert float(sde.scale_prime_t(t)) == pytest.approx(fd, rel=1e-4, abs=1e-9)
 
 
-@pytest.mark.parametrize("t", [0.2, 0.5, 0.8, 0.95])
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        dict(beta_t=lambda t: 1.0 + 0 * t, B_t=lambda t: t, xi_t=lambda t: 2 * t),
-        dict(xi_t=lambda t: 2 * t, variance_exploding=True),
-        dict(beta_t=lambda t: 0.1 + 19.9 * t, variance_preserving=True),
-    ],
-    ids=["general", "variance_exploding", "variance_preserving"],
-)
-def test_song_sde_realises_its_own_sde(kwargs, t):
-    """`SongDiffusionSDE` must realise `dx = -beta/2 x dt + sqrt(xi) dw`, on every branch.
-
-    EDM realises the diffusion as `g = s sqrt(2 sigma sigma')`, so `g^2` must come back as
-    `xi(t)`; that holds only if `sigma^2 = int_0^t xi/s^2` and `sigma' = xi / (2 s^2 sigma)`.
-    """
-    sde = SongDiffusionSDE(dtype=torch.float64, **kwargs)
-    xi_t = kwargs["xi_t"] if "xi_t" in kwargs else kwargs["beta_t"]
-
-    h = 1e-6
-    fd = (float(sde.sigma_t(t + h)) - float(sde.sigma_t(t - h))) / (2 * h)
-    assert float(sde.sigma_prime_t(t)) == pytest.approx(fd, rel=1e-4)
-
-    g_squared = float(sde.forward_diffusion(t) ** 2)
-    assert g_squared == pytest.approx(float(xi_t(torch.tensor(t))), rel=1e-3)
-
-
-@pytest.mark.parametrize("t", [0.2, 0.5, 0.8, 0.95])
-def test_song_vp_matches_ddpm_noise_level(t):
-    """On the VP branch, `sigma_t` must be the DDPM noise level of `alpha_bar = scale_t^2`."""
-    sde = VariancePreservingDiffusion(dtype=torch.float64)
-    alpha_bar = float(sde.scale_t(t)) ** 2
-    ddpm_sigma = ((1 - alpha_bar) / alpha_bar) ** 0.5
-    assert float(sde.sigma_t(t)) == pytest.approx(ddpm_sigma, rel=1e-9)
-
-
 @pytest.mark.parametrize("sde_class", VE_VP_SDE_CLASSES)
 def test_T_is_settable(sde_class):
     """The documented end time `T` must be reachable from the constructor."""

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -16,7 +16,6 @@ from deepinv.sampling import (
     VariancePreservingDiffusion,
     EDMDiffusionSDE,
     FlowMatching,
-    SongDiffusionSDE,
     PosteriorDiffusion,
     DPSDataFidelity,
     EulerSolver,

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -384,20 +384,14 @@ VE_VP_SDE_CLASSES = [VarianceExplodingDiffusion, VariancePreservingDiffusion]
 
 @pytest.mark.parametrize("sde_class", VE_VP_SDE_CLASSES)
 @pytest.mark.parametrize("t", [0.2, 0.5, 0.8, 0.95])
-def test_sigma_prime_matches_finite_difference(sde_class, t):
-    """`sigma_prime_t` must be the derivative of `sigma_t`, on either branch."""
+def test_sigma_scale_prime_matches_finite_difference(sde_class, t):
+    """`sigma_prime_t`, `scale_prime_t` must match finite difference"""
     sde = sde_class(dtype=torch.float64)
     h = 1e-6
+    # For sigma
     fd = (float(sde.sigma_t(t + h)) - float(sde.sigma_t(t - h))) / (2 * h)
     assert float(sde.sigma_prime_t(t)) == pytest.approx(fd, rel=1e-4)
-
-
-@pytest.mark.parametrize("sde_class", VE_VP_SDE_CLASSES)
-@pytest.mark.parametrize("t", [0.2, 0.5, 0.8, 0.95])
-def test_scale_prime_matches_finite_difference(sde_class, t):
-    """`scale_prime_t` must be the derivative of `scale_t`, on either branch."""
-    sde = sde_class(dtype=torch.float64)
-    h = 1e-6
+    # For scale
     fd = (float(sde.scale_t(t + h)) - float(sde.scale_t(t - h))) / (2 * h)
     assert float(sde.scale_prime_t(t)) == pytest.approx(fd, rel=1e-4, abs=1e-9)
 
@@ -418,6 +412,7 @@ def test_sample_init_uses_given_time_step(sde_class, rng, device):
         expected = float(sde.sigma_t(t) * sde.scale_t(t))
         assert float(init.std()) == pytest.approx(expected, rel=5e-2)
 
+    # Default sample must be at time T
     rng.manual_seed(0)
     default = sde.sample_init(shape, rng=rng)
     rng.manual_seed(0)

--- a/deepinv/tests/test_sampling.py
+++ b/deepinv/tests/test_sampling.py
@@ -184,7 +184,7 @@ def test_algo_inpaint(name_algo, device):
         )
     elif name_algo == "DPS":
         algorithm = DPS(
-            model, num_steps=50, weight=2.0, alpha=0.01, verbose=False, device=device
+            model, num_steps=50, weight=2.0, alpha=0.5, verbose=False, device=device
         )
     elif name_algo == "DDRM":
         algorithm = DDRM(model)
@@ -377,6 +377,51 @@ def test_sde(device, load_example_image, sde_class, solver_class, denoiser_class
         del denoiser, sde, posterior
         gc.collect()
         torch.cuda.empty_cache()
+
+
+VE_VP_SDE_CLASSES = [VarianceExplodingDiffusion, VariancePreservingDiffusion]
+
+
+@pytest.mark.parametrize("sde_class", VE_VP_SDE_CLASSES)
+@pytest.mark.parametrize("t", [0.2, 0.5, 0.8, 0.95])
+def test_sigma_prime_matches_finite_difference(sde_class, t):
+    """`sigma_prime_t` must be the derivative of `sigma_t`, on either branch."""
+    sde = sde_class(dtype=torch.float64)
+    h = 1e-6
+    fd = (float(sde.sigma_t(t + h)) - float(sde.sigma_t(t - h))) / (2 * h)
+    assert float(sde.sigma_prime_t(t)) == pytest.approx(fd, rel=1e-4)
+
+
+@pytest.mark.parametrize("sde_class", VE_VP_SDE_CLASSES)
+@pytest.mark.parametrize("t", [0.2, 0.5, 0.8, 0.95])
+def test_scale_prime_matches_finite_difference(sde_class, t):
+    """`scale_prime_t` must be the derivative of `scale_t`, on either branch."""
+    sde = sde_class(dtype=torch.float64)
+    h = 1e-6
+    fd = (float(sde.scale_t(t + h)) - float(sde.scale_t(t - h))) / (2 * h)
+    assert float(sde.scale_prime_t(t)) == pytest.approx(fd, rel=1e-4, abs=1e-9)
+
+
+@pytest.mark.parametrize("sde_class", VE_VP_SDE_CLASSES)
+def test_T_is_settable(sde_class):
+    """The documented end time `T` must be reachable from the constructor."""
+    assert sde_class(T=0.9).T == 0.9
+
+
+@pytest.mark.parametrize("sde_class", VE_VP_SDE_CLASSES)
+def test_sample_init_uses_given_time_step(sde_class, rng, device):
+    """`sample_init` draws at the requested time, defaulting to `T`."""
+    sde = sde_class(device=device)
+    shape = (1, 3, 64, 64)
+    for t in (sde.T, 0.5):
+        init = sde.sample_init(shape, rng=rng, t=t)
+        expected = float(sde.sigma_t(t) * sde.scale_t(t))
+        assert float(init.std()) == pytest.approx(expected, rel=5e-2)
+
+    rng.manual_seed(0)
+    default = sde.sample_init(shape, rng=rng)
+    rng.manual_seed(0)
+    assert torch.allclose(default, sde.sample_init(shape, rng=rng, t=sde.T))
 
 
 @torch.no_grad()

--- a/examples/sampling/demo_diffusers.py
+++ b/examples/sampling/demo_diffusers.py
@@ -62,13 +62,11 @@ dinv.utils.plot(
 
 num_steps = 125
 rng = torch.Generator(device)
-timesteps = torch.linspace(1, 0.001, num_steps)
-solver = EulerSolver(timesteps=timesteps, rng=rng)
-
 sde = VarianceExplodingDiffusion(
     device=device,
     dtype=dtype,
 )
+solver = EulerSolver(t_start=sde.T, t_end=0.001, num_steps=num_steps, rng=rng)
 
 model = PosteriorDiffusion(
     data_fidelity=ZeroFidelity(),

--- a/examples/sampling/demo_diffusion_sde.py
+++ b/examples/sampling/demo_diffusion_sde.py
@@ -83,12 +83,12 @@ denoiser = NCSNpp(pretrained="download").to(device)
 # The reproducibility of the SDE Solver class can be controlled by providing the pseudo-random number generator.
 num_steps = 150
 rng = torch.Generator(device).manual_seed(42)
-timesteps = torch.linspace(1, 0.001, num_steps)
-solver = EulerSolver(timesteps=timesteps, rng=rng)
 sde = VarianceExplodingDiffusion(
+    T=1.0,
     device=device,
     dtype=dtype,
 )
+solver = EulerSolver(t_start=sde.T, t_end=0.001, num_steps=num_steps, rng=rng)
 
 # %%
 # Reverse-time SDE as sampling process
@@ -264,13 +264,13 @@ del trajectory  # clean memory
 sigma_max = 10.0
 rng = torch.Generator(device)
 dtype = torch.float32
-timesteps = torch.linspace(1, 0.001, 250)
-solver = EulerSolver(timesteps=timesteps, rng=rng)
 denoiser = dinv.models.DRUNet(pretrained="download").to(device)
 
 sde = VarianceExplodingDiffusion(
     sigma_max=sigma_max, alpha=0.75, device=device, dtype=dtype
 )
+solver = EulerSolver(t_start=sde.T, t_end=0.001, num_steps=250, rng=rng)
+
 
 x = dinv.utils.load_example(
     "butterfly.png",

--- a/examples/sampling/demo_flow_matching.py
+++ b/examples/sampling/demo_flow_matching.py
@@ -84,9 +84,8 @@ denoiser = MMSE(dataloader=tensors, device=device, dtype=dtype)
 # The module FlowMatching module takes as input the denoiser and the ODE solver.
 
 num_steps = 100
-timesteps = torch.linspace(0.99, 0.0, num_steps)
 rng = torch.Generator(device).manual_seed(5)
-solver = EulerSolver(timesteps=timesteps, rng=rng)
+solver = EulerSolver(t_start=0.99, t_end=0.0, num_steps=num_steps, rng=rng)
 sde = FlowMatching(denoiser=denoiser, solver=solver, device=device, dtype=dtype)
 
 


### PR DESCRIPTION
This PR fixes some bugs in the diffusion sampling framework:

1) The `sigma_prime_t` was incorrect for VP (missing a factor of 2), the sampling never converges, in particular in unconditional sampling, it generates a uniform field rather than an images, and we need to set a very small stochasticity (`alpha`) to make it works in some posterior sampling examples /tests
 
2) The final timestep `T` is stated in the docs but can be set in the constructor. This PR also fixes this. 
    
3) Make the `sample_init` function follows the true initial timestep given by the solver instead of using the default `T`.  

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.