### PR TITLE
Add pretrained weights for `FFDNet`

### DIFF
--- a/deepinv/models/ffdnet.py
+++ b/deepinv/models/ffdnet.py
@@ -17,23 +17,24 @@ class FFDNet(Denoiser):
 
     The network takes into account the noise level of the input image, which is encoded as an additional input channel.
 
-    Pretrained weights can be downloaded by setting ``pretrained='download'``. They can be initialized as:
+    By default, pretrained grayscale weights are downloaded (``pretrained='download'``). Pretrained weights are
+    also available for RGB images:
 
-    - **grayscale**: ``FFDNet(n_conv_layers=15, nf=64, img_channels=1, norm=None, last_conv_bias=True, pretrained='download')``
+    - **grayscale** (default): ``FFDNet(n_conv_layers=15, nf=64, img_channels=1, norm=None, last_conv_bias=True, pretrained='download')``
     - **color**: ``FFDNet(n_conv_layers=12, nf=96, img_channels=3, norm=None, last_conv_bias=True, pretrained='download')``
 
     :param int n_conv_layers: Number of convolutional layers used. Default: 15
     :param int nf: Number of channels per convolutional layer. Default: 64
     :param int img_channels: Number of channels of your input image. Default: 1 (greyscale)
     :param bool residual_denoising: Whether to use a residual connection between input image and the network output. Default: False
-    :param str norm: normalization to use in the convolutional layers. Choose from instance_norm, batch_norm, or None (no norm). Default: batch_norm
+    :param str norm: normalization to use in the convolutional layers. Choose from instance_norm, batch_norm, or None (no norm). Default: None
     :param bool orthogonal_init: Apply orthogonal initialization to the convolutional weights. Ignored if pretrained not None. Default: True
-    :param bool last_conv_bias: Set the learnable bias on or off on the final convolution. Default: False
+    :param bool last_conv_bias: Set the learnable bias on or off on the final convolution. Default: True
     :param str, None pretrained: use a pretrained network. If ``pretrained=None``, the weights will be initialized
         at random (or orthogonally, see ``orthogonal_init``). If ``pretrained='download'``, the original FFDNet
         weights are downloaded (only available for the two initializations listed above).
         ``pretrained`` can also be set as a path to the user's own pretrained weights.
