### PR TITLE
add mask_first option + fix KernelIdentificationNetwork

### DIFF
--- a/deepinv/models/kernel_network.py
+++ b/deepinv/models/kernel_network.py
@@ -11,10 +11,14 @@ class KernelIdentificationNetwork(nn.Module):
     Space varying blur kernel estimation network.
 
     U-Net proposed by :footcite:t:`carbajal2023blind`, estimating
-    the parameters of :class:`deepinv.physics.SpaceVaryingBlur` forward model, i.e., blur kernels and corresponding spatial multipliers (weights).
+    the parameters of :class:`deepinv.physics.SpaceVaryingBlur` forward model, i.e., blur kernels and corresponding spatial multipliers (masks).
+
+    .. note::
+
+        The estimated parameters should therefore be plugged into
+        ``deepinv.physics.SpaceVaryingBlur(mask_first=False, padding="circular")``.
 
     Current implementation supports blur kernels of size 33x33 (default) and 65x65, and 1 or 3 input channels.
-
 
     Code adapted from https://github.com/GuillermoCarbajal/J-MKPD with permission from the author.
 
@@ -41,7 +45,7 @@ class KernelIdentificationNetwork(nn.Module):
         >>> import torch
         >>> device = "cuda" if torch.cuda.is_available() else "cpu"
         >>> kernel_estimator = dinv.models.KernelIdentificationNetwork(device=device)
-        >>> physics = dinv.physics.SpaceVaryingBlur(device=device, padding="constant")
+        >>> physics = dinv.physics.SpaceVaryingBlur(device=device, padding="circular", mask_first=False)
         >>> y = torch.randn(1, 3, 128, 128).to(device)  # random blurry image for demonstration
         >>> with torch.no_grad():
         ...     params = kernel_estimator(y)  # this outputs {"filters": ..., "multipliers": ...}
@@ -159,9 +163,10 @@ class KernelIdentificationNetwork(nn.Module):
         Forward pass of the kernel estimation network.
 
         :param x: input blurry image of shape (N, C, H, W) with values in [0, 1]. Assumed to be non-gamma corrected (i.e., linear RGB).
-        :return: dictionary with estimated blur kernels and spatial multipliers:
-            -  ``'filters'``: estimated blur kernels of shape (N, 1, K, blur_kernel_size, blur_kernel_size)
-            -  ``'multipliers'``: estimated spatial multipliers of shape (N, 1, K, H, W)
+        :return: dictionary with estimated blur kernels and spatial multipliers of the
+            :math:`y = \sum_k w_k \odot (h_k \star x)` model:
+            -  ``'filters'``: estimated blur kernels :math:`h_k` of shape (N, 1, K, blur_kernel_size, blur_kernel_size)
+            -  ``'multipliers'``: estimated spatial masks :math:`w_k` of shape (N, 1, K, H, W)
         """
         x = x - 0.5  # normalize input to [−0.5,0.5]
         # Encoder

--- a/deepinv/physics/blur.py
+++ b/deepinv/physics/blur.py
@@ -741,23 +741,37 @@ class SpaceVaryingBlur(LinearPhysics):
     r"""
     Space varying blur via product-convolution.
 
-    This linear operator performs
+    If ``mask_first=True`` (default), this linear operator performs
 
     .. math::
 
         y = \sum_{k=1}^K h_k \star (w_k \odot x)
 
+    whereas if ``mask_first=False``, the multipliers are applied after the convolutions, i.e.
+
+    .. math::
+
+        y = \sum_{k=1}^K w_k \odot (h_k \star x)
+
     where :math:`\star` is a convolution, :math:`\odot` is a Hadamard product,  :math:`w_k` are multipliers :math:`h_k` are filters.
+
+    .. tip::
+
+        A comparison between both models can be found in :footcite:t:`denis2011fast`.
 
     :param torch.Tensor filters: Filters :math:`h_k`. Tensor of size `(B, C, K, h, w)` where
         `B` is the batch size, `C` the number of channels, `K` the number of filters, `h` and `w` the filter height and width which
         should be smaller or equal than the image :math:`x` height and width respectively.
     :param torch.Tensor multipliers: Multipliers :math:`w_k`. Tensor of size `(B, C, K, H, W)` where
         `B` is the batch size, `C` the number of channels, `K` the number of multipliers, `H` and `W` the image :math:`x` height and width.
