### PR TITLE
2times op

### DIFF
--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -737,6 +737,24 @@ class BlurFFT(DecomposablePhysics):
         super().update_parameters(**filter_parameters)
 
 
+class FactorTimesBlurFFT(BlurFFT):
+    r"""
+    Two Times Blur operation.
+
+    ..math::
+        y = w * (w * x)
+
+    where :math:`*` denotes convolution and :math:`w` is a filter.
+
+    :param float factor: the factor you multiply with
+    """
+    def __init__():
+        super().__init__()
+
+    def forward(self, x: Tensor, filter: Tensor | None = None, **kwargs) -> Tensor:
+        out = 2 * x
+        return out
+
 class SpaceVaryingBlur(LinearPhysics):
     r"""
     Space varying blur via product-convolution.

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -748,12 +748,14 @@ class FactorTimesBlurFFT(BlurFFT):
 
     :param float factor: the factor you multiply with
     """
+
     def __init__():
         super().__init__()
 
     def forward(self, x: Tensor, filter: Tensor | None = None, **kwargs) -> Tensor:
         out = 2 * x
         return out
+
 
 class SpaceVaryingBlur(LinearPhysics):
     r"""

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -81,6 +81,7 @@ OPERATORS = [
     "2DParallelBeamCT",
     "2DFanBeamCT",
     "VirtualLinearPhysics",
+    "TwoTimesPhysics"
 ]
 
 NONLINEAR_OPERATORS = [
@@ -555,6 +556,17 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
         dtype = torch.complex64
         norm = 1.32
         p = dinv.physics.PtychographyLinearOperator(
+            img_size=img_size,
+            probe=None,
+            shifts=None,
+            device=device,
+        )
+        params = ["probe", "shifts"]
+    elif name == "TwoTimesPhysics":
+        img_size = (1, 32, 32) if imsize is None else imsize
+        dtype = torch.complex64
+        norm = 1.32
+        p = dinv.physics.TwoTimesPhysics(
             img_size=img_size,
             probe=None,
             shifts=None,


### PR DESCRIPTION
This contribution multiplies blur by 2.

A snippet to use:

```python
import TwoTimesBlurFFT

# my code
```

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.