-        See :ref:`pretrained-weights <pretrained-weights>` for more details. Default: None
+        See :ref:`pretrained-weights <pretrained-weights>` for more details. Default: 'download'
     :param torch.device, str device: Device to put the model on.
     """
 
@@ -43,10 +44,10 @@ class FFDNet(Denoiser):
         nf: int = 64,
         img_channels: int = 1,
         residual_denoising: bool = False,
-        norm: str | None = "batch_norm",
+        norm: str | None = None,
         orthogonal_init: bool = True,
-        last_conv_bias: bool = False,
-        pretrained: str | None = None,
+        last_conv_bias: bool = True,
+        pretrained: str | None = "download",
         device: str | torch.device = "cpu",
     ):
         super().__init__()

--- a/deepinv/models/ffdnet.py
+++ b/deepinv/models/ffdnet.py
@@ -50,7 +50,7 @@ class FFDNet(Denoiser):
         norm = {
             "instance_norm": nn.InstanceNorm2d,
             "batch_norm": nn.BatchNorm2d,
-            None: nn.Identity(),
+            None: nn.Identity,
         }[norm]
         blocks = []
         blocks.append(

--- a/deepinv/models/ffdnet.py
+++ b/deepinv/models/ffdnet.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 
 from .base import Denoiser
 from .drunet import weights_init_drunet
+from .utils import get_weights_url, load_state_dict_from_url
 
 
 class FFDNet(Denoiser):
@@ -16,6 +17,11 @@ class FFDNet(Denoiser):
 
     The network takes into account the noise level of the input image, which is encoded as an additional input channel.
 
+    Pretrained weights can be downloaded by setting ``pretrained='download'``. They can be initialized as:
+
+    - **grayscale**: ``FFDNet(n_conv_layers=15, nf=64, img_channels=1, norm=None, last_conv_bias=True, pretrained='download')``
+    - **color**: ``FFDNet(n_conv_layers=12, nf=96, img_channels=3, norm=None, last_conv_bias=True, pretrained='download')``
+
     :param int n_conv_layers: Number of convolutional layers used. Default: 15
     :param int nf: Number of channels per convolutional layer. Default: 64
     :param int img_channels: Number of channels of your input image. Default: 1 (greyscale)
@@ -23,7 +29,11 @@ class FFDNet(Denoiser):
     :param str norm: normalization to use in the convolutional layers. Choose from instance_norm, batch_norm, or None (no norm). Default: batch_norm
     :param bool orthogonal_init: Apply orthogonal initialization to the convolutional weights. Ignored if pretrained not None. Default: True
     :param bool last_conv_bias: Set the learnable bias on or off on the final convolution. Default: False
-    :param str pretrained: Load pretrained weights from a checkpoint. Default: None
+    :param str, None pretrained: use a pretrained network. If ``pretrained=None``, the weights will be initialized
+        at random (or orthogonally, see ``orthogonal_init``). If ``pretrained='download'``, the original FFDNet
+        weights are downloaded (only available for the two initializations listed above).
+        ``pretrained`` can also be set as a path to the user's own pretrained weights.
+        See :ref:`pretrained-weights <pretrained-weights>` for more details. Default: None
     :param torch.device, str device: Device to put the model on.
     """
 
@@ -47,6 +57,7 @@ class FFDNet(Denoiser):
             raise ValueError(
                 f"norm must be one of (instance_norm, batch_norm, None), but got {norm}"
             )