+        If ``mask_first=False`` and ``padding='valid'``, the spatial size of the multipliers should match the size of the
+        convolution output instead, i.e. `(B, C, K, H-h+1, W-w+1)`.
     :param str padding: options = ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'``.
         If ``padding = 'valid'`` the blurred output is smaller than the image (no padding),
         otherwise the blurred output has the same size as the image.
     :param bool use_fft: whether to use FFT-based convolutions. If ``True``, it uses FFT-based convolutions which can be faster for large kernels.
+    :param bool mask_first: whether the multipliers :math:`w_k` are applied before (``True``, default) or after
+        (``False``) the convolutions.
     :param torch.device, str device: Device on which the physics' buffers will be created. If a buffer is updated via ``physics.update_parameters()``, if not None, it will be automatically casted to the device of the replaced buffer, else, use the device of the provided value. To change the device of all buffers, please use ``physics.to(device)``.
 
     |sep|
@@ -789,6 +803,7 @@ class SpaceVaryingBlur(LinearPhysics):
         multipliers: Tensor = None,
         padding: str = "valid",
         use_fft: bool = False,
+        mask_first: bool = True,
         device: torch.device | str = "cpu",
         **kwargs,
     ):
@@ -798,6 +813,7 @@ class SpaceVaryingBlur(LinearPhysics):
         self.register_buffer("multipliers", multipliers)
         self.padding = padding
         self.use_fft = use_fft
