### PR TITLE
Improve documentation of `NBUDataset`

### DIFF
--- a/deepinv/datasets/satellite.py
+++ b/deepinv/datasets/satellite.py
@@ -33,7 +33,7 @@ class NBUDataset(ImageDataset):
         When there are 4 channels, they correspond to the blue, green, red, and near-infrared bands.
         When there are 8 channels, they correspond to the coastal, blue, green, yellow, red, red-edge, near-infrared 1,
         and near-infrared 2 bands.
-        See <https://www.pgc.umn.edu/guides/delivery-docs/pgc-commercial-satellite-imagery-documentation/> for more details.
+        See `this <https://www.pgc.umn.edu/guides/delivery-docs/pgc-commercial-satellite-imagery-documentation/>`_ for more details.
 
     For pan-sharpening problems, you can return pan-sharpening measurements by using ``return_pan=True``,
     outputting a :class:`deepinv.utils.TensorList` of ``(MS, PAN)`` where ``PAN`` are 1024x1024 panchromatic images.

--- a/deepinv/datasets/satellite.py
+++ b/deepinv/datasets/satellite.py
@@ -27,7 +27,7 @@ class NBUDataset(ImageDataset):
     """NBU remote sensing multispectral satellite imagery dataset.
 
     Returns ``Cx256x256`` multispectral (MS) satellite images of urban scenes from 6 different satellites.
-    with ``C=4`` for ``"gaofen-1"`` and ``C=8`` for the rest.
+    with ``C=4`` for ``"gaofen-1"``, ``Ikonos``, ``QuickBird``, ``GF-1``, ``WorldView-4`` and ``C=8`` for the rest.
 
     For pan-sharpening problems, you can return pan-sharpening measurements by using ``return_pan=True``,
     outputting a :class:`deepinv.utils.TensorList` of ``(MS, PAN)`` where ``PAN`` are 1024x1024 panchromatic images.

--- a/deepinv/datasets/satellite.py
+++ b/deepinv/datasets/satellite.py
@@ -28,6 +28,12 @@ class NBUDataset(ImageDataset):
 
     Returns ``Cx256x256`` multispectral (MS) satellite images of urban scenes from 6 different satellites.
     with ``C=4`` for ``"gaofen-1"``, ``ikonos``, ``quickbird``, ``worldview-4`` and ``C=8`` for the rest.
+    
+    .. note::
+        When there are 4 channels, they correspond to the blue, green, red, and near-infrared bands. 
+        When there are 8 channels, they correspond to the coastal, blue, green, yellow, red, red-edge, near-infrared 1, 
+        and near-infrared 2 bands. 
+        See <https://www.pgc.umn.edu/guides/delivery-docs/pgc-commercial-satellite-imagery-documentation/> for more details.
 
     For pan-sharpening problems, you can return pan-sharpening measurements by using ``return_pan=True``,
     outputting a :class:`deepinv.utils.TensorList` of ``(MS, PAN)`` where ``PAN`` are 1024x1024 panchromatic images.

--- a/deepinv/datasets/satellite.py
+++ b/deepinv/datasets/satellite.py
@@ -28,11 +28,11 @@ class NBUDataset(ImageDataset):
 
     Returns ``Cx256x256`` multispectral (MS) satellite images of urban scenes from 6 different satellites.
     with ``C=4`` for ``"gaofen-1"``, ``ikonos``, ``quickbird``, ``worldview-4`` and ``C=8`` for the rest.
-    
+
     .. note::
-        When there are 4 channels, they correspond to the blue, green, red, and near-infrared bands. 
-        When there are 8 channels, they correspond to the coastal, blue, green, yellow, red, red-edge, near-infrared 1, 
-        and near-infrared 2 bands. 
+        When there are 4 channels, they correspond to the blue, green, red, and near-infrared bands.
+        When there are 8 channels, they correspond to the coastal, blue, green, yellow, red, red-edge, near-infrared 1,
+        and near-infrared 2 bands.
         See <https://www.pgc.umn.edu/guides/delivery-docs/pgc-commercial-satellite-imagery-documentation/> for more details.
 
     For pan-sharpening problems, you can return pan-sharpening measurements by using ``return_pan=True``,

--- a/deepinv/datasets/satellite.py
+++ b/deepinv/datasets/satellite.py
@@ -27,7 +27,7 @@ class NBUDataset(ImageDataset):
     """NBU remote sensing multispectral satellite imagery dataset.
 
     Returns ``Cx256x256`` multispectral (MS) satellite images of urban scenes from 6 different satellites.
