### PR TITLE
Add Time-of-Flight to PET physics

### DIFF
--- a/deepinv/physics/functional/tomography_subsets.py
+++ b/deepinv/physics/functional/tomography_subsets.py
@@ -181,6 +181,7 @@ def split_physics(
                 views=physics.views.index_select(0, idx).to(device),
                 background=physics.background.index_select(view_dim, idx).to(device),
                 attenuation=physics.attenuation.index_select(view_dim, idx).to(device),
+                tof_info=physics.tof_info,
             )
             for idx in indices
         ]

--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -258,12 +258,15 @@ class PET(LinearPhysics):
                 f"Input volume must have 1 channel, got {x.shape[1]} channels"
             )
         self.update_parameters(attenuation=attenuation, background=background)
-        # print("attenuation!!!!", self.attenuation.shape, self.attenuation.sum())
+        print("attenuation!!!!", self.attenuation.shape, self.attenuation.sum())
         if self.tof_info is None:
             attenuation = self.attenuation
         else:
-            attenuation = self.attenuation.sum(axis=-1).unsqueeze(-1)
-        # print("attenuation2!!!!", attenuation.shape)
+            if self.is_2d:
+                attenuation = self.attenuation.sum(axis=-1).unsqueeze(-1)
+            else:
+                attenuation = self.attenuation.sum(axis=-1).unsqueeze(-1)
+        print("attenuation2!!!!", attenuation.shape)
         if self.is_2d:
             if self.tof_info is None:
                 x = x.unsqueeze(-1)
@@ -276,9 +279,9 @@ class PET(LinearPhysics):
                 # print("qwe", x.shape, attenuation.shape)
             #     # attenuation = attenuation[..., 0]
 
-        # print("A()")
-        # print(x.shape, attenuation.shape)
-        # print(LinearSingleChannelOperator.apply(x, self.pet_lin_op).shape)
+        print("A()")
+        print("x and att", x.shape, attenuation.shape)
+        print("Forward", LinearSingleChannelOperator.apply(x, self.pet_lin_op).shape)
         out = LinearSingleChannelOperator.apply(x, self.pet_lin_op) * attenuation
         # print("gege", out.sum(), x.sum(), attenuation.mean())
         # print(self.proj(x).sum())
@@ -319,7 +322,9 @@ class PET(LinearPhysics):
             else:
                 y = y.unsqueeze(-2)
                 attenuation = attenuation.unsqueeze(-2)
-        # print("tyty", y.shape, attenuation.shape, y.sum(), attenuation.sum())
+        else:
+            attenuation = attenuation.squeeze(-1)
+        print("tyty", y.shape, attenuation.shape, y.sum(), attenuation.sum())
         # print("uio", (y*attenuation).sum(), self.operator_norm.shape)
         out = (
             AdjointLinearSingleChannelOperator.apply(y * attenuation, self.pet_lin_op)
@@ -327,10 +332,12 @@ class PET(LinearPhysics):
         )
         # print("derp", out.sum(), out.shape)
         if self.is_2d:
-            if self.tof_info is None:
-                out = out.squeeze(-1)
-            else:
-                 out = out.squeeze(-2)
+            out = out.squeeze(-1)
+            # if self.tof_info is None:
+            #     out = out.squeeze(-1)
+            # else:
+            #      out = out.squeeze(-2)
+        # print("derp2", out.sum(), out.shape)
         return out
 
     def plot_geometry(self):
@@ -412,7 +419,9 @@ class PET(LinearPhysics):
                     else:
                         proj_att = proj_att.squeeze(-2).sum(axis=-1)
                 print("xcv2.9", proj_att.shape, self.attenuation.shape)
-                self.attenuation = torch.exp(-proj_att).unsqueeze(-1)
+                self.attenuation = torch.exp(-proj_att)
+                if self.tof_info is not None and self.is_2d == True:
+                    self.attenuation = self.attenuation.unsqueeze(-1)
                 print("xcv3", proj_att.shape, self.attenuation.shape)
                 print("xcv3.5", proj_att.min(), proj_att.max(), self.attenuation.min(), self.attenuation.max())
             else:

--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -124,6 +124,7 @@ class PET(LinearPhysics):
         views: torch.Tensor | None = None,
         background: torch.Tensor | None = None,
         attenuation: torch.Tensor | None = None,
+        tof_info: None | parallelproj.tof.TOFParameters = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -182,6 +183,13 @@ class PET(LinearPhysics):
         self.proj = parallelproj.RegularPolygonPETProjector(
             lor_desc, img_shape=img_size, voxel_size=voxel_size, views=views
         )
+
+        if tof_info is not None:
+            self.tof_info = tof_info
+            self.proj.tof_parameters = self.tof_info
+        else:
+            self.tof_info = None
+
         # store the views as a buffer but does not add it to state dict since its part
         # of parallelproj
         self.register_buffer("views", self.proj.views, persistent=False)
@@ -196,7 +204,11 @@ class PET(LinearPhysics):
                 .unsqueeze(0)
             )
             if self.is_2d:
-                background = background.squeeze(-1)
+                if self.tof_info is None:
+                    background = background.squeeze(-1)
+                else:
+                    background = background.squeeze(-2)
+        # print("background", background.shape)
 
         # Default attenuation to zero in image space (no attenuation)
         if attenuation is None:
@@ -217,6 +229,7 @@ class PET(LinearPhysics):
         self.register_buffer("operator_norm", torch.ones(1, device=device))
         self.register_buffer("background", background)
         self.register_buffer("attenuation", attenuation)
+        # print("fgh", background.shape, attenuation.shape)
         self.update_parameters(background=background, attenuation=attenuation)
         self.noise_model = PoissonNoise(gain=gain, normalize=normalize_counts)
         self.to(device)
@@ -245,19 +258,42 @@ class PET(LinearPhysics):
                 f"Input volume must have 1 channel, got {x.shape[1]} channels"
             )
         self.update_parameters(attenuation=attenuation, background=background)
-        attenuation = self.attenuation
+        # print("attenuation!!!!", self.attenuation.shape, self.attenuation.sum())
+        if self.tof_info is None:
+            attenuation = self.attenuation
+        else:
+            attenuation = self.attenuation.sum(axis=-1).unsqueeze(-1)
+        # print("attenuation2!!!!", attenuation.shape)
         if self.is_2d:
-            x = x.unsqueeze(-1)
-            attenuation = attenuation.unsqueeze(-1)
+            if self.tof_info is None:
+                x = x.unsqueeze(-1)
+                attenuation = attenuation.unsqueeze(-1)
+            else:
+                # print("doc", x.shape, attenuation.shape)
+                if x.ndim < 5:
+                    x = x.unsqueeze(-1)
+                attenuation = attenuation.unsqueeze(-2)
+                # print("qwe", x.shape, attenuation.shape)
+            #     # attenuation = attenuation[..., 0]
 
+        # print("A()")
+        # print(x.shape, attenuation.shape)
+        # print(LinearSingleChannelOperator.apply(x, self.pet_lin_op).shape)
         out = LinearSingleChannelOperator.apply(x, self.pet_lin_op) * attenuation
+        # print("gege", out.sum(), x.sum(), attenuation.mean())
+        # print(self.proj(x).sum())
         if self.is_2d:
-            out = out.squeeze(-1)
+            if self.tof_info is None:
+                out = out.squeeze(-1)
+            else:
+                out = out.squeeze(-2)
 
         out /= self.operator_norm
 
         if add_background:
+            # print("dede", out.shape, self.background.shape, self.background.sum())
             out = out + self.background
+        # print("bebe", out.shape, out.sum())
         return out
 
     def A_adjoint(
@@ -277,14 +313,24 @@ class PET(LinearPhysics):
         self.update_parameters(attenuation=attenuation, background=background)
         attenuation = self.attenuation
         if self.is_2d:
-            y = y.unsqueeze(-1)
-            attenuation = attenuation.unsqueeze(-1)
+            if self.tof_info is None:
+                y = y.unsqueeze(-1)
+                attenuation = attenuation.unsqueeze(-1)
+            else:
+                y = y.unsqueeze(-2)
+                attenuation = attenuation.unsqueeze(-2)
+        # print("tyty", y.shape, attenuation.shape, y.sum(), attenuation.sum())
+        # print("uio", (y*attenuation).sum(), self.operator_norm.shape)
         out = (
             AdjointLinearSingleChannelOperator.apply(y * attenuation, self.pet_lin_op)
             / self.operator_norm
         )
+        # print("derp", out.sum(), out.shape)
         if self.is_2d:
-            out = out.squeeze(-1)
+            if self.tof_info is None:
+                out = out.squeeze(-1)
+            else:
+                 out = out.squeeze(-2)
         return out
 
     def plot_geometry(self):
@@ -347,18 +393,30 @@ class PET(LinearPhysics):
             attenuation = attenuation.to(self.scanner.dev)
             n = len(self.img_size)
             is_image_space = tuple(attenuation.shape[-n:]) == tuple(self.img_size)
+            print("xcv", is_image_space, attenuation.shape)
             if is_image_space:
                 # Add missing batch and channel dimensions before projection.
                 while attenuation.ndim < n + 2:
                     attenuation = attenuation.unsqueeze(0)
+                print("xcv2", attenuation.shape)
                 if self.is_2d:
-                    attenuation = attenuation.unsqueeze(-1)
-
+                    if self.tof_info is None:
+                        attenuation = attenuation.unsqueeze(-1)
+                    else:
+                        attenuation = attenuation.unsqueeze(-1)
                 proj_att = LinearSingleChannelOperator.apply(attenuation, self.proj)
+                print("xcv2.5", attenuation.shape, attenuation.min(), attenuation.max(), proj_att.shape)
                 if self.is_2d:
-                    proj_att = proj_att.squeeze(-1)
-                self.attenuation = torch.exp(-proj_att)
+                    if self.tof_info is None:
+                        proj_att = proj_att.squeeze(-1)
+                    else:
+                        proj_att = proj_att.squeeze(-2).sum(axis=-1)
+                print("xcv2.9", proj_att.shape, self.attenuation.shape)
+                self.attenuation = torch.exp(-proj_att).unsqueeze(-1)
+                print("xcv3", proj_att.shape, self.attenuation.shape)
+                print("xcv3.5", proj_att.min(), proj_att.max(), self.attenuation.min(), self.attenuation.max())
             else:
+                print("xcv4", attenuation.shape)
                 self.attenuation = attenuation
 
             if self.normalize:

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -31,7 +31,9 @@ OPERATORS = [
     "deblur_circular",
     "deblur_reflect",
     "pet_2d",
+    "pet_2d_tof",
     "pet_3d",
+    "pet_3d_tof",
     "deblur_replicate",
     "deblur_constant",
     "composition",
@@ -229,6 +231,34 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
         )  # B,N,D,H,W where N is coils and D is depth
         p = MultiCoilMRI(coil_maps=maps, img_size=img_size, three_d=True, device=device)
         params = ["mask"]
+    elif name == "pet_2d_tof":
+        # dsa todo todo
+        pytest.importorskip(
+            "parallelproj",
+            reason="This test requires parallelproj. It should be "
+            "installed with `conda install -c conda-forge parallelproj`",
+        )
+        img_size = (1, 16, 16) if imsize is None else imsize  # C,H,W
+        attenuation = torch.full(img_size, 0.01, device=device)
+        import parallelproj
+        tof_info = parallelproj.tof.TOFParameters(
+            num_tofbins=5,
+            tofbin_width=80.0,
+            sigma_tof=10.0,
+            num_sigmas=3.0,
+        )
+        p = dinv.physics.PET(
+            img_size,
+            normalize=True,
+            device=device,
+            attenuation=attenuation,
+            tof_info=tof_info,
+        )
+        assert not torch.allclose(p.attenuation, torch.ones_like(p.attenuation))
+        p.update(attenuation=torch.ones_like(p.attenuation))
+        p.noise_model = dinv.physics.ZeroNoise()
+        p.normalize = False  # stop auto-normalize to compute gradients wrt to attn
+        params = ["background", "attenuation"]
     elif name == "pet_2d":
         pytest.importorskip(
             "parallelproj",
@@ -248,6 +278,29 @@ def find_operator(name, device, imsize=None, get_physics_param=False):
         p.noise_model = dinv.physics.ZeroNoise()
         p.normalize = False  # stop auto-normalize to compute gradients wrt to attn
         params = ["background", "attenuation"]
+    elif name == "pet_3d_tof":
+        pytest.importorskip(
+            "parallelproj",
+            reason="This test requires parallelproj. It should be "
+            "installed with `conda install -c conda-forge parallelproj`",
+        )
+        img_size = (1, 16, 16, 16) if imsize is None else imsize  # C,H,W
+        import parallelproj
+        tof_info = parallelproj.tof.TOFParameters(
+            num_tofbins=5,
+            tofbin_width=80.0,
+            sigma_tof=10.0,
+            num_sigmas=3.0,
+        )
+        p = dinv.physics.PET(
+            img_size,
+            normalize=True,
+            device=device,
+            tof_info=tof_info,
+        )
+        p.noise_model = dinv.physics.ZeroNoise()
+        p.normalize = False  # stop auto-normalize to compute gradients wrt to attn
+        params = ["attenuation", "background"]
     elif name == "pet_3d":
         pytest.importorskip(
             "parallelproj",
@@ -2097,7 +2150,9 @@ def test_adjoint_autograd(name, device):
         "radio",
         "radio_weighted",
         "pet_2d",
+        "pet_2d_tof",
         "pet_3d",
+        "pet_3d_tof",
     }:
         pytest.skip(f"Operator {name} is not supported by adjoint_function.")
 
@@ -2393,6 +2448,7 @@ MULTISCALE_EXCLUSION = [
     "3DMRI",
     "3DMultiCoilMRI",
     "pet_3d",
+    "pet_3d_tof",
     "DynamicMRI",
     "fast_singlepixel",
     "fast_singlepixel_zig_zag",
@@ -2410,6 +2466,7 @@ def test_multiscale_coarse_adjointness(name, device):
         "MRI" in name
         or "cassi" in name
         or "pet_2d" == name
+        or "pet_2d_tof" == name
         or "ptychography_linear" == name
         or "hyperspectral_unmixing" == name
         or "composition2" == name
@@ -2447,6 +2504,7 @@ def test_multiscale_A_adjoint_A(name, device):
         "MRI" in name
         or "cassi" in name
         or "pet_2d" == name
+        or "pet_2d_tof" == name
         or "ptychography_linear" == name
         or "hyperspectral_unmixing" == name
         or "composition2" == name

--- a/examples/physics/demo_pet2dTof.py
+++ b/examples/physics/demo_pet2dTof.py
@@ -1,0 +1,431 @@
+r"""
+Positron emission tomography (PET) in 2D
+========================================
+
+This demo shows how to define a non time-of-flight PET scanner, simulate measurements
+and reconstruct an image from them.
+
+The PET forward model is defined as
+
+.. math::
+
+    y \sim \gamma \mathcal{P}\left(\frac{c \circ H(g*x) + b}{\gamma}\right)
+
+where :math:`H \in \mathbb{R}_{+}^{m \times n}` is the projection operator,
+:math:`g \in \mathbb{R}_{+}^{n}` is a Gaussian blur kernel, :math:`x\in\mathbb{R}_{+}^{n}`
+is the emission image, :math:`b \in \mathbb{R}_{+}^{m}` is the (expected) background,
+:math:`\mathcal{P}` denotes Poisson noise with gain :math:`\gamma > 0`,
+:math:`c=\exp(-H\mu)\in \mathbb{R}_{+}^{m}` is an (optional) attenuation term
+with :math:`\mu \in \mathbb{R}_{+}^{n}` an attenuation map (typically obtained through an auxiliary CT scan).
+
+.. note::
+
+    This operator requires the `parallelproj` package to be installed.
+    This in turn requires :ref:`installing deepinv via pixi or conda <install>`,
+    but not pypi/uv (as `parallelproj` is not currently available on pypi).
+
+    If you are working on a conda environment, you can install `parallelproj` as
+
+    ::
+
+        conda install -c conda-forge parallelproj
+
+
+    If you are working on a pixi installation, simply do
+
+    ::
+
+        pixi install -e full
+
+    which installs all optional dependencies.
+
+    Check the `parallelproj` documentation for more details: https://parallelproj.readthedocs.io/en/stable/.
+
+"""
+
+# %%
+import time
+
+import matplotlib.pyplot as plt
+import deepinv as dinv
+from deepinv.physics import PET
+from deepinv.utils.phantoms import generate_pet_phantom
+import torch
+import parallelproj
+from array_api_compat import torch as torch_compat
+
+
+
+# %%
+# Setup a minimal non-TOF PET projector
+# -------------------------------------
+#
+# Here we define each pixel to have size :math:`3\times 3` mm
+# such that the total area to reconstruct is of size :math:`38.4\times 38.4` cm
+# which fits approximately a slice of a human chest.
+#
+# The maximum achievable resolution (in high count settings) is typically proportional to the full-width at half
+# maximum (FWHM) of the Gaussian blur kernel, which here is set to 4 mm.
+#
+# We use a PET scanner with a single ring of detectors, which is a polygon of
+# 32 sides, with each side containing 16 detectors. This gives us a total of 32*16=512 detectors in total.
+#
+# .. tip::
+#
+#       You can play with different geometries and voxel sizes to get a good grasp of
+#       the scanner geometry, and visualize it with `physics.plot_geometry()`
+#
+# .. note::
+#
+#      In this example, we normalize the forward operator :math:`\|A\|=1` (`normalize=True`) and
+#      the Poisson counts to be between 0 and 1 (`normalize_counts=True`), to simplify reconstruction.
+#      If you want to use the operator with real PET measurements, you will need to
+#      carefully handle the normalization. See also the :ref:`unnormalized 3D PET example <sphx_glr_auto_examples_physics_demo_pet3d.py>`.
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+img_size = (128, 128)
+voxel_size = (3, 3)
+
+# number of sides of the polygon approximating a circle
+num_sides = 32
+
+# number of detectors per polygon side
+num_lor_endpoints_per_side = 16
+
+# choose a single ring for 2D
+num_rings = 1
+
+scanner = parallelproj.pet_scanners.DemoPETScannerGeometry(
+    torch_compat,
+    dev=device,
+    num_rings=num_rings,
+    num_sides=num_sides,
+    num_lor_endpoints_per_side=num_lor_endpoints_per_side,
+)
+
+# dsa tof 
+# tof_info = parallelproj.tof.TOFParameters()
+tof_info = parallelproj.tof.TOFParameters(
+    num_tofbins=5,
+    tofbin_width=80.0,
+    sigma_tof=10.0,
+    num_sigmas=3.0,
+)
+# tof_info = parallelproj.tof.TOFParameters(
+#     num_tofbins=11,
+#     tofbin_width=40.0,
+#     sigma_tof=10.0,
+#     num_sigmas=3.0,
+# )
+
+# gain of the device:
+# higher gains are associated to lower dose and/or shorter acquisition times,
+# while lower gains are associated to higher dose and/or longer acquisition times.
+# larger gain -> more poisson noise -> harder reconstruction
+gain = 0.001
+
+# FWHM of the Gaussian blur kernel in mm
+fwhm_data_mm = 4
+
+physics = PET(
+    device=device,
+    voxel_size=voxel_size,
+    fwhm_data_mm=fwhm_data_mm,
+    scanner=scanner,
+    img_size=img_size,
+    normalize_counts=True,
+    normalize=True,
+    gain=gain,
+    tof_info=tof_info,
+)
+
+physics.plot_geometry()
+
+# %%
+# Define a phantom and attenuation map
+# ------------------------------------
+#
+# We define a 2D phantom and attenuation map, whose shape is the same as the phantom.
+#
+# In practice, the attenuation is typically obtained with an auxiliary CT scan of the patient.
+
+x, attenuation = generate_pet_phantom(img_size, device=device)
+
+dinv.utils.plot(
+    [x, attenuation], titles=["Emission image", "Attenuation image"], figsize=(8, 4)
+)
+
+# %%
+# Simulating measurements
+# -----------------------
+# The shape of measurements is approximately `(B, 1, N, N/2)` where
+# `N=num_lor_endpoints_per_side*num_sides` is the number of detectors per ring.
+# This provides one measurement for every possible Line of Response (LOR), or in other words 'rays', connecting
+# two detectors in the scanner, which are arranged in a sinogram format, with the first axis
+# corresponding to the angle of the ray and the second axis corresponding to the distance of the ray to the center of the field of view.
+#
+# .. tip::
+#
+#     The size of measurements is independent of the chosen `img_size`
+
+y = physics(x)
+
+# yPure = physics.A(x)
+# print(x.shape)
+# yRaw = physics.A(x)
+# print("yRaw", yRaw.shape, yRaw.sum())
+# sensitivities = physics.A_adjoint(torch.ones_like(y))
+
+print(
+    f"Measurements shape={tuple(y.shape)}, range=({y.min().item():.2f},{y.max().item():.2f})"
+)
+
+dinv.utils.plot(
+    [y.sum(axis=-1), y[..., 0], y[..., 1], y[..., 2], y[..., 3], y[..., 4]], ["meas.", "tof 1", "tof 2", "tof 3", "tof 4", "tof 5"]
+)
+
+# %%
+# Setting up background and attenuation
+# -------------------------------------
+# The attenuation term reduces the amount of signal measured in rays that
+# go through highly attenuating regions, such as bones. This makes the reconstruction more challenging, but also more realistic.
+#
+# In PET, we generally have access to a realization of the background,
+# i.e., :math:`\tilde{s} \sim \mathcal{P}(s)`, which is a Poisson random variable with mean :math:`s`.
+#
+# Both attenuation and background are stored as "physics parameters" which are patient dependent
+# and can be updated via :meth:`physics.update(...) <deepinv.physics.Physics.update>` or by passing them as kwargs in
+# :meth:`physics(x, ...) <deepinv.physics.Physics.forward>`, :meth:`physics.A(x, ...) <deepinv.physics.Physics.A>` or
+# :meth:`physics.A_adjoint(y, ...) <deepinv.physics.LinearPhysics.A_adjoint>`.
+#
+# .. note::
+#
+#   The attenuation is stored in the physics in sinogram space as :math:`\exp(-\mu)` to speed up computations,
+#   but it can be provided either in image space, i.e., :math:`\mu`, to the physics, or in sinogram space, i.e., :math:`\exp(-\mu)`.
+#   The class figures out the attenuation space by comparing it to `img_size`.
+
+yRaw = physics.A(x)
+expected_background = torch.ones_like(y) * x.max() * 0.05
+background = physics.generate_background(expected_background)
+physics.update(attenuation=attenuation, background=background)
+y = physics(x)
+print(y.sum())
+y2 = y - background
+print(physics.attenuation.shape, y.shape, y2.shape)
+dinv.utils.plot(
+    [physics.attenuation.sum(axis=-1), y.sum(axis=-1), y2.sum(axis=-1), yRaw.sum(axis=-1)], ["sino. atten.", "meas.", "corrected meas.", "True sino"]
+)
+dinv.utils.plot(
+    [physics.attenuation[..., 0], y[..., 0], y2[..., 0], yRaw[..., 0]], ["sino. atten.", "meas.", "corrected meas.", "True sino"]
+)
+
+
+# %%
+# Backprojection and sensitivities
+# --------------------------------
+# We backproject the data to visualize the sensitivity map of the scanner.
+# The sensitivity map is defined as the back-projection of a sinogram of ones :math:`s = A^\top \mathbf{1}`,
+# which corresponds to the number of rays intersecting each voxel.
+#
+# Here we also obtain a simple linear least-squares reconstruction by using
+# :meth:`A_dagger <deepinv.physics.LinearPhysics.A_dagger>`.
+
+with torch.no_grad():
+    x_dag = physics.A_dagger(y - background)
+    sensitivities = physics.A_adjoint(torch.ones_like(y))
+
+print(f"Norm operator: {physics.compute_norm(x):.2f}")
+
+print(x_dag.shape, sensitivities.shape)
+dinv.utils.plot([x_dag, sensitivities], ["pseudoinverse", "sensitivities"])
+
+# %%
+# MLEM reconstruction
+# -------------------
+#
+# We run the standard MLEM reconstruction algorithm :footcite:p:`sheppMaximumLikelihoodReconstruction1982`
+# to obtain a reconstructed emission volume.
+#
+# The algorithm can be seen as a preconditioned gradient descent on the negative log-likelihood of the Poisson model:
+#
+# .. math::
+#
+#   x^{(k+1)} = x^{(k)} - P \nabla f(Ax^{(k)}+b,y)
+#
+# where :math:`f` is the Poisson data-fidelity term, :math:`P=\mathrm{diag}(\frac{x}{A^T\mathbf{1}})` is a preconditioner
+# and :math:`b` is the background.
+
+gain = physics.noise_model.gain
+mlem_iter = 40
+
+
+def _sync():
+    if torch.device(device).type == "cuda":
+        torch.cuda.synchronize()
+
+
+nrmse = dinv.metric.NRMSE()
+
+
+# With ``denormalize=True``, the likelihood is evaluated in the count domain.
+# The background produced by PET is in the normalized measurement domain, so it
+# must be divided by the gain as well.
+data_fidelity = dinv.optim.PoissonLikelihood(
+    gain=gain,
+    bkg=background / gain,
+    denormalize=True,
+)
+model_mlem = dinv.optim.MLEM(
+    data_fidelity=data_fidelity,
+    prior=None,
+    max_iter=mlem_iter,
+    custom_metrics={
+        "nrmse": lambda _values, _x_prev, x_cur: nrmse(x_cur.unsqueeze(0), x).item()
+    },
+)
+
+with torch.no_grad():
+    _sync()
+    start = time.perf_counter()
+    x_mlem, metrics_mlem = model_mlem(
+        y, physics, init=torch.ones_like(x), compute_metrics=True
+    )
+    _sync()
+    mlem_time = time.perf_counter() - start
+
+print(f"MLEM runtime: {mlem_time:.2f} s for {mlem_iter} iterations")
+
+psnr = dinv.metric.PSNR(max_pixel=None)
+
+psnr_mlem = psnr(x_mlem, x)
+psnr_dag = psnr(x_dag, x)
+nrmse_mlem = nrmse(x_mlem, x)
+nrmse_dag = nrmse(x_dag, x)
+
+dinv.utils.plot(
+    [x, x_mlem, x_dag],
+    ["Ground truth", f"MLEM ({mlem_iter} it.)", "L2 pseudoinv."],
+    subtitles=[
+        "Reference",
+        f"PSNR: {psnr_mlem.item():.2f} dB\n" f"NRMSE: {100 * nrmse_mlem.item():.2f}%",
+        f"PSNR: {psnr_dag.item():.2f} dB\n" f"NRMSE: {100 * nrmse_dag.item():.2f}%",
+    ],
+    rescale_mode="clip",
+    vmin=0,
+    vmax=x.max().item(),
+    figsize=(8, 4),
+    cbar=True,
+)
+
+# %%
+# Accelerating MLEM with ordered subsets
+# ---------------------------------------
+#
+# One MLEM iteration evaluates the forward and adjoint operators using the complete
+# PET acquisition. This can be slow when the scanner geometry and its measurements
+# are large, especially in 3D.
+#
+# Ordered-Subsets Expectation-Maximization (OSEM) :footcite:p:`hudsonAcceleratedImageReconstruction1994`
+# partitions the measurements and the forward operator into :math:`L` matching angular subsets indexed by
+# :math:`l=1,\ldots,L`:
+#
+# .. math::
+#
+#   y = (y_1,\ldots,y_L), \qquad
+#   A = (A_1^\top,\ldots,A_L^\top)^\top.
+#
+# OSEM applies an EM update successively with each pair :math:`(y_l,A_l)`. Each subset
+# update is cheaper than a full MLEM iteration and updates the complete image, so OSEM
+# generally reaches a useful reconstruction in fewer passes over the complete acquisition.
+
+# %%
+# OSEM reconstruction
+# -------------------
+#
+# OSEM accepts the full measurements and physics and splits them internally.
+# Alternatively, pre-split inputs can be created with  :func:`deepinv.physics.split_measurements`
+# and :func:`deepinv.physics.split_physics` and passed directly to :class:`deepinv.optim.OSEM`.
+
+osem_iter = 5
+num_subsets = 8
+
+model_osem = dinv.optim.OSEM(
+    data_fidelity=data_fidelity,
+    prior=None,
+    max_iter=osem_iter,
+    num_subsets=num_subsets,
+    custom_metrics={
+        "nrmse": lambda _values, _x_prev, x_cur: nrmse(x_cur.unsqueeze(0), x).item()
+    },
+)
+
+with torch.no_grad():
+    _sync()
+    start = time.perf_counter()
+    x_osem, metrics_osem = model_osem(
+        y,
+        physics,
+        init=torch.ones_like(x),
+        compute_metrics=True,
+    )
+    _sync()
+    osem_time = time.perf_counter() - start
+
+print(
+    f"OSEM runtime: {osem_time:.2f} s "
+    f"for {osem_iter} iterations "
+    f"({num_subsets} subsets)"
+)
+print(f"Reconstruction speedup MLEM/OSEM: {mlem_time / osem_time:.2f}x")
+
+psnr_osem = psnr(x_osem, x)
+nrmse_osem = nrmse(x_osem, x)
+
+dinv.utils.plot(
+    [x, x_mlem, x_osem],
+    [
+        "Ground truth",
+        f"MLEM ({mlem_iter} it.)",
+        f"OSEM ({osem_iter} it.)",
+    ],
+    subtitles=[
+        "Reference",
+        f"PSNR: {psnr_mlem.item():.2f} dB\n" f"NRMSE: {100 * nrmse_mlem.item():.2f}%",
+        f"PSNR: {psnr_osem.item():.2f} dB\n" f"NRMSE: {100 * nrmse_osem.item():.2f}%",
+    ],
+    rescale_mode="clip",
+    vmin=0,
+    vmax=x.max().item(),
+    figsize=(8, 4),
+    cbar=True,
+)
+
+# We also compare the Poisson objective and NRMSE after every iteration.
+fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+axes[0].plot(metrics_mlem["cost"][0], label="MLEM")
+axes[0].plot(metrics_osem["cost"][0], label="OSEM")
+axes[0].set_xlabel("Iteration")
+axes[0].set_ylabel("Poisson NLL")
+axes[0].legend()
+
+axes[1].plot([100 * v for v in metrics_mlem["nrmse"][0]], label="MLEM")
+axes[1].plot([100 * v for v in metrics_osem["nrmse"][0]], label="OSEM")
+axes[1].set_xlabel("Iteration")
+axes[1].set_ylabel("NRMSE (%)")
+axes[1].yaxis.set_major_formatter("{x:.0f}%")
+axes[1].legend()
+fig.tight_layout()
+
+# %%
+# What next?
+# ------------
+# Now that you master the basics of PET, you can go further by
+#
+# - Check out the :ref:`3D PET example <sphx_glr_auto_examples_physics_demo_pet3d.py>`.
+# - Reconstructing PET with learning-based methods (:ref:`PnP <iterative>`, :ref:`diffusion <sampling>`, :ref:`unrolled <unfolded>`, etc.)
+# - Playing with the scanner setup: changing number of detectors, voxel size, etc.
+
+# %%
+# :References:
+#
+# .. footbibliography::

--- a/examples/physics/demo_pet3dTof.py
+++ b/examples/physics/demo_pet3dTof.py
@@ -91,13 +91,13 @@ img_size = (128, 128, 24)
 voxel_size = (3, 3, 3)
 
 # number of sides of the polygon approximating a circle
-num_sides = 16 # dsa was 32
+num_sides = 32 # dsa was 32
 
 # number of detectors per polygon side
-num_lor_endpoints_per_side = 8 # dsa was 16 
+num_lor_endpoints_per_side = 16 # dsa was 16 
 
 # number of rings of detectors on the depth axes
-num_rings = 7
+num_rings = 8
 
 scanner = parallelproj.pet_scanners.DemoPETScannerGeometry(
     torch_compat,
@@ -110,8 +110,8 @@ scanner = parallelproj.pet_scanners.DemoPETScannerGeometry(
 
 # dsa tof 
 tof_info = parallelproj.tof.TOFParameters(
-    num_tofbins=5,
-    tofbin_width=80.0,
+    num_tofbins=23,
+    tofbin_width=20.0,
     sigma_tof=10.0,
     num_sigmas=3.0,
 )

--- a/examples/physics/demo_pet3dTof.py
+++ b/examples/physics/demo_pet3dTof.py
@@ -1,0 +1,420 @@
+r"""
+Positron emission tomography (PET) in 3D
+========================================
+
+This demo shows how to define a non time-of-flight PET scanner, simulate measurements
+and reconstruct a volume from them.
+
+The (unnormalized) PET forward model is defined as
+
+.. math::
+
+    y \sim \gamma \mathcal{P}(c \circ H(g*x) + b)
+
+where :math:`H \in \mathbb{R}_{+}^{m \times n}` is the projection operator,
+:math:`g \in \mathbb{R}_{+}^{n}` is a Gaussian blur kernel, :math:`x\in\mathbb{R}_{+}^{n}`
+is the emission image, :math:`b \in \mathbb{R}_{+}^{m}` is the (expected) background,
+:math:`\mathcal{P}` denotes Poisson noise,
+:math:`c=\exp(-H\mu)\in \mathbb{R}_{+}^{m}` is an (optional) attenuation term
+with :math:`\mu \in \mathbb{R}_{+}^{n}` an attenuation map (typically obtained through an auxiliary CT scan).
+
+.. note::
+
+    In this example, we consider the unnormalized case, which allows to obtain quantitative reconstructions (i.e., :math:`x` has real
+    physical units). The operator also can be used in a normalized setting (forcing :math:`\|A\|_2=1` and normalizing counts to be between 0 and 1).
+    See also the :ref:`normalized 2D PET example <sphx_glr_auto_examples_physics_demo_pet2d.py>`.
+    When using deep learning-based reconstruction methods, it is often easier to consider the normalized case, but a special attention is required
+    to denormalize the reconstructions and obtain physical units.
+
+.. tip::
+
+    If you prefer to get started with PET on a simpler 2D problem, please check out :ref:`the 2D PET demo <sphx_glr_auto_examples_physics_demo_pet2d.py>`.
+
+.. note::
+
+    This operator requires the `parallelproj` package to be installed.
+    This in turn requires :ref:`installing deepinv via pixi or conda <install>`,
+    but not pypi/uv (as `parallelproj` is not currently available on pypi).
+
+    If you are working on a conda environment, you can install `parallelproj` as
+
+    ::
+
+        conda install -c conda-forge parallelproj
+
+
+    If you are working on a pixi installation, simply do
+
+    ::
+
+        pixi install -e full
+
+    which installs all optional dependencies.
+
+    Check the `parallelproj` documentation for more details: https://parallelproj.readthedocs.io/en/stable/.
+
+"""
+
+# %%
+import time
+
+import matplotlib.pyplot as plt
+import deepinv as dinv
+from deepinv.physics import PET
+from deepinv.utils.phantoms import generate_pet_phantom
+import torch
+import parallelproj
+from array_api_compat import torch as torch_compat
+
+# %%
+# Setup a minimal non-TOF PET projector
+# -------------------------------------
+#
+# Here we define each voxel to have size :math:`3\times 3\times 3` mm
+# such that the total volume to reconstruct is of size :math:`38.4\times 38.4\times 7.2` cm
+# which fits approximately a portion of a human chest.
+#
+# The maximum achievable resolution (in high count settings) is typically proportional to the full-width at half
+# maximum (FWHM) of the Gaussian blur kernel, which here is set to 4 mm.
+#
+# We use a PET scanner with 8 rings of detectors, each ring being a polygon of
+# 32 sides, and each side containing 16 detectors. This gives us a total of 32*16=512 detectors per ring.
+#
+# .. tip::
+#
+#       You can play with different geometries and voxel sizes to get a good grasp of
+#       the scanner geometry.
+#
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+img_size = (128, 128, 24)
+voxel_size = (3, 3, 3)
+
+# number of sides of the polygon approximating a circle
+num_sides = 16 # dsa was 32
+
+# number of detectors per polygon side
+num_lor_endpoints_per_side = 8 # dsa was 16 
+
+# number of rings of detectors on the depth axes
+num_rings = 7
+
+scanner = parallelproj.pet_scanners.DemoPETScannerGeometry(
+    torch_compat,
+    dev=device,
+    num_rings=num_rings,
+    num_sides=num_sides,
+    num_lor_endpoints_per_side=num_lor_endpoints_per_side,
+)
+
+
+# dsa tof 
+tof_info = parallelproj.tof.TOFParameters(
+    num_tofbins=5,
+    tofbin_width=80.0,
+    sigma_tof=10.0,
+    num_sigmas=3.0,
+)
+
+# FWHM of the Gaussian blur kernel in mm
+fwhm_data_mm = 4
+
+# gain of the device:
+# higher gains are associated to lower dose and/or shorter acquisition times,
+# while lower gains are associated to higher dose and/or longer acquisition times.
+# larger gain -> more poisson noise -> harder reconstruction
+gain = 0.001
+
+physics = PET(
+    device=device,
+    voxel_size=voxel_size,
+    scanner=scanner,
+    fwhm_data_mm=fwhm_data_mm,
+    img_size=img_size,
+    normalize_counts=True,
+    normalize=True,
+    gain=gain,
+    tof_info=tof_info,
+)
+
+physics.plot_geometry()
+
+# %%
+# Define a phantom and attenuation map
+# ------------------------------------
+#
+# We define a 3D phantom and attenuation map, whose shape is the same as the phantom.
+#
+# In practice, the attenuation is typically obtained with an auxiliary CT scan of the patient.
+
+x, attenuation = generate_pet_phantom(img_size, device=device)
+mid_slice = img_size[-1] // 2
+
+dinv.utils.plot(
+    [x[..., mid_slice], attenuation[..., mid_slice]],
+    titles=["Emission image", "Attenuation image"],
+)
+
+# %%
+# Simulating measurements
+# -----------------------
+# The shape of measurements is approximately `(B, 1, N, N/2, R^2)` where
+# `N=num_lor_endpoints_per_side*num_sides` is the number of detectors per ring
+# and `R` is the number of rings.
+# This provides one measurement for every possible Line of Response (LOR), or in other words 'rays', connecting
+# two detectors in the scanner, which are arranged in a sinogram format, with the first axis
+# corresponding to the angle of the ray, the second axis corresponding to the distance of the ray to the center of the field of view
+# and the last axis corresponding to the depth of the ray (i.e., which rings of detectors are connected by the ray)
+#
+# .. tip::
+#
+#     The size of measurements is independent of the chosen `img_size`
+
+y = physics(x)
+
+print(
+    f"Measurements shape={tuple(y.shape)}, range=({y.min().item():.2f},{y.max().item():.2f})"
+)
+
+# %%
+# Setting up background and attenuation
+# -------------------------------------
+# The attenuation term reduces the amount of signal measured in rays that
+# go through highly attenuating regions, such as bones. This makes the reconstruction more challenging, but also more realistic.
+#
+# In PET, we generally have access to a realization of the background,
+# i.e., :math:`\tilde{s} \sim \mathcal{P}(s)`, which is a Poisson random variable with mean :math:`s`.
+#
+# Both attenuation and background are stored as "physics parameters" which are patient dependent
+# and can be updated via :meth:`physics.update(...) <deepinv.physics.Physics.update>` or by passing them as kwargs in
+# :meth:`physics(x, ...) <deepinv.physics.Physics.forward>`, :meth:`physics.A(x, ...) <deepinv.physics.Physics.A>` or
+# :meth:`physics.A_adjoint(y, ...) <deepinv.physics.LinearPhysics.A_adjoint>`.
+#
+# .. note::
+#
+#   The attenuation is stored in the physics in sinogram space as :math:`\exp(-\mu)` to speed up computations,
+#   but it can be provided either in image space, i.e., :math:`\mu`, to the physics, or in sinogram space, i.e., :math:`\exp(-\mu)`.
+#   The class figures out the attenuation space by comparing it to `img_size`.
+
+expected_background = torch.ones_like(y) * x.max() * 0.05
+background = physics.generate_background(expected_background)
+physics.update(attenuation=attenuation, background=background)
+y = physics(x)
+y2 = y - background
+print(physics.attenuation.shape, y.shape, y2.shape)
+dinv.utils.plot(
+    [physics.attenuation.sum(axis=-1)[..., mid_slice], y[..., mid_slice, :].sum(axis=-1), y2[..., mid_slice, :].sum(axis=-1)],
+    ["sino. atten.", "meas.", "corrected meas."],
+    figsize=(6, 6),
+)
+
+# %%
+# Backprojection and sensitivities
+# --------------------------------
+# We backproject the data to visualize the sensitivity map of the scanner.
+# The sensitivity map is defined as the back-projection of a sinogram of ones :math:`s = A^\top \mathbf{1}`, which corresponds to the number of rays intersecting each voxel.
+#
+# Here we also obtain a simple linear least-squares reconstruction by using
+# :meth:`A_dagger <deepinv.physics.LinearPhysics.A_dagger>`.
+
+with torch.no_grad():
+    x_dag = physics.A_dagger(y - background)
+    sensitivities = physics.A_adjoint(torch.ones_like(y))
+
+print(f"Norm operator: {physics.compute_norm(x):.2f}")
+
+dinv.utils.plot(sensitivities[..., mid_slice], ["sensitivities"])
+
+# %%
+# MLEM reconstruction
+# -------------------
+#
+# We run the standard MLEM reconstruction algorithm :footcite:p:`sheppMaximumLikelihoodReconstruction1982`
+# to obtain a reconstructed emission volume.
+#
+# The algorithm can be seen as a preconditioned gradient descent on the negative log-likelihood of the Poisson model:
+#
+# .. math::
+#
+#   x^{(k+1)} = x^{(k)} - P \nabla f(Ax^{(k)}+b,y)
+#
+# where :math:`f` is the Poisson data-fidelity term, :math:`P=\mathrm{diag}(\frac{x}{A^T\mathbf{1}})` is a preconditioner
+# and :math:`b` is the background.
+
+gain = physics.noise_model.gain
+mlem_iter = 40
+
+
+def _sync():
+    if torch.device(device).type == "cuda":
+        torch.cuda.synchronize()
+
+
+nrmse = dinv.metric.NRMSE()
+
+
+# With ``denormalize=True``, the likelihood is evaluated in the count domain.
+# The background produced by PET is in the normalized measurement domain, so it
+# must be divided by the gain as well.
+data_fidelity = dinv.optim.PoissonLikelihood(
+    gain=gain,
+    bkg=background / gain,
+    denormalize=True,
+)
+model_mlem = dinv.optim.MLEM(
+    data_fidelity=data_fidelity,
+    prior=None,
+    max_iter=mlem_iter,
+    custom_metrics={
+        "nrmse": lambda _values, _x_prev, x_cur: nrmse(x_cur.unsqueeze(0), x).item()
+    },
+)
+
+with torch.no_grad():
+    _sync()
+    start = time.perf_counter()
+    x_mlem, metrics_mlem = model_mlem(
+        y, physics, init=torch.ones_like(x), compute_metrics=True
+    )
+    _sync()
+    mlem_time = time.perf_counter() - start
+
+print(f"MLEM runtime: {mlem_time:.2f} s for {mlem_iter} iterations")
+
+psnr = dinv.metric.PSNR(max_pixel=x.max().item())
+
+psnr_mlem = psnr(x_mlem, x)
+psnr_dag = psnr(x_dag, x)
+nrmse_mlem = nrmse(x_mlem, x)
+nrmse_dag = nrmse(x_dag, x)
+
+dinv.utils.plot(
+    [x[..., mid_slice], x_mlem[..., mid_slice], x_dag[..., mid_slice]],
+    ["Ground truth", f"MLEM ({mlem_iter} it.)", "L2 pseudoinv."],
+    subtitles=[
+        "Reference",
+        f"PSNR: {psnr_mlem.item():.2f} dB\n" f"NRMSE: {100 * nrmse_mlem.item():.2f}%",
+        f"PSNR: {psnr_dag.item():.2f} dB\n" f"NRMSE: {100 * nrmse_dag.item():.2f}%",
+    ],
+    rescale_mode="clip",
+    vmin=0,
+    vmax=x.max().item(),
+    figsize=(8, 4),
+    cbar=True,
+)
+
+# %%
+# Accelerating MLEM with ordered subsets
+# ---------------------------------------
+#
+# One MLEM iteration evaluates the forward and adjoint operators using the complete
+# PET acquisition. This can be slow when the scanner geometry and its measurements
+# are large, especially in 3D.
+#
+# Ordered-Subsets Expectation-Maximization (OSEM) :footcite:p:`hudsonAcceleratedImageReconstruction1994`
+# partitions the measurements and the forward operator into :math:`L` matching angular subsets indexed by
+# :math:`l=1,\ldots,L`:
+#
+# .. math::
+#
+#   y = (y_1,\ldots,y_L), \qquad
+#   A = (A_1^\top,\ldots,A_L^\top)^\top.
+#
+# OSEM applies an EM update successively with each pair :math:`(y_l,A_l)`. Each subset
+# update is cheaper than a full MLEM iteration and updates the complete image, so OSEM
+# generally reaches a useful reconstruction in fewer passes over the complete acquisition.
+
+# %%
+# OSEM reconstruction
+# -------------------
+#
+# OSEM accepts the full measurements and physics and splits them internally. Alternatively,
+# pre-split inputs can be created with :func:`deepinv.physics.split_measurements` and
+# :func:`deepinv.physics.split_physics` and passed directly to :class:`deepinv.optim.OSEM`.
+
+osem_iter = 3
+num_subsets = 16
+
+model_osem = dinv.optim.OSEM(
+    data_fidelity=data_fidelity,
+    prior=None,
+    max_iter=osem_iter,
+    num_subsets=num_subsets,
+    custom_metrics={
+        "nrmse": lambda _values, _x_prev, x_cur: nrmse(x_cur.unsqueeze(0), x).item()
+    },
+)
+
+with torch.no_grad():
+    _sync()
+    start = time.perf_counter()
+    x_osem, metrics_osem = model_osem(
+        y,
+        physics,
+        init=torch.ones_like(x),
+        compute_metrics=True,
+    )
+    _sync()
+    osem_time = time.perf_counter() - start
+
+print(
+    f"OSEM runtime: {osem_time:.2f} s "
+    f"for {osem_iter} iterations "
+    f"({num_subsets} subsets)"
+)
+print(f"Reconstruction speedup MLEM/OSEM: {mlem_time / osem_time:.2f}x")
+
+psnr_osem = psnr(x_osem, x)
+nrmse_osem = nrmse(x_osem, x)
+
+dinv.utils.plot(
+    [
+        x[..., mid_slice],
+        x_mlem[..., mid_slice],
+        x_osem[..., mid_slice],
+    ],
+    [
+        "Ground truth",
+        f"MLEM ({mlem_iter} it.)",
+        f"OSEM ({osem_iter} it.)",
+    ],
+    subtitles=[
+        "Reference",
+        f"PSNR: {psnr_mlem.item():.2f} dB\n" f"NRMSE: {100 * nrmse_mlem.item():.2f}%",
+        f"PSNR: {psnr_osem.item():.2f} dB\n" f"NRMSE: {100 * nrmse_osem.item():.2f}%",
+    ],
+    rescale_mode="clip",
+    vmin=0,
+    vmax=x.max().item(),
+    figsize=(8, 4),
+    cbar=True,
+)
+
+# We also compare the Poisson objective and NRMSE after every iteration.
+fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+axes[0].plot(metrics_mlem["cost"][0], label="MLEM")
+axes[0].plot(metrics_osem["cost"][0], label="OSEM")
+axes[0].set_xlabel("Iteration")
+axes[0].set_ylabel("Poisson NLL")
+axes[0].legend()
+
+axes[1].plot([100 * v for v in metrics_mlem["nrmse"][0]], label="MLEM")
+axes[1].plot([100 * v for v in metrics_osem["nrmse"][0]], label="OSEM")
+axes[1].set_xlabel("Iteration")
+axes[1].set_ylabel("NRMSE (%)")
+axes[1].yaxis.set_major_formatter("{x:.0f}%")
+axes[1].legend()
+fig.tight_layout()
+
+# %%
+# What next?
+# ------------
+# Now that you master the basics of PET, you can go further by
+#
+# - Reconstructing PET with learning-based methods (:ref:`PnP <iterative>`, :ref:`diffusion <sampling>`, :ref:`unrolled <unfolded>`, etc.)
+# - Playing with the scanner setup: changing number of detectors, voxel size, etc.
+
+# %%
+# :References:
+#
+# .. footbibliography::


### PR DESCRIPTION
Add Time-of-Flight (TOF) to PET physics

The goal is to make TOF available for both 2D and 3D PET physics. TOF can be seen as a new dimension in the projection domain, where each projection can be divided in T segments, T being the number of TOF bins.

The intent is only for PET sinogram. List-mode are not supported in TOF-less currently.

Progress:

- [x] Proof of concept for 2D
- [ ] Proof of concept for 3D (In progress)
- [ ] Documentation
- [ ] Tests (2D case work, 3D case fail for adjoint)
- [ ] Add TOF to Demo PET 2D (In progress)
- [ ] Add TOF  to demo PET 3D with TOF

### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.