+        norm_name = norm
         norm = {
             "instance_norm": nn.InstanceNorm2d,
             "batch_norm": nn.BatchNorm2d,
@@ -82,11 +93,29 @@ class FFDNet(Denoiser):
             self.apply(weights_init_drunet)  # DRUNet also applies orthogonal init.
         if pretrained is not None:
             if pretrained == "download":
-                raise ValueError(
-                    'Received pretrained "download", but FFDNet has no downloadable weights.'
+                name = ""
+                if norm_name is None and last_conv_bias and not residual_denoising:
+                    if img_channels == 1 and n_conv_layers == 15 and nf == 64:
+                        name = "ffdnet_gray.pth"
+                    elif img_channels == 3 and n_conv_layers == 12 and nf == 96:
+                        name = "ffdnet_color.pth"
+                if name == "":
+                    raise ValueError(
+                        "No pretrained weights were found online that match the chosen architecture. "
+                        "Downloadable weights are only available for "
+                        "FFDNet(n_conv_layers=15, nf=64, img_channels=1, norm=None, last_conv_bias=True) and "
+                        "FFDNet(n_conv_layers=12, nf=96, img_channels=3, norm=None, last_conv_bias=True)."
+                    )
+                url = get_weights_url(model_name="FFDNet", file_name=name)
+                state = load_state_dict_from_url(
+                    url, map_location=lambda storage, loc: storage, file_name=name
                 )
-            state = torch.load(pretrained, map_location=lambda storage, loc: storage)
+            else:
+                state = torch.load(
+                    pretrained, map_location=lambda storage, loc: storage
+                )
             self.load_state_dict(state, strict=True)
+            self.eval()
         if device is not None:
             self.to(device)
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -166,7 +166,9 @@ def choose_denoiser(name, imsize):
     elif name == "bilateral":
         out = dinv.models.BilateralFilter()
     elif name == "ffdnet":
-        out = dinv.models.FFDNet(img_channels=imsize[0], n_conv_layers=2, nf=16)
+        out = dinv.models.FFDNet(
+            img_channels=imsize[0], n_conv_layers=2, nf=16, pretrained=None
+        )
     else:
         raise Exception("Unknown denoiser")
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -1372,6 +1372,17 @@ def test_denoiser_perf(device, load_example_image):
         (dinv.models.ADMUNet(pretrained="download").to(device), (7.0, 11.5, 11.0)),
         (dinv.models.DScCP(pretrained="download").to(device), (4.5, 9.0, 3.0)),
         (
+            dinv.models.FFDNet(
+                n_conv_layers=12,
+                nf=96,
+                img_channels=3,
+                norm=None,
+                last_conv_bias=True,
+                pretrained="download",
+            ).to(device),
+            (5.5, 10.0, 9.5),
+        ),
+        (
             dinv.models.DiffusersDenoiserWrapper(
                 mode_id="google/ddpm-ema-celebahq-256"
             ).to(device),

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Current
 
 New Features
 ^^^^^^^^^^^^
+- Add downloadable pretrained weights to :class:`deepinv.models.FFDNet` (:gh:`1350` by `Vicky De Ridder`_)
 
 Changed
 ^^^^^^^

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,10 +8,11 @@ Current
 
 New Features
 ^^^^^^^^^^^^
-- Add downloadable pretrained weights to :class:`deepinv.models.FFDNet` (:gh:`1350` by `Vicky De Ridder`_)
+- Add downloadable pretrained weights to :class:`deepinv.models.FFDNet` (:gh:`1357` by `Vicky De Ridder`_)
 
 Changed
 ^^^^^^^
+- :class:`deepinv.models.FFDNet` default network parameters changed, to allow pretrained weights by default (:gh:`1357` by `Vicky De Ridder`_)
 
 Fixed
 ^^^^^

--- a/docs/source/user_guide/reconstruction/denoisers.rst
+++ b/docs/source/user_guide/reconstruction/denoisers.rst
@@ -129,7 +129,7 @@ See :ref:`pretrained-weights` for more information on pretrained denoisers.
    * - :class:`deepinv.models.FFDNet`
      - CNN
      - Any C; H,W must be even
-     - No
+     - RGB, grayscale
      - Yes
      - No
 .. _non-learned-denoisers:

--- a/docs/source/user_guide/reconstruction/pretrained-models.rst
+++ b/docs/source/user_guide/reconstruction/pretrained-models.rst
@@ -100,6 +100,12 @@ Click on the model name to learn more about the type of model and use `pretraine
      -
      - Alternative weights trained on noise level 2.0/255 with Lipschitz constraint to ensure approximate firm nonexpansiveness:
        `Non-expansive DnCNN grayscale weights <https://huggingface.co/deepinv/dncnn/resolve/main/dncnn_sigma2_lipschitz_gray.pth?download=true>`_, `Non-expansive DnCNN color weights <https://huggingface.co/deepinv/dncnn/resolve/main/dncnn_sigma2_lipschitz_color.pth?download=true>`_.
+   * - :class:`deepinv.models.FFDNet`
+     - Denoiser
+     - Weights from the original FFDNet paper, trained on noise levels in [0, 75]/255.
+       `FFDNet grayscale weights <https://huggingface.co/deepinv/FFDNet/resolve/main/ffdnet_gray.pth?download=true>`_, and
+       `FFDNet color weights <https://huggingface.co/deepinv/FFDNet/resolve/main/ffdnet_color.pth?download=true>`_.
+
    * - :class:`deepinv.models.DRUNet`
      - Denoiser
      - Default weights trained with deepinv `(logs) <https://wandb.ai/matthieu-terris/drunet?workspace=user-matthieu-terris>`_, trained on noise levels in [0, 20]/255


### PR DESCRIPTION
- Add the original `FFDNet` weights, modified from https://github.com/cszn/KAIR/tree/master to fit our implementation
- Fix a bug that makes `FFDNet` init fail when `norm=None`


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.