-    with ``C=4`` for ``"gaofen-1"``, ``Ikonos``, ``QuickBird``, ``GF-1``, ``WorldView-4`` and ``C=8`` for the rest.
+    with ``C=4`` for ``"gaofen-1"``, ``ikonos``, ``quickbird``, ``worldview-4`` and ``C=8`` for the rest.
 
     For pan-sharpening problems, you can return pan-sharpening measurements by using ``return_pan=True``,
     outputting a :class:`deepinv.utils.TensorList` of ``(MS, PAN)`` where ``PAN`` are 1024x1024 panchromatic images.

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Changed
 
 Fixed
 ^^^^^
-- Fix description of channels in documentation of :class:`deepinv.datasets.NBUDataset` (:gh:`1348` by `Delphine Doutsas`_)
+- Fix description of channels in documentation of :class:`deepinv.datasets.NBUDataset` and provide link for more information on the dataset (:gh:`1348` by `Delphine Doutsas`_)
 
 
 v0.4.2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Changed
 
 Fixed
 ^^^^^
-- Fix description of channels in sattelite/NBUDataset (:gh:`1348` by dldou) 
+- Fix description of channels in :class:`deepinv.datasets.NBUDataset` (:gh:`1348` by `Delphine Doutsas`_)
 
 
 v0.4.2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Changed
 
 Fixed
 ^^^^^
-- Fix description of channels in :class:`deepinv.datasets.NBUDataset` (:gh:`1348` by `Delphine Doutsas`_)
+- Fix description of channels in documentation of :class:`deepinv.datasets.NBUDataset` (:gh:`1348` by `Delphine Doutsas`_)
 
 
 v0.4.2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -44,6 +44,7 @@ Fixed
 - Fix inversion in :class:`deepinv.transform.Reflect` (:gh:`1236` by `Sarra Amiri`_)
 - (Breaking) Have `x_shift` represent horizontal shifts and `y_shift` vertical shifts in :class:`deepinv.transform.Shift` (:gh:`1236` by `Sarra Amiri`_)
 - Force trainer non_blocking_transfers=False on MPS and CPU (:gh:`1311` by `Andrew Wang`_)
+- Fix description of channels in sattelite/NBUDataset (:gh:`1348` by dldou) 
 
 
 v0.4.1
@@ -687,3 +688,4 @@ Changed
 .. _Irène Waldspurger: https://github.com/IWalds
 .. _Kushagra Shukla: https://github.com/Kushagra481
 .. _Sarra Amiri: https://github.com/amirisarra18-jpg
+.. _Delphine Doutsas: https://github.com/dldou


### PR DESCRIPTION
Fix the description of NBUDataset's channels in satellites.py in the documentation:
- Ikonos, QuickBird, GF-1, and WorldView-4 have 4 channels
- WorldView-2 and WorldView-3 have 8.


Thank you for contributing to DeepInverse!

Please read our [contributing guidelines](https://deepinv.org/contributing.html) for instructions on how to contribute, including writing tests, documentation and code style.

Once the GitHub tests have been approved by a maintainer (only required for first-time contributors), and the `Build Docs` GitHub action has run successfully, you can download the documentation as a zip file from the [Actions page](https://github.com/deepinv/deepinv/actions/workflows/docs_cpu.yml). Look for the workflow run corresponding to your pull request.


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.