+        self.mask_first = mask_first
         self.to(device)
 
     def A(
@@ -818,7 +834,12 @@ class SpaceVaryingBlur(LinearPhysics):
         """
         self.update_parameters(filters, multipliers, padding, **kwargs)
         return dF.product_convolution2d(
-            x, self.multipliers, self.filters, self.padding, use_fft=self.use_fft
+            x,
+            self.multipliers,
+            self.filters,
+            self.padding,
+            use_fft=self.use_fft,
+            mask_first=self.mask_first,
         )
 
     def A_adjoint(
@@ -845,7 +866,12 @@ class SpaceVaryingBlur(LinearPhysics):
             filters=filters, multipliers=multipliers, padding=padding, **kwargs
         )
         return dF.product_convolution2d_adjoint(
-            y, self.multipliers, self.filters, self.padding, use_fft=self.use_fft
+            y,
+            self.multipliers,
+            self.filters,
+            self.padding,
+            use_fft=self.use_fft,
+            mask_first=self.mask_first,
         )
 
     def update_parameters(

--- a/deepinv/physics/functional/product_convolution.py
+++ b/deepinv/physics/functional/product_convolution.py
@@ -8,25 +8,39 @@ import torch
 
 
 def product_convolution2d(
-    x: Tensor, w: Tensor, h: Tensor, padding: str = "valid", use_fft: bool = False
+    x: Tensor,
+    w: Tensor,
+    h: Tensor,
+    padding: str = "valid",
+    use_fft: bool = False,
+    mask_first: bool = True,
 ) -> torch.Tensor:
     r"""
 
     Product-convolution operator in 2d. Details available in the paper :footcite:t:`escande2017approximation`.
 
-    This forward operator performs
+    If ``mask_first=True`` (default), this forward operator performs
 
     .. math::
 
         y = \sum_{k=1}^K h_k \star (w_k \odot x)
 
+    whereas if ``mask_first=False``, the multipliers are applied after the convolutions, i.e.
+
+    .. math::
+
+        y = \sum_{k=1}^K w_k \odot (h_k \star x)
+
     where :math:`\star` is a convolution, :math:`\odot` is a Hadamard product, :math:`w_k` are multipliers :math:`h_k` are filters.
 
     :param torch.Tensor x: Tensor of size :math:`(B, C, H, W)`
-    :param torch.Tensor w: Tensor of size :math:`(b, c, K, H, W)`. :math:`b \in \{1, B\}` and :math:`c \in \{1, C\}`
+    :param torch.Tensor w: Tensor of size :math:`(b, c, K, H, W)`. :math:`b \in \{1, B\}` and :math:`c \in \{1, C\}`.
+        If ``mask_first=False`` and ``padding='valid'``, the spatial size of the multipliers should match the size of
+        the convolution output instead, i.e. :math:`(b, c, K, H-h+1, W-w+1)`.
     :param torch.Tensor h: Tensor of size :math:`(b, c, K, h, w)`. :math:`b \in \{1, B\}` and :math:`c \in \{1, C\}`, :math:`h\leq H` and :math:`w\leq W`.
     :param padding: ( options = ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'`` or ``'constant'``). If `padding = `'valid'` the blurred output is smaller than the image (no padding), otherwise the blurred output has the same size as the image.
     :param bool use_fft: whether to use FFT-based convolutions. If ``True``, it uses FFT-based convolutions which can be faster for large kernels.
+    :param bool mask_first: whether the multipliers are applied before (``True``, default) or after (``False``) the convolutions.
     :return: :class:`torch.Tensor` the blurry image.
     """
 
@@ -34,35 +48,52 @@ def product_convolution2d(
     result = 0.0
     conv2d = dF.conv2d_fft if use_fft else dF.conv2d
     for k in range(K):
-        result += conv2d(
-            multiplier(x, w[:, :, k, ...]), h[:, :, k, ...], padding=padding
-        )
+        if mask_first:
+            result += conv2d(
+                multiplier(x, w[:, :, k, ...]), h[:, :, k, ...], padding=padding
+            )
+        else:
+            result += multiplier(
+                conv2d(x, h[:, :, k, ...], padding=padding), w[:, :, k, ...]
+            )
 
     return result
 
 
 def product_convolution2d_adjoint(
-    y: Tensor, w: Tensor, h: Tensor, padding: str = "valid", use_fft: bool = False
+    y: Tensor,
+    w: Tensor,
+    h: Tensor,
+    padding: str = "valid",
+    use_fft: bool = False,
+    mask_first: bool = True,
 ) -> torch.Tensor:
     r"""
 
     Product-convolution adjoint operator in 2d.
 
-    :param torch.Tensor x: Tensor of size (B, C, ...)
+    :param torch.Tensor y: Tensor of size (B, C, ...)
     :param torch.Tensor w: Tensor of size (b, c, K, ...)
     :param torch.Tensor h: Tensor of size (b, c, K, ...)
     :param padding: options = ``'valid'``, ``'circular'``, ``'replicate'``, ``'reflect'``.
         If `padding = 'valid'` the blurred output is smaller than the image (no padding),
         otherwise the blurred output has the same size as the image.
     :param bool use_fft: whether to use FFT-based convolutions. If ``True``, it uses FFT-based convolutions which can be faster for large kernels.
+    :param bool mask_first: whether the multipliers are applied before (``True``, default) or after (``False``) the
+        convolutions in the forward operator, see :func:`deepinv.physics.functional.product_convolution2d`.
     """
 
     K = w.size(2)
     result = 0.0
     conv_transpose2d = dF.conv_transpose2d_fft if use_fft else dF.conv_transpose2d
     for k in range(K):
-        result += multiplier_adjoint(
-            conv_transpose2d(y, h[:, :, k, ...], padding=padding), w[:, :, k, ...]
-        )
+        if mask_first:
+            result += multiplier_adjoint(
+                conv_transpose2d(y, h[:, :, k, ...], padding=padding), w[:, :, k, ...]
+            )
+        else:
+            result += conv_transpose2d(
+                multiplier_adjoint(y, w[:, :, k, ...]), h[:, :, k, ...], padding=padding
+            )
 
     return result

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -41,6 +41,8 @@ OPERATORS = [
     "space_deblur_reflect",
     "space_deblur_replicate",
     "space_deblur_constant",
+    "space_deblur_maskafter_valid",
+    "space_deblur_maskafter_circular",
     "tiled_space_deblur_valid",
     "hyperspectral_unmixing",
     "3Ddeblur_valid",
@@ -400,6 +402,16 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
         h = dinv.physics.functional.bilinear_filter(factor=2).unsqueeze(0).to(device)
         h /= torch.sum(h)
         h = torch.cat([h, h], dim=2)
+        # if the masks are applied after the convolutions with 'valid' padding,
+        # they live on the (smaller) convolution output
+        mask_first = "maskafter" not in name
+        if not mask_first and padding == "valid":
+            mult_size = (
+                img_size[-2] - h.shape[-2] + 1,
+                img_size[-1] - h.shape[-1] + 1,
+            )
+        else:
+            mult_size = tuple(img_size[-2:])
         p = dinv.physics.SpaceVaryingBlur(
             filters=h,
             multipliers=torch.ones(
@@ -408,11 +420,12 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
                     img_size[0],
                     2,
                 )
-                + img_size[-2:],
+                + mult_size,
                 device=device,
             ).to(device)
             * 0.5,
             padding=padding,
+            mask_first=mask_first,
             device=device,
         )
         params = ["filters", "multipliers"]

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -48,7 +48,7 @@ Changed
 
 Fixed
 ^^^^^
-- Fix the ``mask_first=False`` pretrained :class:`deepinv.models.KernelIdentificationNetwork` (:gh:`1338` by `Julian Tachella`_)
+- Fix the ``mask_first=False`` pretrained :class:`deepinv.models.KernelIdentificationNetwork` (:gh:`1347` by `Julian Tachella`_)
 - Deprecate the `theta` attribute from :class:`deepinv.physics.Tomography` (:gh:`1262` by `Matthieu Terris`_)
 - Remove redundant parameters `unitary` and `compute_inverse` from :class:`deepinv.physics.RandomPhaseRetrieval` (:gh:`1220` by `Zhiyuan Hu`_)
 - Add :class:`deepinv.utils.DownloadError` to avoid CI errors when downloading demos/datasets (:gh:`1234` by `Julian Tachella`_)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,6 +23,7 @@ New Features
 - Add espirit_crop parameter to control ESPIRiT multicoil MRI map estimation (:gh:`1263` by `Andrew Wang`_)
 - Add :class:`deepinv.loss.metric.BRISQUE` and :class:`deepinv.loss.metric.NIMA` no-reference image quality metrics (:gh:`1310` by `Julian Tachella`_)
 - Add :class:`deepinv.datasets.BrainWebPET` (:gh:`1286` by `Thibaut Modrzyk`_)
+- Add ``mask_first`` option to :class:`deepinv.physics.SpaceVaryingBlur` and :func:`deepinv.physics.functional.product_convolution2d` (:gh:`1338` by `Julian Tachella`_)
 
 Changed
 ^^^^^^^
@@ -34,6 +35,7 @@ Changed
 
 Fixed
 ^^^^^
+- Fix the ``mask_first=False`` pretrained :class:`deepinv.models.KernelIdentificationNetwork` (:gh:`1338` by `Julian Tachella`_)
 - Deprecate the `theta` attribute from :class:`deepinv.physics.Tomography` (:gh:`1262` by `Matthieu Terris`_)
 - Remove redundant parameters `unitary` and `compute_inverse` from :class:`deepinv.physics.RandomPhaseRetrieval` (:gh:`1220` by `Zhiyuan Hu`_)
 - Add :class:`deepinv.utils.DownloadError` to avoid CI errors when downloading demos/datasets (:gh:`1234` by `Julian Tachella`_)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -35,7 +35,7 @@ New Features
 - Add espirit_crop parameter to control ESPIRiT multicoil MRI map estimation (:gh:`1263` by `Andrew Wang`_)
 - Add :class:`deepinv.loss.metric.BRISQUE` and :class:`deepinv.loss.metric.NIMA` no-reference image quality metrics (:gh:`1310` by `Julian Tachella`_)
 - Add :class:`deepinv.datasets.BrainWebPET` (:gh:`1286` by `Thibaut Modrzyk`_)
-- Add ``mask_first`` option to :class:`deepinv.physics.SpaceVaryingBlur` and :func:`deepinv.physics.functional.product_convolution2d` (:gh:`1338` by `Julian Tachella`_)
+- Add ``mask_first`` option to :class:`deepinv.physics.SpaceVaryingBlur` and :func:`deepinv.physics.functional.product_convolution2d` (:gh:`1347` by `Julian Tachella`_)
 - Add ``use_dict_output`` option to every dataset class, returning a dict ``{"x", "y", "params"}`` instead of a tuple; propagate support to all deepinv internals (:gh:`1244` by `Romain Vo`_)
 
 Changed

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1342,6 +1342,19 @@ journal = {ACM Trans. Graph.}
 	year = {2000},
 }
 
+@inproceedings{denis2011fast,
+  title = {Fast Model of Space-Variant Blurring and Its Application to Deconvolution in Astronomy},
+  booktitle = {2011 18th {{IEEE International Conference}} on {{Image Processing}}},
+  author = {Denis, L. and Thiebaut, E. and Soulez, F.},
+  year = 2011,
+  month = sep,
+  pages = {2817--2820},
+  publisher = {IEEE},
+  address = {Brussels, Belgium},
+  doi = {10.1109/ICIP.2011.6116257},
+  isbn = {978-1-4577-1303-3 978-1-4577-1304-0 978-1-4577-1302-6}
+}
+
 
 @article{gilbert_iterative_1972,
 	title = {Iterative methods for the three-dimensional reconstruction of an object from projections},

--- a/examples/blind-inverse-problems/demo_blind_deblurring.py
+++ b/examples/blind-inverse-problems/demo_blind_deblurring.py
@@ -6,14 +6,14 @@ This example demonstrates blind image deblurring using the pretrained kernel est
 the paper :footcite:t:`carbajal2023blind`. The network estimates spatially-varying blur kernels from a blurred image,
 which are then used in a space-varying blur physics model to reconstruct the sharp image using a non-blind deblurring algorithm.
 
-The model estimates 25 spatially-varying (33 x 33) blur kernels and corresponding spatial multipliers (weights) of the space-varying blur model:
+The model estimates 25 spatially-varying (33 x 33) blur kernels and corresponding spatial masks (weights) of the space-varying blur model:
 
 .. math::
 
-    y \approx \sum_{k=1}^{25} h_k \star (w_k \odot x)
+    y \approx \sum_{k=1}^{25} w_k \odot (h_k \star x)
 
-where :math:`\star` is a convolution, :math:`\odot` is a Hadamard product,  :math:`w_k` are multipliers :math:`h_k` are filters.
-
+where :math:`\star` is a convolution with circular padding, :math:`\odot` is a Hadamard product, :math:`w_k` are masks
+and :math:`h_k` are filters.
 
 """
 
@@ -42,7 +42,7 @@ dinv.utils.plot({"Blurry Image": y})  # plot blurry image
 # ~~~~~~~~~~~~~~~~~~~~~
 #
 # We use the pretrained kernel estimation network to estimate the spatially-varying blur kernels from the blurry image.
-# The network provides 25 filters and corresponding spatial multipliers (weights) of the space-varying blur model (:class:`deepinv.physics.SpaceVaryingBlur`).
+# The network provides 25 filters and corresponding spatial masks (weights) of the space-varying blur model (kernels first configuration).
 #
 # We can visualise the estimated kernels by applying the forward operator to a Dirac comb input.
 #
@@ -55,8 +55,11 @@ dinv.utils.plot({"Blurry Image": y})  # plot blurry image
 # load pretrained kernel estimation network
 kernel_estimator = KernelIdentificationNetwork(device=device)
 
-# define space-varying blur physics
-physics = dinv.physics.SpaceVaryingBlur(device=device, padding="constant")
+# define space-varying blur physics, using the convention of the pretrained network
+# (masks applied after the convolutions, circular padding)
+physics = dinv.physics.SpaceVaryingBlur(
+    device=device, padding="circular", mask_first=False
+)
 
 with torch.no_grad():
     params = kernel_estimator(y)  # this outputs {"filters": ..., "multipliers": ...}
@@ -67,8 +70,8 @@ with torch.no_grad():
     # visualize on a zoomed region
     dinv.utils.plot(
         {
-            "Estimated Kernels": kernel_map[..., 128:512, 128:512],
-            "Blurry Image": y[..., 200:300, 200:300],
+            "Estimated Kernels": kernel_map[..., 200:400, 300:500],
+            "Blurry Image": y[..., 200:400, 300:500],
         }
     )
 
@@ -80,12 +83,14 @@ with torch.no_grad():
 # Finally, we use two different non-blind deblurring algorithms to reconstruct the sharp image from the blurry observation and the estimated blur kernels:
 # Here we use the general reconstruction model :class:`deepinv.models.RAM` and the plug-and-play method :class:`deepinv.optim.DPIR`.
 
+sigma = 0.02
+
 model = RAM(device=device)
 with torch.no_grad():
-    x_ram = model(y, physics, sigma=0.05)
+    x_ram = model(y, physics, sigma=sigma)
     x_ram = x_ram.clamp(0, 1)
 
-model = DPIR(sigma=0.05, device=device)
+model = DPIR(sigma=sigma, device=device)
 x_dpir = model(y, physics)
 x_dpir = x_dpir.clamp(0, 1)
 
@@ -96,17 +101,11 @@ x_dpir = x_dpir.clamp(0, 1)
 #
 # As here we assume that we do not have access to the ground truth sharp image,
 # we cannot compute reference metrics such as PSNR or SSIM.
-# However, we can still compute no-reference metrics such as NIQE (lower is better), Blur Strength (lower is better) and
+# However, we can still compute no-reference metrics such as Blur Strength (lower is better) and
 # Sharpness Index (higher is better)
 # to assess the quality of the reconstructions.
 
 center_crop = -10  # remove 10 pixels from each border to avoid boundary effects
-
-# niqe = dinv.metric.NIQE(center_crop=center_crop)
-
-# niqe_blurry = niqe(y).item()
-# niqe_ram = niqe(x_ram).item()
-# niqe_dpir = niqe(x_dpir).item()
 
 bs = dinv.metric.BlurStrength(center_crop=center_crop)
 
@@ -120,13 +119,12 @@ si_blurry = si(y).item()
 si_ram = si(x_ram).item()
 si_dpir = si(x_dpir).item()
 
-
 dinv.utils.plot(
-    {"Blurry": y, "RAM": x_ram, "DPIR": x_dpir},
+    {"Blurry": y[..., 200:400, 300:500], "RAM": x_ram[..., 200:400, 300:500], "DPIR": x_dpir[..., 200:400, 300:500]},
     subtitles=[
-        f"SI: {si_blurry:.0f} \n BS: {bs_blurry:.3f}",  # \n  NIQE: {niqe_blurry:.2f}",
-        f"SI: {si_ram:.0f} \n BS: {bs_ram:.3f}",  # \n  NIQE: {niqe_ram:.2f} ",
-        f"SI: {si_dpir:.0f} \n BS: {bs_dpir:.3f}",  # \n  NIQE: {niqe_dpir:.2f} ",
+        f"SI: {si_blurry:.0f} \n BS: {bs_blurry:.3f}",
+        f"SI: {si_ram:.0f} \n BS: {bs_ram:.3f}",
+        f"SI: {si_dpir:.0f} \n BS: {bs_dpir:.3f}",
     ],
     figsize=(10, 5),
 )

--- a/examples/blind-inverse-problems/demo_blind_deblurring.py
+++ b/examples/blind-inverse-problems/demo_blind_deblurring.py
@@ -120,7 +120,11 @@ si_ram = si(x_ram).item()
 si_dpir = si(x_dpir).item()
 
 dinv.utils.plot(
-    {"Blurry": y[..., 200:400, 300:500], "RAM": x_ram[..., 200:400, 300:500], "DPIR": x_dpir[..., 200:400, 300:500]},
+    {
+        "Blurry": y[..., 200:400, 300:500],
+        "RAM": x_ram[..., 200:400, 300:500],
+        "DPIR": x_dpir[..., 200:400, 300:500],
+    },
     subtitles=[
         f"SI: {si_blurry:.0f} \n BS: {bs_blurry:.3f}",
         f"SI: {si_ram:.0f} \n BS: {bs_ram:.3f}",


### PR DESCRIPTION
Solves #1342 

1. adds an option to `SpaceVaryingBlur` which allows applying masks first, and kernels afterwards, following the model

$$ A(x) = \sum_i h_i * (m_i \circ x)$$

which offers an alternative to the model

$$ A(x) = \sum_i m_i \circ (h_i * x)$$

2. Fixes the KernelIdentificationNetwork demo and docs to use this new convention, since the pretrained weights have been trained for this case.

Demo results with fixes
<img width="1842" height="775" alt="image" src="https://github.com/user-attachments/assets/e7db793e-3762-4612-8335-78b8b9746bca" />



### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.