### PR TITLE
Fourier ptycho

### DIFF
--- a/deepinv/physics/__init__.py
+++ b/deepinv/physics/__init__.py
@@ -70,7 +70,7 @@ from .phase_retrieval import (
     PtychographyLinearOperator,
     Ptychography,
     FourierPtychographyLinearOperator,
-    MultiplexPtychography
+    MultiplexPtychography,
 )
 from .radio import RadioInterferometry
 from .structured_random import StructuredRandom

--- a/deepinv/physics/__init__.py
+++ b/deepinv/physics/__init__.py
@@ -69,6 +69,8 @@ from .phase_retrieval import (
     StructuredRandomPhaseRetrieval,
     PtychographyLinearOperator,
     Ptychography,
+    FourierPtychographyLinearOperator,
+    MultiplexPtychography
 )
 from .radio import RadioInterferometry
 from .structured_random import StructuredRandom

--- a/deepinv/physics/__init__.py
+++ b/deepinv/physics/__init__.py
@@ -70,7 +70,7 @@ from .phase_retrieval import (
     PtychographyLinearOperator,
     Ptychography,
     FourierPtychographyLinearOperator,
-    MultiplexedPtychography,
+    MultiplexedFourierPtychography,
 )
 from .radio import RadioInterferometry
 from .structured_random import StructuredRandom

--- a/deepinv/physics/__init__.py
+++ b/deepinv/physics/__init__.py
@@ -70,7 +70,7 @@ from .phase_retrieval import (
     PtychographyLinearOperator,
     Ptychography,
     FourierPtychographyLinearOperator,
-    MultiplexPtychography,
+    MultiplexedPtychography,
 )
 from .radio import RadioInterferometry
 from .structured_random import StructuredRandom

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -542,16 +542,16 @@ def generate_shifts(
 class FourierPtychographyLinearOperator(LinearPhysics):
 
     def __init__(
-            self,
-            img_size=None,
-            measure_size=None,
-            probe=None,
-            shifts=None,
-            normalize=True,
-            include_fft=True,
-            include_ifft=True,
-            device="cpu",
-            **kwargs,
+        self,
+        img_size=None,
+        measure_size=None,
+        probe=None,
+        shifts=None,
+        normalize=True,
+        include_fft=True,
+        include_ifft=True,
+        device="cpu",
+        **kwargs,
     ):
         super().__init__(**kwargs)
 
@@ -575,21 +575,23 @@ class FourierPtychographyLinearOperator(LinearPhysics):
 
         if normalize:
             probe_sq = (self.probe.abs() ** 2).expand(1, self.shifts.size(1), -1, -1)
-            overlap_img = self.shift_and_pad(probe_sq, -self.shifts).sum(dim=1, keepdim=True)
+            overlap_img = self.shift_and_pad(probe_sq, -self.shifts).sum(
+                dim=1, keepdim=True
+            )
             self.norm = 1.0 / torch.sqrt(overlap_img.max()).item()
         else:
-            self.norm= 1.0
+            self.norm = 1.0
 
         self.include_fft = include_fft
         self.include_ifft = include_ifft
 
-    def op_fft2(self, y, norm='ortho'):
+    def op_fft2(self, y, norm="ortho"):
         if self.include_fft:
             return torch.fft.fftshift(torch.fft.fft2(y, norm=norm), dim=(-2, -1))
         else:
             return y
 
-    def op_ifft2(self, x, norm='ortho'):
+    def op_ifft2(self, x, norm="ortho"):
         if self.include_ifft:
             return torch.fft.ifft2(torch.fft.ifftshift(x, dim=(-2, -1)), norm=norm)
         else:
@@ -614,7 +616,7 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         crop_y, crop_x = torch.meshgrid(
             torch.arange(cy - my, cy + my, device=x.device),
             torch.arange(cx - mx, cx + mx, device=x.device),
-            indexing='ij'
+            indexing="ij",
         )
 
         dy = shifts[:, :, 0].view(B, N_crops, 1, 1)
@@ -652,23 +654,25 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         c_idx = torch.arange(C_img, device=crop.device).view(1, C_img, 1, 1)
 
         out = crop[b_idx, c_idx, src_y_c, src_x_c]
-        out = torch.where(mask, out, torch.tensor(0.0, dtype=out.dtype, device=out.device))
+        out = torch.where(
+            mask, out, torch.tensor(0.0, dtype=out.dtype, device=out.device)
+        )
         return out
 
 
 class MultiplexPtychography(PhaseRetrieval):
 
     def __init__(
-            self,
-            img_size=None,
-            measure_size=None,
-            probe=None,
-            shifts=None,
-            ledidx=None,
-            scale=1,
-            normalize=True,
-            device="cpu",
-            **kwargs,
+        self,
+        img_size=None,
+        measure_size=None,
+        probe=None,
+        shifts=None,
+        ledidx=None,
+        scale=torch.ones(1, 1, 1, 1),
+        normalize=True,
+        device="cpu",
+        **kwargs,
     ):
 
         B = FourierPtychographyLinearOperator(
@@ -690,10 +694,14 @@ class MultiplexPtychography(PhaseRetrieval):
         self.img_size = img_size
         self.measure_size = measure_size
         # 1. Aplatir les index et calculer la taille de chaque groupe
-        self.register_buffer('lengths', torch.tensor([idx.numel() for idx in ledidx], device=device))
-        self.register_buffer('flat_idx', torch.cat([idx for idx in ledidx]).to(device))
-        self.register_buffer('norm_factors',
-                             torch.repeat_interleave(1.0 / self.lengths, self.lengths).view(1, -1, 1, 1))
+        self.register_buffer(
+            "lengths", torch.tensor([idx.numel() for idx in ledidx], device=device)
+        )
+        self.register_buffer("flat_idx", torch.cat([idx for idx in ledidx]).to(device))
+        self.register_buffer(
+            "norm_factors",
+            torch.repeat_interleave(1.0 / self.lengths, self.lengths).view(1, -1, 1, 1),
+        )
 
         Nimg = len(ledidx)
         self.Nimg = Nimg
@@ -706,7 +714,9 @@ class MultiplexPtychography(PhaseRetrieval):
         B, _, H, W = y.shape
 
         # 2. Associer chaque index aplati à son canal de destination (C)
-        c_indices = torch.repeat_interleave(torch.arange(self.Nimg, device=y.device), self.lengths)
+        c_indices = torch.repeat_interleave(
+            torch.arange(self.Nimg, device=y.device), self.lengths
+        )
         idx_expanded = c_indices.view(1, -1, 1, 1).expand(B, -1, H, W)
 
         # 3. Extraire les valeurs (Shape: B, total_n, H, W)
@@ -720,7 +730,13 @@ class MultiplexPtychography(PhaseRetrieval):
         return y
 
     def A_adjoint(self, y, **kwargs):
-        y2 = torch.zeros(y.size(0), self.shifts.size(1), *self.measure_size[-2:], dtype=y.dtype, device=y.device)
+        y2 = torch.zeros(
+            y.size(0),
+            self.shifts.size(1),
+            *self.measure_size[-2:],
+            dtype=y.dtype,
+            device=y.device,
+        )
 
         # 2. Répétition variable par canal (B, total_n, H, W)
         y_repeated = torch.repeat_interleave(y, self.lengths, dim=1)
@@ -736,9 +752,17 @@ class MultiplexPtychography(PhaseRetrieval):
         return super().A_adjoint(y2)
 
     def A_vjp(self, x, v):
-        v2 = torch.zeros(v.size(0), self.shifts.size(1), *self.measure_size[-2:], dtype=v.dtype, device=v.device)
+        v2 = torch.zeros(
+            v.size(0),
+            self.shifts.size(1),
+            *self.measure_size[-2:],
+            dtype=v.dtype,
+            device=v.device,
+        )
 
-        v_normalized = torch.repeat_interleave(v, self.lengths, dim=1) * self.norm_factors
+        v_normalized = (
+            torch.repeat_interleave(v, self.lengths, dim=1) * self.norm_factors
+        )
 
         v2.index_add_(1, self.flat_idx, v_normalized)
         v2 = v2 * self.scale
@@ -747,7 +771,7 @@ class MultiplexPtychography(PhaseRetrieval):
 
     def update_parameters(self, **kwargs):
         self.B.update_parameters(**kwargs)
-        ledidx = kwargs.get('ledidx')
+        ledidx = kwargs.get("ledidx")
         if ledidx is not None:
             device = ledidx[0].device
             lengths = torch.tensor([idx.numel() for idx in ledidx], device=device)

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -537,3 +537,208 @@ def generate_shifts(
     return torch.concatenate(
         [x_shifts.reshape(n_img, 1), y_shifts.reshape(n_img, 1)], dim=1
     )
+
+
+class FourierPtychographyLinearOperator(LinearPhysics):
+
+    def __init__(
+            self,
+            img_size=None,
+            measure_size=None,
+            probe=None,
+            shifts=None,
+            norm=1,
+            device="cpu",
+            **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.img_size = img_size
+        self.norm = norm
+        if shifts.ndim != 3:
+            raise ValueError("shifts must be a 3D tensor of shape (B, n_img, 2)")
+        self.register_buffer("shifts", shifts)
+
+        if probe.ndim != 4:
+            raise ValueError("probe must be a 4D tensor of shape (B, 1, H, W)")
+
+        self.register_buffer("probe", probe)
+        self.to(device)
+
+        cy, cx = img_size[-2] // 2, img_size[-1] // 2
+        my, mx = measure_size[-2] // 2, measure_size[-1] // 2
+        self.cy = cy
+        self.cx = cx
+        self.my = my
+        self.mx = mx
+
+    def op_fft2(self, y, norm='ortho'):
+        return torch.fft.fftshift(torch.fft.fft2(y, norm=norm), dim=(-2, -1))
+
+    def op_ifft2(self, x, norm='ortho'):
+        return torch.fft.ifft2(torch.fft.ifftshift(x, dim=(-2, -1)), norm=norm)
+
+    def A(self, x, **kwargs):
+        fx = self.op_fft2(x)
+        crop = self.shift_index(fx, self.shifts)
+        return self.norm * self.op_ifft2(self.probe * crop).to(torch.complex64)
+
+    def A_adjoint(self, y, **kwargs):
+        crop = self.probe.conj() * self.op_fft2(y)
+        Tx2 = self.op_ifft2(self.shift_and_pad(crop, -self.shifts))
+        return self.norm * Tx2.sum(dim=1, keepdim=True)
+
+    def shift_index(self, x, shifts):
+        B, C_img, H, W = x.shape
+        cy, cx = self.cy, self.cx
+        my, mx = self.my, self.mx
+        N_crops = shifts.size(1)
+
+        crop_y, crop_x = torch.meshgrid(
+            torch.arange(cy - my, cy + my, device=x.device),
+            torch.arange(cx - mx, cx + mx, device=x.device),
+            indexing='ij'
+        )
+
+        dy = shifts[:, :, 0].view(B, N_crops, 1, 1)
+        dx = shifts[:, :, 1].view(B, N_crops, 1, 1)
+
+        src_y = (crop_y.view(1, 1, 2 * my, 2 * mx) - dy) % H
+        src_x = (crop_x.view(1, 1, 2 * my, 2 * mx) - dx) % W
+
+        b_idx = torch.arange(B, device=x.device).view(B, 1, 1, 1)
+        c_idx = torch.arange(C_img, device=x.device).view(1, C_img, 1, 1)
+        return x[b_idx, c_idx, src_y, src_x]
+
+    def shift_and_pad(self, crop, shifts):
+        B, C_img, h_crop, w_crop = crop.shape
+        H, W = self.img_size[-2], self.img_size[-1]
+        cy, cx = self.cy, self.cx
+        my, mx = self.my, self.mx
+        N_crops = shifts.size(1)
+
+        grid_y = torch.arange(H, device=crop.device).view(1, 1, H, 1)
+        grid_x = torch.arange(W, device=crop.device).view(1, 1, 1, W)
+
+        dy = shifts[:, :, 0].view(B, N_crops, 1, 1)
+        dx = shifts[:, :, 1].view(B, N_crops, 1, 1)
+
+        src_y = grid_y - dy - (cy - my)
+        src_x = grid_x - dx - (cx - mx)
+
+        mask = (src_y >= 0) & (src_y < 2 * my) & (src_x >= 0) & (src_x < 2 * mx)
+
+        src_y_c = src_y.clamp(0, 2 * my - 1)
+        src_x_c = src_x.clamp(0, 2 * mx - 1)
+
+        b_idx = torch.arange(B, device=crop.device).view(B, 1, 1, 1)
+        c_idx = torch.arange(C_img, device=crop.device).view(1, C_img, 1, 1)
+
+        out = crop[b_idx, c_idx, src_y_c, src_x_c]
+        out = torch.where(mask, out, torch.tensor(0.0, dtype=out.dtype, device=out.device))
+        return out
+
+
+class MultiplexPtychography(PhaseRetrieval):
+
+    def __init__(
+            self,
+            img_size=None,
+            measure_size=None,
+            probe=None,
+            shifts=None,
+            ledidx=None,
+            scale=1,
+            norm=1,
+            device="cpu",
+            **kwargs,
+    ):
+
+        B = FourierPtychographyLinearOperator(
+            img_size=img_size,
+            measure_size=measure_size,
+            probe=probe,
+            shifts=shifts,
+            norm=norm,
+            device=device,
+        )
+        super().__init__(B, **kwargs)
+        self.register_buffer("probe", B.probe)
+        self.register_buffer("shifts", B.shifts)
+        if isinstance(ledidx, torch.Tensor):
+            self.register_buffer("ledidx", ledidx)
+        else:
+            self.ledidx = ledidx
+        self.register_buffer("scale", scale)
+        self.img_size = img_size
+        self.measure_size = measure_size
+        # 1. Aplatir les index et calculer la taille de chaque groupe
+        self.register_buffer('lengths', torch.tensor([idx.numel() for idx in ledidx], device=device))
+        self.register_buffer('flat_idx', torch.cat([idx for idx in ledidx]).to(device))
+        self.register_buffer('norm_factors',
+                             torch.repeat_interleave(1.0 / self.lengths, self.lengths).view(1, -1, 1, 1))
+
+        # self.lengths = torch.tensor([idx.numel() for idx in self.ledidx], device=shifts.device)
+        # self.flat_idx = torch.cat([idx for idx in ledidx]).to(device)
+
+        Nimg = len(ledidx)
+        self.Nimg = Nimg
+
+        self.name = f"Ptychography_PRV2"
+        self.to(device)
+
+    def A(self, x, **kwargs):
+        y = super().A(x, **kwargs) * self.scale  # scale de dim (1, y.size(1), 1, 1)
+        B, _, H, W = y.shape
+
+        # 2. Associer chaque index aplati à son canal de destination (C)
+        c_indices = torch.repeat_interleave(torch.arange(self.Nimg, device=y.device), self.lengths)
+        idx_expanded = c_indices.view(1, -1, 1, 1).expand(B, -1, H, W)
+
+        # 3. Extraire les valeurs (Shape: B, total_n, H, W)
+        gathered = y[:, self.flat_idx, :, :]
+
+        # 4. Agréger par canal (somme) puis diviser pour obtenir la moyenne (Shape: B, C, H, W)
+        out = torch.zeros((B, self.Nimg, H, W), dtype=y.dtype, device=y.device)
+        out.scatter_add_(1, idx_expanded, gathered)
+
+        y = out / self.lengths.view(1, self.Nimg, 1, 1)
+        return y
+
+    def A_adjoint(self, y, **kwargs):
+        y2 = torch.zeros(y.size(0), self.shifts.size(1), *self.measure_size[-2:], dtype=y.dtype, device=y.device)
+
+        # 2. Répétition variable par canal (B, total_n, H, W)
+        y_repeated = torch.repeat_interleave(y, self.lengths, dim=1)
+
+        # 3. Normalisation par 1/n_i
+
+        y_normalized = y_repeated * self.norm_factors
+
+        # 4. Accumulation aux indices correspondants
+        y2.index_add_(1, self.flat_idx, y_normalized)
+
+        y2 = y2 * self.scale
+        return super().A_adjoint(y2)
+
+    def A_vjp(self, x, v):
+        v2 = torch.zeros(v.size(0), self.shifts.size(1), *self.measure_size[-2:], dtype=v.dtype, device=v.device)
+
+        v_normalized = torch.repeat_interleave(v, self.lengths, dim=1) * self.norm_factors
+
+        v2.index_add_(1, self.flat_idx, v_normalized)
+        v2 = v2 * self.scale
+
+        return super().A_vjp(x, v2)
+
+    def update_parameters(self, **kwargs):
+        self.B.update_parameters(**kwargs)
+        ledidx = kwargs.get('ledidx')
+        if ledidx is not None:
+            device = ledidx[0].device
+            lengths = torch.tensor([idx.numel() for idx in ledidx], device=device)
+            flat_idx = torch.cat([idx for idx in ledidx]).to(device)
+            self.ledidx = ledidx
+            super().update_parameters(lengths=lengths, flat_idx=flat_idx, **kwargs)
+        else:
+            super().update_parameters(**kwargs)

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -779,7 +779,7 @@ class MultiplexedPtychography(PhaseRetrieval):
         self.register_buffer("led_intensity", led_intensity)
         self.img_size = img_size
         self.measurement_size = measurement_size
-        # 1. Aplatir les index et calculer la taille de chaque groupe
+
         self.register_buffer(
             "lengths", torch.tensor([idx.numel() for idx in ledidx], device=device)
         )

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -697,8 +697,8 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         grid_y = torch.arange(H, device=crop.device).view(1, 1, H, 1)
         grid_x = torch.arange(W, device=crop.device).view(1, 1, 1, W)
 
-        dy = shifts[:, :, 0].view(B, N_crops, 1, 1)
-        dx = shifts[:, :, 1].view(B, N_crops, 1, 1)
+        dy = shifts[:, :, 0].view(1, N_crops, 1, 1).expand(B, N_crops, 1, 1)
+        dx = shifts[:, :, 1].view(1, N_crops, 1, 1).expand(B, N_crops, 1, 1)
 
         src_y = grid_y - dy - (self.cy - self.my)
         src_x = grid_x - dx - (self.cx - self.mx)

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -720,7 +720,7 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         return out
 
 
-class MultiplexedPtychography(PhaseRetrieval):
+class MultiplexedFourierPtychography(PhaseRetrieval):
     r"""
     Multiplexed Fourier Ptychography forward operator.
 

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -544,7 +544,7 @@ class FourierPtychographyLinearOperator(LinearPhysics):
     def __init__(
         self,
         img_size=None,
-        measure_size=None,
+        measurement_size=None,
         probe=None,
         shifts=None,
         normalize=True,
@@ -567,7 +567,7 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         self.to(device)
 
         cy, cx = img_size[-2] // 2, img_size[-1] // 2
-        my, mx = measure_size[-2] // 2, measure_size[-1] // 2
+        my, mx = measurement_size[-2] // 2, measurement_size[-1] // 2
         self.cy = cy
         self.cx = cx
         self.my = my
@@ -665,11 +665,11 @@ class MultiplexPtychography(PhaseRetrieval):
     def __init__(
         self,
         img_size=None,
-        measure_size=None,
+        measurement_size=None,
         probe=None,
         shifts=None,
         ledidx=None,
-        scale=torch.ones(1, 1, 1, 1),
+        led_intensity=torch.ones(1, 1, 1, 1),
         normalize=True,
         device="cpu",
         **kwargs,
@@ -677,7 +677,7 @@ class MultiplexPtychography(PhaseRetrieval):
 
         B = FourierPtychographyLinearOperator(
             img_size=img_size,
-            measure_size=measure_size,
+            measurement_size=measurement_size,
             probe=probe,
             shifts=shifts,
             normalize=normalize,
@@ -690,9 +690,9 @@ class MultiplexPtychography(PhaseRetrieval):
             self.register_buffer("ledidx", ledidx)
         else:
             self.ledidx = ledidx
-        self.register_buffer("scale", scale)
+        self.register_buffer("led_intensity", led_intensity)
         self.img_size = img_size
-        self.measure_size = measure_size
+        self.measurement_size = measurement_size
         # 1. Aplatir les index et calculer la taille de chaque groupe
         self.register_buffer(
             "lengths", torch.tensor([idx.numel() for idx in ledidx], device=device)
@@ -710,7 +710,7 @@ class MultiplexPtychography(PhaseRetrieval):
         self.to(device)
 
     def A(self, x, **kwargs):
-        y = super().A(x, **kwargs) * self.scale  # scale de dim (1, y.size(1), 1, 1)
+        y = super().A(x, **kwargs) * self.led_intensity  # led_intensity de dim (1, y.size(1), 1, 1)
         B, _, H, W = y.shape
 
         # 2. Associer chaque index aplati à son canal de destination (C)
@@ -733,7 +733,7 @@ class MultiplexPtychography(PhaseRetrieval):
         y2 = torch.zeros(
             y.size(0),
             self.shifts.size(1),
-            *self.measure_size[-2:],
+            *self.measurement_size[-2:],
             dtype=y.dtype,
             device=y.device,
         )
@@ -748,14 +748,14 @@ class MultiplexPtychography(PhaseRetrieval):
         # 4. Accumulation aux indices correspondants
         y2.index_add_(1, self.flat_idx, y_normalized)
 
-        y2 = y2 * self.scale
+        y2 = y2 * self.led_intensity
         return super().A_adjoint(y2)
 
     def A_vjp(self, x, v):
         v2 = torch.zeros(
             v.size(0),
             self.shifts.size(1),
-            *self.measure_size[-2:],
+            *self.measurement_size[-2:],
             dtype=v.dtype,
             device=v.device,
         )
@@ -765,7 +765,7 @@ class MultiplexPtychography(PhaseRetrieval):
         )
 
         v2.index_add_(1, self.flat_idx, v_normalized)
-        v2 = v2 * self.scale
+        v2 = v2 * self.led_intensity
 
         return super().A_vjp(x, v2)
 

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -728,7 +728,7 @@ class MultiplexedPtychography(PhaseRetrieval):
 
     .. math::
 
-         y_i = \cdot \frac{1}{|L_i|} \sum_{l \in L_i} \left| s_l B_l x \right|^2
+         y_i = \frac{1}{|\mathcal{L}_i|} \sum_{l \in \mathcal{L}_i} \left| s_l B_l x \right|^2
 
     where :math:`B` is the linear forward operator defined by a :class:`deepinv.physics.FourierPtychographyLinearOperator` object. The measurements are summed according to specific LED patterns where :math:`L_i` represents the set of LED indices multiplexed into the :math:`i`-th measurement, and :math:`s_l` is the intensity of each LED.
 

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -558,8 +558,8 @@ class FourierPtychographyLinearOperator(LinearPhysics):
     :param torch.Tensor probe: A 4D tensor representing the pupil (probe) function.
     :param torch.Tensor shifts: A 3D tensor of shape ``(B, n_img, 2)`` corresponding to the ``n_img`` Fourier shift positions.
     :param bool normalize: Normalization factor for the linear operator to adjust its norm.
-    :param bool include_fft:
-    :param bool include_ifft:
+    :param bool include_fft: If ``True``, applies the 2D FFT in :meth:`op_fft2`; if ``False``, the input is assumed to already be in the Fourier domain.
+    :param bool include_ifft: If ``True``, applies the 2D inverse FFT in :meth:`op_ifft2`; if ``False``, the output remains in the Fourier domain.
     :param torch.device, str device: Device "cpu" or "gpu".
     """
 
@@ -738,7 +738,9 @@ class MultiplexedPtychography(PhaseRetrieval):
     :param torch.Tensor shifts: A 3D tensor of shape ``(B, n_img, 2)`` corresponding to the Fourier shift positions.
     :param list[torch.Tensor], torch.Tensor ledidx: Indices of the LEDs multiplexed into each measurement.
     :param float, torch.Tensor led_intensity: Intensity :math:`s_l` for each LED.
-    :param float norm: Normalization factor for the underlying linear operator.
+    :param float normalize: Normalization factor for the linear operator to adjust its norm.
+    :param bool include_fft: If ``True``, applies the 2D FFT in :meth:`op_fft2`; if ``False``, the input is assumed to already be in the Fourier domain.
+    :param bool include_ifft: If ``True``, applies the 2D inverse FFT in :meth:`op_ifft2`; if ``False``, the output remains in the Fourier domain.
     :param torch.device, str device: Device "cpu" or "gpu".
     """
 

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -664,21 +664,19 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         :return: (:class:`torch.Tensor`) cropped and shifted tensor.
         """
         B, C_img, H, W = x.shape
-        cy, cx = self.cy, self.cx
-        my, mx = self.my, self.mx
         N_crops = shifts.size(1)
 
         crop_y, crop_x = torch.meshgrid(
-            torch.arange(cy - my, cy + my, device=x.device),
-            torch.arange(cx - mx, cx + mx, device=x.device),
+            torch.arange(self.cy - self.my, self.cy + self.my, device=x.device),
+            torch.arange(self.cx - self.mx, self.cx + self.mx, device=x.device),
             indexing="ij",
         )
 
         dy = shifts[:, :, 0].view(B, N_crops, 1, 1)
         dx = shifts[:, :, 1].view(B, N_crops, 1, 1)
 
-        src_y = (crop_y.view(1, 1, 2 * my, 2 * mx) - dy) % H
-        src_x = (crop_x.view(1, 1, 2 * my, 2 * mx) - dx) % W
+        src_y = (crop_y.view(1, 1, 2 * self.my, 2 * self.mx) - dy) % H
+        src_x = (crop_x.view(1, 1, 2 * self.my, 2 * self.mx) - dx) % W
 
         b_idx = torch.arange(B, device=x.device).view(B, 1, 1, 1)
         c_idx = torch.arange(C_img, device=x.device).view(1, C_img, 1, 1)
@@ -694,8 +692,6 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         """
         B, C_img, h_crop, w_crop = crop.shape
         H, W = self.img_size[-2], self.img_size[-1]
-        cy, cx = self.cy, self.cx
-        my, mx = self.my, self.mx
         N_crops = shifts.size(1)
 
         grid_y = torch.arange(H, device=crop.device).view(1, 1, H, 1)
@@ -704,13 +700,13 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         dy = shifts[:, :, 0].view(B, N_crops, 1, 1)
         dx = shifts[:, :, 1].view(B, N_crops, 1, 1)
 
-        src_y = grid_y - dy - (cy - my)
-        src_x = grid_x - dx - (cx - mx)
+        src_y = grid_y - dy - (self.cy - self.my)
+        src_x = grid_x - dx - (self.cx - self.mx)
 
-        mask = (src_y >= 0) & (src_y < 2 * my) & (src_x >= 0) & (src_x < 2 * mx)
+        mask = (src_y >= 0) & (src_y < 2 * self.my) & (src_x >= 0) & (src_x < 2 * self.mx)
 
-        src_y_c = src_y.clamp(0, 2 * my - 1)
-        src_x_c = src_x.clamp(0, 2 * mx - 1)
+        src_y_c = src_y.clamp(0, 2 * self.my - 1)
+        src_x_c = src_x.clamp(0, 2 * self.mx - 1)
 
         b_idx = torch.arange(B, device=crop.device).view(B, 1, 1, 1)
         c_idx = torch.arange(C_img, device=crop.device).view(1, C_img, 1, 1)

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -730,7 +730,7 @@ class MultiplexedFourierPtychography(PhaseRetrieval):
 
          y_i = \frac{1}{|\mathcal{L}_i|} \sum_{l \in \mathcal{L}_i} \left| s_l B_l x \right|^2
 
-    where :math:`B_l` is the linear forward operator associated to the  :math:`l`th LED, computed with :class:` FourierPtychographyLinearOperator<deepinv.physics.FourierPtychographyLinearOperator>` . The measurements are summed according to specific LED subsets where :math:`\mathcal{L}_i` represents the set of LED indices multiplexed into the :math:`i`-th measurement, and :math:`s_l > 0` is the intensity of each LED.
+    where :math:`B_l` is the linear forward operator associated to the :math:`l` th LED, computed with :class:`FourierPtychographyLinearOperator<deepinv.physics.FourierPtychographyLinearOperator>` . The measurements are summed according to specific LED subsets where :math:`\mathcal{L}_i` represents the set of LED indices multiplexed into the :math:`i`-th measurement, and :math:`s_l > 0` is the intensity of each LED.
 
     :param tuple img_size: Shape of the input image.
     :param tuple measure_size: Shape of the measurements.

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -728,7 +728,7 @@ class MultiplexedFourierPtychography(PhaseRetrieval):
 
     .. math::
 
-         y_i = \frac{1}{|\mathcal{L}_i|} \sum_{l \in \mathcal{L}_i} \left| s_l B_l x \right|^2
+         y_i = \frac{1}{|\mathcal{L}_i|} \sum_{l \in \mathcal{L}_i} \left| s_l F^{-1} P T_l F x \right|^2
 
     where :math:`B_l` is the linear forward operator associated to the :math:`l` th LED, computed with :class:`FourierPtychographyLinearOperator<deepinv.physics.FourierPtychographyLinearOperator>` . The measurements are summed according to specific LED subsets where :math:`\mathcal{L}_i` represents the set of LED indices multiplexed into the :math:`i`-th measurement, and :math:`s_l > 0` is the intensity of each LED.
 

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -730,7 +730,7 @@ class MultiplexedFourierPtychography(PhaseRetrieval):
 
          y_i = \frac{1}{|\mathcal{L}_i|} \sum_{l \in \mathcal{L}_i} \left| s_l F^{-1} P T_l F x \right|^2
 
-    where :math:`B_l` is the linear forward operator associated to the :math:`l` th LED, computed with :class:`FourierPtychographyLinearOperator<deepinv.physics.FourierPtychographyLinearOperator>` . The measurements are summed according to specific LED subsets where :math:`\mathcal{L}_i` represents the set of LED indices multiplexed into the :math:`i`-th measurement, and :math:`s_l > 0` is the intensity of each LED.
+    where :math:`F` is the 2D Fourier transform, :math:`P` is the probe function, and :math:`T_l` is a 2D shift in the Fourier domain. The linear part is computed with :class:`FourierPtychographyLinearOperator<deepinv.physics.FourierPtychographyLinearOperator>` . The measurements are summed according to specific LED subsets where :math:`\mathcal{L}_i` represents the set of LED indices multiplexed into the :math:`i`-th measurement, and :math:`s_l > 0` is the intensity of each LED.
 
     :param tuple img_size: Shape of the input image.
     :param tuple measure_size: Shape of the measurements.

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -730,7 +730,7 @@ class MultiplexedPtychography(PhaseRetrieval):
 
          y_i = \frac{1}{|\mathcal{L}_i|} \sum_{l \in \mathcal{L}_i} \left| s_l B_l x \right|^2
 
-    where :math:`B` is the linear forward operator defined by a :class:`deepinv.physics.FourierPtychographyLinearOperator` object. The measurements are summed according to specific LED patterns where :math:`L_i` represents the set of LED indices multiplexed into the :math:`i`-th measurement, and :math:`s_l` is the intensity of each LED.
+    where :math:`B_l` is the linear forward operator associated to the  :math:`l`th LED, computed with :class:` FourierPtychographyLinearOperator<deepinv.physics.FourierPtychographyLinearOperator>` . The measurements are summed according to specific LED subsets where :math:`\mathcal{L}_i` represents the set of LED indices multiplexed into the :math:`i`-th measurement, and :math:`s_l > 0` is the intensity of each LED.
 
     :param tuple img_size: Shape of the input image.
     :param tuple measure_size: Shape of the measurements.

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -739,8 +739,8 @@ class MultiplexedPtychography(PhaseRetrieval):
     :param list[torch.Tensor], torch.Tensor ledidx: Indices of the LEDs multiplexed into each measurement.
     :param float, torch.Tensor led_intensity: Intensity :math:`s_l` for each LED.
     :param float normalize: Normalization factor for the linear operator to adjust its norm.
-    :param bool include_fft: If ``True``, applies the 2D FFT in :meth:`op_fft2`; if ``False``, the input is assumed to already be in the Fourier domain.
-    :param bool include_ifft: If ``True``, applies the 2D inverse FFT in :meth:`op_ifft2`; if ``False``, the output remains in the Fourier domain.
+    :param bool include_fft: If ``True``, applies the 2D FFT in :meth:`deepinv.physics.FourierPtychographyLinearOperator.op_fft2`; if ``False``, the input is assumed to already be in the Fourier domain.
+    :param bool include_ifft: If ``True``, applies the 2D inverse FFT in :meth:`deepinv.physics.FourierPtychographyLinearOperator.op_ifft2`; if ``False``, the output remains in the Fourier domain.
     :param torch.device, str device: Device "cpu" or "gpu".
     """
 

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -548,6 +548,8 @@ class FourierPtychographyLinearOperator(LinearPhysics):
             probe=None,
             shifts=None,
             normalize=True,
+            include_fft=True,
+            include_ifft=True,
             device="cpu",
             **kwargs,
     ):
@@ -578,11 +580,20 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         else:
             self.norm= 1.0
 
+        self.include_fft = include_fft
+        self.include_ifft = include_ifft
+
     def op_fft2(self, y, norm='ortho'):
-        return torch.fft.fftshift(torch.fft.fft2(y, norm=norm), dim=(-2, -1))
+        if self.include_fft:
+            return torch.fft.fftshift(torch.fft.fft2(y, norm=norm), dim=(-2, -1))
+        else:
+            return y
 
     def op_ifft2(self, x, norm='ortho'):
-        return torch.fft.ifft2(torch.fft.ifftshift(x, dim=(-2, -1)), norm=norm)
+        if self.include_ifft:
+            return torch.fft.ifft2(torch.fft.ifftshift(x, dim=(-2, -1)), norm=norm)
+        else:
+            return x
 
     def A(self, x, **kwargs):
         fx = self.op_fft2(x)

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -703,7 +703,9 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         src_y = grid_y - dy - (self.cy - self.my)
         src_x = grid_x - dx - (self.cx - self.mx)
 
-        mask = (src_y >= 0) & (src_y < 2 * self.my) & (src_x >= 0) & (src_x < 2 * self.mx)
+        mask = (
+            (src_y >= 0) & (src_y < 2 * self.my) & (src_x >= 0) & (src_x < 2 * self.mx)
+        )
 
         src_y_c = src_y.clamp(0, 2 * self.my - 1)
         src_x_c = src_x.clamp(0, 2 * self.mx - 1)

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -544,20 +544,22 @@ class FourierPtychographyLinearOperator(LinearPhysics):
     Forward linear operator for Fourier ptychography.
 
     Models the imaging process of Fourier ptychography, where a complex object is reconstructed from multiple low-resolution intensity measurements acquired under different illumination angles.
-    Mathematically, this is equivalent to shifting a pupil (probe) function in the Fourier domain of the object, applying it, and inverse Fourier transforming to the spatial domain.
+    Mathematically, this is equivalent to shifting a probe function in the Fourier domain of the object, applying it, and inverse Fourier transforming to the spatial domain.
 
     .. math::
 
         B = \left[ \begin{array}{c} B_1 \\ B_2 \\ \vdots \\ B_{n_{\text{img}}} \end{array} \right],
-        B_l = F^{-1} \text{diag}(p) T_l F, \quad l = 1, \dots, n_{\text{img}},
+        B_l = F^{-1} P T_l F, \quad l = 1, \dots, n_{\text{img}},
 
-    where :math:`F` is the 2D Fourier transform, :math:`\text{diag}(p)` is the pupil (probe) function :math:`p`, and :math:`T_l` is a 2D shift in the Fourier domain.
+    where :math:`F` is the 2D Fourier transform, :math:`P` is the probe function, and :math:`T_l` is a 2D shift in the Fourier domain.
 
-    :param tuple img_size: Shape of the input image (high-resolution object), typically ``(batch_size, channels, height, width)``.
-    :param tuple measure_size: Shape of the measurements (low-resolution acquisitions).
+    :param tuple img_size: Shape of the input image (high-resolution object), typically ``(channels, height, width)``.
+    :param tuple measurement_size: Shape of the measurements (low-resolution acquisitions).
     :param torch.Tensor probe: A 4D tensor representing the pupil (probe) function.
     :param torch.Tensor shifts: A 3D tensor of shape ``(B, n_img, 2)`` corresponding to the ``n_img`` Fourier shift positions.
-    :param float norm: Normalization factor for the linear operator to adjust its spectral norm.
+    :param bool normalize: Normalization factor for the linear operator to adjust its norm.
+    :param bool include_fft:
+    :param bool include_ifft:
     :param torch.device, str device: Device "cpu" or "gpu".
     """
 
@@ -697,7 +699,7 @@ class MultiplexedPtychography(PhaseRetrieval):
     :param torch.Tensor probe: A tensor representing the pupil (probe) function.
     :param torch.Tensor shifts: A 3D tensor of shape ``(B, n_img, 2)`` corresponding to the Fourier shift positions.
     :param list[torch.Tensor], torch.Tensor ledidx: Indices of the LEDs multiplexed into each measurement.
-    :param float, torch.Tensor led_intensity: Scaling factor :math:`s` applied to the measurements.
+    :param float, torch.Tensor led_intensity: Intensity :math:`s_l` for each LED.
     :param float norm: Normalization factor for the underlying linear operator.
     :param torch.device, str device: Device "cpu" or "gpu".
     """

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -608,28 +608,61 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         self.include_ifft = include_ifft
 
     def op_fft2(self, y, norm="ortho"):
+        r"""
+        Applies a 2D Fourier transform to the input tensor.
+
+        :param torch.Tensor y: input tensor.
+        :param str norm: normalization mode. Default is 'ortho'.
+        :return: (:class:`torch.Tensor`) Fourier transformed tensor.
+        """
         if self.include_fft:
             return torch.fft.fftshift(torch.fft.fft2(y, norm=norm), dim=(-2, -1))
         else:
             return y
 
     def op_ifft2(self, x, norm="ortho"):
+        r"""
+        Applies a 2D inverse Fourier transform to the input tensor.
+
+        :param torch.Tensor x: input tensor.
+        :param str norm: normalization mode. Default is 'ortho'.
+        :return: (:class:`torch.Tensor`) inverse Fourier transformed tensor.
+        """
         if self.include_ifft:
             return torch.fft.ifft2(torch.fft.ifftshift(x, dim=(-2, -1)), norm=norm)
         else:
             return x
 
     def A(self, x, **kwargs):
+        r"""
+        Applies the forward operator to the input image.
+
+        :param torch.Tensor x: input image tensor.
+        :return: (:class:`torch.Tensor`) transformed tensor after shifting and probe multiplication.
+        """
         fx = self.op_fft2(x)
         crop = self.shift_index(fx, self.shifts)
         return self.norm * self.op_ifft2(self.probe * crop).to(torch.complex64)
 
     def A_adjoint(self, y, **kwargs):
+        r"""
+        Applies the adjoint operator to the input measurements.
+
+        :param torch.Tensor y: measurements tensor.
+        :return: (:class:`torch.Tensor`) reconstructed image tensor.
+        """
         crop = self.probe.conj() * self.op_fft2(y)
         Tx2 = self.op_ifft2(self.shift_and_pad(crop, -self.shifts))
         return self.norm * Tx2.sum(dim=1, keepdim=True)
 
     def shift_index(self, x, shifts):
+        r"""
+        Shifts and centrale crop the input tensor in the Fourier domain.
+
+        :param torch.Tensor x: input tensor.
+        :param torch.Tensor shifts: tensor of 2D shift positions.
+        :return: (:class:`torch.Tensor`) cropped and shifted tensor.
+        """
         B, C_img, H, W = x.shape
         cy, cx = self.cy, self.cx
         my, mx = self.my, self.mx
@@ -652,6 +685,13 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         return x[b_idx, c_idx, src_y, src_x]
 
     def shift_and_pad(self, crop, shifts):
+        r"""
+        Pads and shift a cropped tensor back to the original image size.
+
+        :param torch.Tensor crop: cropped input tensor.
+        :param torch.Tensor shifts: tensor of 2D shift positions.
+        :return: (:class:`torch.Tensor`) shifted and padded tensor.
+        """
         B, C_img, h_crop, w_crop = crop.shape
         H, W = self.img_size[-2], self.img_size[-1]
         cy, cx = self.cy, self.cx
@@ -713,6 +753,8 @@ class MultiplexedPtychography(PhaseRetrieval):
         ledidx=None,
         led_intensity=torch.ones(1, 1, 1, 1),
         normalize=True,
+        include_fft=True,
+        include_ifft=True,
         device="cpu",
         **kwargs,
     ):
@@ -723,6 +765,8 @@ class MultiplexedPtychography(PhaseRetrieval):
             probe=probe,
             shifts=shifts,
             normalize=normalize,
+            include_fft=include_fft,
+            include_ifft=include_ifft,
             device=device,
         )
         super().__init__(B, **kwargs)
@@ -752,19 +796,22 @@ class MultiplexedPtychography(PhaseRetrieval):
         self.to(device)
 
     def A(self, x, **kwargs):
+        r"""
+        Applies the multiplexed forward operator to the input image.
+
+        :param torch.Tensor x: input image tensor.
+        :return: (:class:`torch.Tensor`) multiplexed intensity measurements.
+        """
         y = super().A(x, **kwargs) * self.led_intensity  # led_intensity de dim (1, y.size(1), 1, 1)
         B, _, H, W = y.shape
 
-        # 2. Associer chaque index aplati à son canal de destination (C)
         c_indices = torch.repeat_interleave(
             torch.arange(self.Nimg, device=y.device), self.lengths
         )
         idx_expanded = c_indices.view(1, -1, 1, 1).expand(B, -1, H, W)
 
-        # 3. Extraire les valeurs (Shape: B, total_n, H, W)
         gathered = y[:, self.flat_idx, :, :]
 
-        # 4. Agréger par canal (somme) puis diviser pour obtenir la moyenne (Shape: B, C, H, W)
         out = torch.zeros((B, self.Nimg, H, W), dtype=y.dtype, device=y.device)
         out.scatter_add_(1, idx_expanded, gathered)
 
@@ -772,6 +819,12 @@ class MultiplexedPtychography(PhaseRetrieval):
         return y
 
     def A_adjoint(self, y, **kwargs):
+        r"""
+        Applies the adjoint of the multiplexed operator to the measurements.
+
+        :param torch.Tensor y: multiplexed measurements tensor.
+        :return: (:class:`torch.Tensor`) reconstructed image tensor.
+        """
         y2 = torch.zeros(
             y.size(0),
             self.shifts.size(1),
@@ -780,20 +833,22 @@ class MultiplexedPtychography(PhaseRetrieval):
             device=y.device,
         )
 
-        # 2. Répétition variable par canal (B, total_n, H, W)
         y_repeated = torch.repeat_interleave(y, self.lengths, dim=1)
-
-        # 3. Normalisation par 1/n_i
-
         y_normalized = y_repeated * self.norm_factors
 
-        # 4. Accumulation aux indices correspondants
         y2.index_add_(1, self.flat_idx, y_normalized)
 
         y2 = y2 * self.led_intensity
         return super().A_adjoint(y2)
 
     def A_vjp(self, x, v):
+        r"""
+        Computes the product between a vector and the Jacobian of the forward operator.
+
+        :param torch.Tensor x: signal/image.
+        :param torch.Tensor v: vector.
+        :return: (:class:`torch.Tensor`) the VJP product.
+        """
         v2 = torch.zeros(
             v.size(0),
             self.shifts.size(1),
@@ -812,6 +867,11 @@ class MultiplexedPtychography(PhaseRetrieval):
         return super().A_vjp(x, v2)
 
     def update_parameters(self, **kwargs):
+        r"""
+        Updates the parameters of the operator.
+
+        :param dict kwargs: updated parameters.
+        """
         self.B.update_parameters(**kwargs)
         ledidx = kwargs.get("ledidx")
         if ledidx is not None:

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -802,7 +802,9 @@ class MultiplexedPtychography(PhaseRetrieval):
         :param torch.Tensor x: input image tensor.
         :return: (:class:`torch.Tensor`) multiplexed intensity measurements.
         """
-        y = super().A(x, **kwargs) * self.led_intensity  # led_intensity de dim (1, y.size(1), 1, 1)
+        y = (
+            super().A(x, **kwargs) * self.led_intensity
+        )  # led_intensity de dim (1, y.size(1), 1, 1)
         B, _, H, W = y.shape
 
         c_indices = torch.repeat_interleave(

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -547,14 +547,13 @@ class FourierPtychographyLinearOperator(LinearPhysics):
             measure_size=None,
             probe=None,
             shifts=None,
-            norm=1,
+            normalize=True,
             device="cpu",
             **kwargs,
     ):
         super().__init__(**kwargs)
 
         self.img_size = img_size
-        self.norm = norm
         if shifts.ndim != 3:
             raise ValueError("shifts must be a 3D tensor of shape (B, n_img, 2)")
         self.register_buffer("shifts", shifts)
@@ -571,6 +570,13 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         self.cx = cx
         self.my = my
         self.mx = mx
+
+        if normalize:
+            probe_sq = (self.probe.abs() ** 2).expand(1, self.shifts.size(1), -1, -1)
+            overlap_img = self.shift_and_pad(probe_sq, -self.shifts).sum(dim=1, keepdim=True)
+            self.norm = 1.0 / torch.sqrt(overlap_img.max()).item()
+        else:
+            self.norm= 1.0
 
     def op_fft2(self, y, norm='ortho'):
         return torch.fft.fftshift(torch.fft.fft2(y, norm=norm), dim=(-2, -1))
@@ -649,7 +655,7 @@ class MultiplexPtychography(PhaseRetrieval):
             shifts=None,
             ledidx=None,
             scale=1,
-            norm=1,
+            normalize=True,
             device="cpu",
             **kwargs,
     ):
@@ -659,7 +665,7 @@ class MultiplexPtychography(PhaseRetrieval):
             measure_size=measure_size,
             probe=probe,
             shifts=shifts,
-            norm=norm,
+            normalize=normalize,
             device=device,
         )
         super().__init__(B, **kwargs)
@@ -677,9 +683,6 @@ class MultiplexPtychography(PhaseRetrieval):
         self.register_buffer('flat_idx', torch.cat([idx for idx in ledidx]).to(device))
         self.register_buffer('norm_factors',
                              torch.repeat_interleave(1.0 / self.lengths, self.lengths).view(1, -1, 1, 1))
-
-        # self.lengths = torch.tensor([idx.numel() for idx in self.ledidx], device=shifts.device)
-        # self.flat_idx = torch.cat([idx for idx in ledidx]).to(device)
 
         Nimg = len(ledidx)
         self.Nimg = Nimg

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -672,8 +672,8 @@ class FourierPtychographyLinearOperator(LinearPhysics):
             indexing="ij",
         )
 
-        dy = shifts[:, :, 0].view(B, N_crops, 1, 1)
-        dx = shifts[:, :, 1].view(B, N_crops, 1, 1)
+        dy = shifts[:, :, 0].view(1, N_crops, 1, 1).expand(B, N_crops, 1, 1)
+        dx = shifts[:, :, 1].view(1, N_crops, 1, 1).expand(B, N_crops, 1, 1)
 
         src_y = (crop_y.view(1, 1, 2 * self.my, 2 * self.mx) - dy) % H
         src_x = (crop_x.view(1, 1, 2 * self.my, 2 * self.mx) - dx) % W

--- a/deepinv/physics/phase_retrieval.py
+++ b/deepinv/physics/phase_retrieval.py
@@ -540,6 +540,26 @@ def generate_shifts(
 
 
 class FourierPtychographyLinearOperator(LinearPhysics):
+    r"""
+    Forward linear operator for Fourier ptychography.
+
+    Models the imaging process of Fourier ptychography, where a complex object is reconstructed from multiple low-resolution intensity measurements acquired under different illumination angles.
+    Mathematically, this is equivalent to shifting a pupil (probe) function in the Fourier domain of the object, applying it, and inverse Fourier transforming to the spatial domain.
+
+    .. math::
+
+        B = \left[ \begin{array}{c} B_1 \\ B_2 \\ \vdots \\ B_{n_{\text{img}}} \end{array} \right],
+        B_l = F^{-1} \text{diag}(p) T_l F, \quad l = 1, \dots, n_{\text{img}},
+
+    where :math:`F` is the 2D Fourier transform, :math:`\text{diag}(p)` is the pupil (probe) function :math:`p`, and :math:`T_l` is a 2D shift in the Fourier domain.
+
+    :param tuple img_size: Shape of the input image (high-resolution object), typically ``(batch_size, channels, height, width)``.
+    :param tuple measure_size: Shape of the measurements (low-resolution acquisitions).
+    :param torch.Tensor probe: A 4D tensor representing the pupil (probe) function.
+    :param torch.Tensor shifts: A 3D tensor of shape ``(B, n_img, 2)`` corresponding to the ``n_img`` Fourier shift positions.
+    :param float norm: Normalization factor for the linear operator to adjust its spectral norm.
+    :param torch.device, str device: Device "cpu" or "gpu".
+    """
 
     def __init__(
         self,
@@ -660,7 +680,27 @@ class FourierPtychographyLinearOperator(LinearPhysics):
         return out
 
 
-class MultiplexPtychography(PhaseRetrieval):
+class MultiplexedPtychography(PhaseRetrieval):
+    r"""
+    Multiplexed Fourier Ptychography forward operator.
+
+    Corresponding to the phase retrieval operator:
+
+    .. math::
+
+         y_i = \cdot \frac{1}{|L_i|} \sum_{l \in L_i} \left| s_l B_l x \right|^2
+
+    where :math:`B` is the linear forward operator defined by a :class:`deepinv.physics.FourierPtychographyLinearOperator` object. The measurements are summed according to specific LED patterns where :math:`L_i` represents the set of LED indices multiplexed into the :math:`i`-th measurement, and :math:`s_l` is the intensity of each LED.
+
+    :param tuple img_size: Shape of the input image.
+    :param tuple measure_size: Shape of the measurements.
+    :param torch.Tensor probe: A tensor representing the pupil (probe) function.
+    :param torch.Tensor shifts: A 3D tensor of shape ``(B, n_img, 2)`` corresponding to the Fourier shift positions.
+    :param list[torch.Tensor], torch.Tensor ledidx: Indices of the LEDs multiplexed into each measurement.
+    :param float, torch.Tensor led_intensity: Scaling factor :math:`s` applied to the measurements.
+    :param float norm: Normalization factor for the underlying linear operator.
+    :param torch.device, str device: Device "cpu" or "gpu".
+    """
 
     def __init__(
         self,

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -587,7 +587,9 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
         measurement_size = (N_shift, 16, 16)
         radius = 4
         y, x_coord = torch.meshgrid(
-            torch.arange(measurement_size[1]), torch.arange(measurement_size[2]), indexing="ij"
+            torch.arange(measurement_size[1]),
+            torch.arange(measurement_size[2]),
+            indexing="ij",
         )
         center_y, center_x = measurement_size[1] // 2, measurement_size[2] // 2
         mask = ((y - center_y) ** 2 + (x_coord - center_x) ** 2) <= radius**2
@@ -719,7 +721,9 @@ def find_phase_retrieval_operator(name, device):
         radius = 4
 
         y, x_coord = torch.meshgrid(
-            torch.arange(measurement_size[1]), torch.arange(measurement_size[2]), indexing="ij"
+            torch.arange(measurement_size[1]),
+            torch.arange(measurement_size[2]),
+            indexing="ij",
         )
         center_y, center_x = measurement_size[1] // 2, measurement_size[2] // 2
         mask = ((y - center_y) ** 2 + (x_coord - center_x) ** 2) <= radius**2

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -580,7 +580,7 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
             device=device,
         )
         params = ["probe", "shifts"]
-    elif name == "Fourier_ptychography_linear":
+    elif name == "fourier_ptychography_linear":
         img_size = (1, 32, 32)
         dtype = torch.complex64
         N_shift = 14

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -571,12 +571,12 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
         img_size = (1, 32, 32)
         dtype = torch.complex64
         N_shift = 14
-        measure_size = (N_shift, 16, 16)
+        measurement_size = (N_shift, 16, 16)
         radius = 4
         y, x_coord = torch.meshgrid(
-            torch.arange(measure_size[1]), torch.arange(measure_size[2]), indexing="ij"
+            torch.arange(measurement_size[1]), torch.arange(measurement_size[2]), indexing="ij"
         )
-        center_y, center_x = measure_size[1] // 2, measure_size[2] // 2
+        center_y, center_x = measurement_size[1] // 2, measurement_size[2] // 2
         mask = ((y - center_y) ** 2 + (x_coord - center_x) ** 2) <= radius**2
         probe = mask[None, None].to(torch.complex64).to(device)
         shifts = torch.randint(
@@ -584,7 +584,7 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
         )
         p = dinv.physics.FourierPtychographyLinearOperator(
             img_size=img_size,
-            measure_size=(N_shift, 16, 16),
+            measurement_size=(N_shift, 16, 16),
             probe=probe,
             shifts=shifts,
             device=device,
@@ -702,19 +702,19 @@ def find_phase_retrieval_operator(name, device):
     elif name == "multiplexed_ptychography":
         img_size = (1, 32, 32)
         N_shift = 14
-        measure_size = (N_shift, 16, 16)
+        measurement_size = (N_shift, 16, 16)
         radius = 4
 
         y, x_coord = torch.meshgrid(
-            torch.arange(measure_size[1]), torch.arange(measure_size[2]), indexing="ij"
+            torch.arange(measurement_size[1]), torch.arange(measurement_size[2]), indexing="ij"
         )
-        center_y, center_x = measure_size[1] // 2, measure_size[2] // 2
+        center_y, center_x = measurement_size[1] // 2, measurement_size[2] // 2
         mask = ((y - center_y) ** 2 + (x_coord - center_x) ** 2) <= radius**2
         probe = mask[None, None].to(torch.complex64)
         shifts = torch.randint(-10, 10, (1, N_shift, 2))
         p = dinv.physics.MultiplexedPtychography(
             img_size=img_size,
-            measure_size=(N_shift, 16, 16),
+            measurement_size=(N_shift, 16, 16),
             probe=probe,
             shifts=shifts,
             ledidx=torch.arange(0, N_shift, 1).view(N_shift, 1),

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -712,7 +712,7 @@ def find_phase_retrieval_operator(name, device):
         mask = ((y - center_y) ** 2 + (x_coord - center_x) ** 2) <= radius**2
         probe = mask[None, None].to(torch.complex64)
         shifts = torch.randint(-10, 10, (1, N_shift, 2))
-        p = dinv.physics.MultiplexPtychography(
+        p = dinv.physics.MultiplexedPtychography(
             img_size=img_size,
             measure_size=(N_shift, 16, 16),
             probe=probe,

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -729,7 +729,7 @@ def find_phase_retrieval_operator(name, device):
         mask = ((y - center_y) ** 2 + (x_coord - center_x) ** 2) <= radius**2
         probe = mask[None, None].to(torch.complex64)
         shifts = torch.randint(-10, 10, (1, N_shift, 2))
-        p = dinv.physics.MultiplexedPtychography(
+        p = dinv.physics.MultiplexedFourierPtychography(
             img_size=img_size,
             measurement_size=(N_shift, 16, 16),
             probe=probe,

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -81,6 +81,7 @@ OPERATORS = [
     "2DParallelBeamCT",
     "2DFanBeamCT",
     "VirtualLinearPhysics",
+    "Fourier_ptychography_linear",
 ]
 
 NONLINEAR_OPERATORS = [
@@ -95,6 +96,7 @@ PHASE_RETRIEVAL_OPERATORS = [
     "random_phase_retrieval",
     "structured_random_phase_retrieval",
     "ptychography",
+    "multiplexed_ptychography",
 ]
 
 NOISES = [
@@ -565,6 +567,29 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
             device=device,
         )
         params = ["probe", "shifts"]
+    elif name == "Fourier_ptychography_linear":
+        img_size = (1, 32, 32)
+        dtype = torch.complex64
+        N_shift = 14
+        measure_size = (N_shift, 16, 16)
+        radius = 4
+        y, x_coord = torch.meshgrid(
+            torch.arange(measure_size[1]), torch.arange(measure_size[2]), indexing="ij"
+        )
+        center_y, center_x = measure_size[1] // 2, measure_size[2] // 2
+        mask = ((y - center_y) ** 2 + (x_coord - center_x) ** 2) <= radius**2
+        probe = mask[None, None].to(torch.complex64).to(device)
+        shifts = torch.randint(
+            -10, 10, (1, N_shift, 2), generator=torch.Generator().manual_seed(0)
+        )
+        p = dinv.physics.FourierPtychographyLinearOperator(
+            img_size=img_size,
+            measure_size=(N_shift, 16, 16),
+            probe=probe,
+            shifts=shifts,
+            device=device,
+        )
+        params = ["probe", "shifts"]
     else:
         raise Exception("The inverse problem chosen doesn't exist")
 
@@ -673,6 +698,27 @@ def find_phase_retrieval_operator(name, device):
         img_size = (1, 10, 10)
         p = dinv.physics.StructuredRandomPhaseRetrieval(
             img_size=img_size, output_size=img_size, n_layers=2, device=device
+        )
+    elif name == "multiplexed_ptychography":
+        img_size = (1, 32, 32)
+        N_shift = 14
+        measure_size = (N_shift, 16, 16)
+        radius = 4
+
+        y, x_coord = torch.meshgrid(
+            torch.arange(measure_size[1]), torch.arange(measure_size[2]), indexing="ij"
+        )
+        center_y, center_x = measure_size[1] // 2, measure_size[2] // 2
+        mask = ((y - center_y) ** 2 + (x_coord - center_x) ** 2) <= radius**2
+        probe = mask[None, None].to(torch.complex64)
+        shifts = torch.randint(-10, 10, (1, N_shift, 2))
+        p = dinv.physics.MultiplexPtychography(
+            img_size=img_size,
+            measure_size=(N_shift, 16, 16),
+            probe=probe,
+            shifts=shifts,
+            ledidx=torch.arange(0, N_shift, 1).view(N_shift, 1),
+            device=device,
         )
     else:
         raise Exception("The inverse problem chosen doesn't exist")
@@ -815,7 +861,6 @@ def test_operator_multiscale_wrapper(name, device, rng):
         "pansharpen",  # shape handling
         "radio",  # data type (complex)
         "3d",  # shape handling
-        "ptychography",  # ?
         "composition2",  # shape handling
         "dynamicmri",  # shape handling
         "complex_compressed_sensing",  # data type (complex)
@@ -2111,7 +2156,7 @@ def test_adjoint_autograd(name, device):
     # Compute Df^\top(z) using autograd where f(z) = A^\top z.
     y.requires_grad_()
     z = torch.randn_like(x, device=device, dtype=dtype)
-    l = (z * A_adjoint(y)).sum()
+    l = (z.conj() * A_adjoint(y)).sum().real
     l.backward()
     # \delta y := \delta_y <z, A^\top y> = Az
     delta_y = y.grad

--- a/docs/source/api/deepinv.physics.rst
+++ b/docs/source/api/deepinv.physics.rst
@@ -67,7 +67,7 @@ Operators
    deepinv.physics.SpatialUnwrapping
    deepinv.physics.StructuredRandomPhaseRetrieval
    deepinv.physics.Ptychography
-   deepinv.physics.MultiplexedPtychography
+   deepinv.physics.MultiplexedFourierPtychography
    deepinv.physics.PtychographyLinearOperator
    deepinv.physics.FourierPtychographyLinearOperator
    deepinv.physics.Scattering

--- a/docs/source/api/deepinv.physics.rst
+++ b/docs/source/api/deepinv.physics.rst
@@ -67,6 +67,7 @@ Operators
    deepinv.physics.SpatialUnwrapping
    deepinv.physics.StructuredRandomPhaseRetrieval
    deepinv.physics.Ptychography
+   deepinv.physics.MultiplexedPtychography
    deepinv.physics.PtychographyLinearOperator
    deepinv.physics.Scattering
    deepinv.physics.to_multiscale

--- a/docs/source/api/deepinv.physics.rst
+++ b/docs/source/api/deepinv.physics.rst
@@ -69,6 +69,7 @@ Operators
    deepinv.physics.Ptychography
    deepinv.physics.MultiplexedPtychography
    deepinv.physics.PtychographyLinearOperator
+   deepinv.physics.FourierPtychographyLinearOperator
    deepinv.physics.Scattering
    deepinv.physics.to_multiscale
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,6 +23,7 @@ New Features
 - Add espirit_crop parameter to control ESPIRiT multicoil MRI map estimation (:gh:`1263` by `Andrew Wang`_)
 - Add :class:`deepinv.loss.metric.BRISQUE` and :class:`deepinv.loss.metric.NIMA` no-reference image quality metrics (:gh:`1310` by `Julian Tachella`_)
 - Add :class:`deepinv.datasets.BrainWebPET` (:gh:`1286` by `Thibaut Modrzyk`_)
+- Add :class:`deepinv.physics.phase_retrieval.FourierPtychographyLinearOperator` and :class:`deepinv.physics.phase_retrieval.MultiplexedPtychography` (:gh:`1351` by `Victor Sechaud`_)
 
 Changed
 ^^^^^^^

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,7 +38,7 @@ New Features
 - Add :class:`deepinv.datasets.BrainWebPET` (:gh:`1286` by `Thibaut Modrzyk`_)
 - Add ``mask_first`` option to :class:`deepinv.physics.SpaceVaryingBlur` and :func:`deepinv.physics.functional.product_convolution2d` (:gh:`1347` by `Julian Tachella`_)
 - Add ``use_dict_output`` option to every dataset class, returning a dict ``{"x", "y", "params"}`` instead of a tuple; propagate support to all deepinv internals (:gh:`1244` by `Romain Vo`_)
-- Add :class:`deepinv.physics.phase_retrieval.FourierPtychographyLinearOperator` and :class:`deepinv.physics.phase_retrieval.MultiplexedPtychography` (:gh:`1351` by `Victor Sechaud`_)
+- Add :class:`deepinv.physics.phase_retrieval.FourierPtychographyLinearOperator` and :class:`deepinv.physics.phase_retrieval.MultiplexedFourierPtychography` (:gh:`1351` by `Victor Sechaud`_)
 
 Changed
 ^^^^^^^

--- a/docs/source/user_guide/physics/physics.rst
+++ b/docs/source/user_guide/physics/physics.rst
@@ -116,7 +116,9 @@ This is particular useful when dealing with blind inverse problems or parameter 
        | :class:`RandomPhaseRetrieval <deepinv.physics.RandomPhaseRetrieval>`
        | :class:`StructuredRandomPhaseRetrieval <deepinv.physics.StructuredRandomPhaseRetrieval>`
        | :class:`Ptychography <deepinv.physics.Ptychography>`
+       | :class:`MultiplexedFourierPtychography <deepinv.physics.MultiplexedFourierPtychography>`
        | :class:`PtychographyLinearOperator <deepinv.physics.PtychographyLinearOperator>`
+       | :class:`FourierPtychographyLinearOperator <deepinv.physics.FourierPtychographyLinearOperator>`
      - | :func:`build_probe <deepinv.physics.phase_retrieval.build_probe>`
        | :func:`generate_shifts <deepinv.physics.phase_retrieval.generate_shifts>`
 


### PR DESCRIPTION
Add new forward operators: `LinearFourierPtychography` and `MultiplexedPtychography`.
It is a more general version of `Ptychography`, and so it can be a bit redundant.


### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.