### PR TITLE
PIDAL implementation for Poisson inverse problems

### DIFF
--- a/deepinv/optim/__init__.py
+++ b/deepinv/optim/__init__.py
@@ -28,6 +28,7 @@ from .optimizers import (
     SIRT,
     MLEM,
     OSEM,
+    PIDAL,
 )
 from .fixed_point import FixedPoint
 from .prior import (
@@ -60,6 +61,7 @@ from .optim_iterators import (
     SIRTIteration,
     MLEMIteration,
     OSEMIteration,
+    PIDALIteration,
 )
 from .epll import EPLL
 from .dpir import DPIR

--- a/deepinv/optim/distance.py
+++ b/deepinv/optim/distance.py
@@ -228,9 +228,10 @@ class PoissonLikelihoodDistance(Distance):
         """
         if self.denormalize:
             y = y / self.gain
-        return (-y * torch.log(x / self.gain + self.bkg)).flatten().sum() + (
-            (x / self.gain) + self.bkg - y
-        ).reshape(x.shape[0], -1).sum(dim=1)
+        scaled_x = x / self.gain + self.bkg
+        return (
+            (-y * torch.log(scaled_x) + scaled_x - y).reshape(x.shape[0], -1).sum(dim=1)
+        )
 
     def grad(self, x: torch.Tensor, y: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         r"""
@@ -241,7 +242,7 @@ class PoissonLikelihoodDistance(Distance):
         """
         if self.denormalize:
             y = y / self.gain
-        return self.gain * (1 - y / (x / self.gain + self.bkg))
+        return (1 - y / (x / self.gain + self.bkg)) / self.gain
 
     def prox(
         self, x: torch.Tensor, y: torch.Tensor, *args, gamma: float = 1.0, **kwargs
@@ -255,12 +256,10 @@ class PoissonLikelihoodDistance(Distance):
         """
         if self.denormalize:
             y = y / self.gain
-        out = (
-            x
-            - (1 / (self.gain * gamma))
-            * ((x - (1 / (self.gain * gamma))).pow(2) + 4 * y / gamma).sqrt()
+        shift = x - gamma / self.gain + self.gain * self.bkg
+        return 0.5 * (shift + (shift.square() + 4 * gamma * y).sqrt()) - (
+            self.gain * self.bkg
         )
-        return out / 2
 
 
 class L1Distance(Distance):

--- a/deepinv/optim/distance.py
+++ b/deepinv/optim/distance.py
@@ -257,7 +257,7 @@ class PoissonLikelihoodDistance(Distance):
             y = y / self.gain
         out = (
             x
-            - (1 / (self.gain * gamma))
+            + (1 / (self.gain * gamma))
             * ((x - (1 / (self.gain * gamma))).pow(2) + 4 * y / gamma).sqrt()
         )
         return out / 2

--- a/deepinv/optim/optim_iterators/__init__.py
+++ b/deepinv/optim/optim_iterators/__init__.py
@@ -9,3 +9,4 @@ from .spectral_methods import SMIteration
 from .sirt import SIRTIteration
 from .mlem import MLEMIteration
 from .osem import OSEMIteration
+from .pidal import PIDALIteration

--- a/deepinv/optim/optim_iterators/pidal.py
+++ b/deepinv/optim/optim_iterators/pidal.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
-import torch
-from .optim_iterator import OptimIterator, fStep, gStep
+
 from typing import TYPE_CHECKING
 
+import torch
+
 from deepinv.optim.linear import least_squares
+
+from .optim_iterator import OptimIterator
 
 if TYPE_CHECKING:
     from deepinv.optim import DataFidelity, Prior
     from deepinv.physics import Physics
+
 
 class PIDALIteration(OptimIterator):
     r"""
@@ -18,7 +22,7 @@ class PIDALIteration(OptimIterator):
 
     .. math::
         x_{k+1} &= \underset{x}{\text{argmin}}\lbrace \frac{1}{2\gamma}\left\Vert Mx - z_{k} + u_{k}\right\Vert^2\rbrace \\
-        z_{k+1}^1 &= \operatorname{prox}_{\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\
+        z_{k+1}^1 &= \operatorname{prox}_{\gamma\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\
         z_{k+1}^2 &=  \operatorname{prox}_{\gamma \lambda \regname}(x_{k+1} + u_{k}^2) \\
         z_{k+1}^3 &= \text{max}(0, x_{k+1} + u_{k}^3) \\
         u_{k+1} &= u_{k} + Mx_{k+1} - z_{k+1}
@@ -42,15 +46,15 @@ class PIDALIteration(OptimIterator):
         u1, u2, u3 = u
 
         return least_squares(
-                    A=lambda y: physics.A(y),
-                    AT=lambda x: physics.A_adjoint(x),
-                    y=z1 - u1,
-                    gamma=0.25,
-                    z=0.5 * (z2 - u2 + z3 - u3),
-                    solver=cur_params["f_solver"],
-                    max_iter=cur_params["f_max_iter"],
-                    tol=cur_params["f_tol"],
-                    init=torch.ones_like(z2),
+            A=physics.A,
+            AT=physics.A_adjoint,
+            y=z1 - u1,
+            gamma=0.5,
+            z=0.5 * (z2 - u2 + z3 - u3),
+            solver=cur_params["f_solver"],
+            max_iter=cur_params["f_max_iter"],
+            tol=cur_params["f_tol"],
+            init=z2,
         )
 
     def z_step(
@@ -61,16 +65,22 @@ class PIDALIteration(OptimIterator):
         cur_params: dict,
         cur_data_fidelity: DataFidelity,
         y: torch.Tensor,
-        physics: Physics
+        physics: Physics,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
         u1, u2, u3 = u
 
-        z1 = cur_data_fidelity.prox_d(physics.A(x) + u1, y,)
-        z2 = cur_prior.prox(x + u2, cur_params["g_param"], gamma=cur_params["lambda"] * cur_params["stepsize"])
+        z1 = cur_data_fidelity.prox_d(
+            physics.A(x) + u1, y, gamma=cur_params["stepsize"]
+        )
+        z2 = cur_prior.prox(
+            x + u2,
+            cur_params["g_param"],
+            gamma=cur_params["lambda"] * cur_params["stepsize"],
+        )
         z3 = torch.clamp(x + u3, min=0)
 
-        return (z1, z2, z3)
+        return z1, z2, z3
 
     def forward(
         self,
@@ -103,6 +113,7 @@ class PIDALIteration(OptimIterator):
         u1 = u1 + physics.A(x) - z1
         u2 = u2 + x - z2
         u3 = u3 + x - z3
+        u = (u1, u2, u3)
 
         F = (
             self.cost_fn(x, cur_data_fidelity, cur_prior, cur_params, y, physics)

--- a/deepinv/optim/optim_iterators/pidal.py
+++ b/deepinv/optim/optim_iterators/pidal.py
@@ -47,9 +47,9 @@ class PIDALIteration(OptimIterator):
                     y=z1 - u1,
                     gamma=0.25,
                     z=0.5 * (z2 - u2 + z3 - u3),
-                    solver=cur_params["f_solver"],
-                    max_iter=cur_params["f_max_iter"],
-                    tol=cur_params["f_tol"],
+                    solver=cur_params["x_solver"],
+                    max_iter=cur_params["x_max_iter"],
+                    tol=cur_params["x_tol"],
                     init=torch.ones_like(z2),
         )
 
@@ -103,6 +103,7 @@ class PIDALIteration(OptimIterator):
         u1 = u1 + physics.A(x) - z1
         u2 = u2 + x - z2
         u3 = u3 + x - z3
+        u = (u1, u2, u3)
 
         F = (
             self.cost_fn(x, cur_data_fidelity, cur_prior, cur_params, y, physics)

--- a/deepinv/optim/optim_iterators/pidal.py
+++ b/deepinv/optim/optim_iterators/pidal.py
@@ -30,55 +30,47 @@ class PIDALIteration(OptimIterator):
     def __init__(self, **kwargs):
         super(PIDALIteration, self).__init__(**kwargs)
 
-    def M(self, y: torch.Tensor, physics: Physics):
-        Aty = physics.A_adjoint(y)
-        return torch.cat([Aty, y, y], dim=2)
-
-    def MT(self, x: torch.Tensor, physics: Physics):
-        Ax = physics.A(x)
-        return torch.cat([Ax, x, x], dim=3)
-
     def x_step(
         self,
-        z: torch.Tensor,
-        u: torch.Tensor,
+        z: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        u: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
         cur_params: dict,
         physics: Physics,
     ) -> torch.Tensor:
 
+        z1, z2, z3 = z
+        u1, u2, u3 = u
+
         return least_squares(
-                    A=lambda y: self.M(y, physics),
-                    AT=lambda x: self.MT(x, physics),
-                    y=z - u,
-                    gamma=None,
+                    A=lambda y: physics.A(y),
+                    AT=lambda x: physics.A_adjoint(x),
+                    y=z1 - u1,
+                    gamma=0.25,
+                    z=0.5 * (z2 - u2 + z3 - u3),
                     solver=cur_params["f_solver"],
-                    kwargs=cur_params["f_solver_kwargs"],
                     max_iter=cur_params["f_max_iter"],
                     tol=cur_params["f_tol"],
+                    init=torch.ones_like(z2),
         )
 
     def z_step(
         self,
         x: torch.Tensor,
-        u: torch.Tensor,
+        u: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
         cur_prior: Prior,
         cur_params: dict,
         cur_data_fidelity: DataFidelity,
         y: torch.Tensor,
         physics: Physics
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
-        h = u.shape[2] // 3
-
-        u1 = u[:, :, 0:h, ...]
-        u2 = u[:, :, h:2 * h, ...]
-        u3 = u[:, :, 2 * h:3 * h, ...]
+        u1, u2, u3 = u
 
         z1 = cur_data_fidelity.prox_d(physics.A(x) + u1, y,)
         z2 = cur_prior.prox(x + u2, cur_params["g_param"], gamma=cur_params["lambda"] * cur_params["stepsize"])
         z3 = torch.clamp(x + u3, min=0)
 
-        return torch.cat([z1, z2, z3], dim=2)
+        return (z1, z2, z3)
 
     def forward(
         self,
@@ -103,9 +95,14 @@ class PIDALIteration(OptimIterator):
 
         x, z, u = X["est"]
 
-        x = self.f_step(z, u, cur_params, physics)
-        z = self.g_step(x, u, cur_prior, cur_params, cur_data_fidelity, y, physics)
-        u = u + self.M(x, physics) - z
+        x = self.x_step(z, u, cur_params, physics)
+        z = self.z_step(x, u, cur_prior, cur_params, cur_data_fidelity, y, physics)
+
+        z1, z2, z3 = z
+        u1, u2, u3 = u
+        u1 = u1 + physics.A(x) - z1
+        u2 = u2 + x - z2
+        u3 = u3 + x - z3
 
         F = (
             self.cost_fn(x, cur_data_fidelity, cur_prior, cur_params, y, physics)

--- a/deepinv/optim/optim_iterators/pidal.py
+++ b/deepinv/optim/optim_iterators/pidal.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+import torch
+from .optim_iterator import OptimIterator, fStep, gStep
+from typing import TYPE_CHECKING
+
+from deepinv.optim.linear import least_squares
+
+if TYPE_CHECKING:
+    from deepinv.optim import DataFidelity, Prior
+    from deepinv.physics import Physics
+
+class PIDALIteration(OptimIterator):
+    r"""
+    Iterator for the PIDAL (Poisson image deconvolution by augmented Lagrangian) algorithm.
+
+    Class for a single iteration of the PIDAL algorithm for
+    minimising :math:`f(x) + \lambda \regname(x)` when :math:`f` is a Poisson likelihood data fidelity and :math:`\regname` is a regularization term.
+
+    .. math::
+        x_{k+1} &= \underset{x}{\text{argmin}}\lbrace \frac{1}{2\gamma}\left\Vert Mx - z_{k} + u_{k}\right\Vert^2\rbrace \\
+        z_{k+1}^1 &= \operatorname{prox}_{\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\
+        z_{k+1}^2 &=  \operatorname{prox}_{\gamma \lambda \regname}(x_{k+1} + u_{k}^2) \\
+        z_{k+1}^3 &= \text{max}(0, x_{k+1} + u_{k}^3) \\
+        u_{k+1} &= u_{k} + Mx_{k+1} - z_{k+1}
+
+    where :math:`\gamma>0` is a stepsize, :math:`M=\begin{bmatrix}A\\I\\I\end{bmatrix}` and :math:`z_{k} = \begin{bmatrix}z_{k}^1\\z_{k}^2\\z_{k}^3\end{bmatrix}`.
+
+    """
+
+    def __init__(self, **kwargs):
+        super(PIDALIteration, self).__init__(**kwargs)
+
+    def M(self, y: torch.Tensor, physics: Physics):
+        Aty = physics.A_adjoint(y)
+        return torch.cat([Aty, y, y], dim=2)
+
+    def MT(self, x: torch.Tensor, physics: Physics):
+        Ax = physics.A(x)
+        return torch.cat([Ax, x, x], dim=3)
+
+    def x_step(
+        self,
+        z: torch.Tensor,
+        u: torch.Tensor,
+        cur_params: dict,
+        physics: Physics,
+    ) -> torch.Tensor:
+
+        return least_squares(
+                    A=lambda y: self.M(y, physics),
+                    AT=lambda x: self.MT(x, physics),
+                    y=z - u,
+                    gamma=None,
+                    solver=cur_params["f_solver"],
+                    kwargs=cur_params["f_solver_kwargs"],
+                    max_iter=cur_params["f_max_iter"],
+                    tol=cur_params["f_tol"],
+        )
+
+    def z_step(
+        self,
+        x: torch.Tensor,
+        u: torch.Tensor,
+        cur_prior: Prior,
+        cur_params: dict,
+        cur_data_fidelity: DataFidelity,
+        y: torch.Tensor,
+        physics: Physics
+    ) -> torch.Tensor:
+
+        h = u.shape[2] // 3
+
+        u1 = u[:, :, 0:h, ...]
+        u2 = u[:, :, h:2 * h, ...]
+        u3 = u[:, :, 2 * h:3 * h, ...]
+
+        z1 = cur_data_fidelity.prox_d(physics.A(x) + u1, y,)
+        z2 = cur_prior.prox(x + u2, cur_params["g_param"], gamma=cur_params["lambda"] * cur_params["stepsize"])
+        z3 = torch.clamp(x + u3, min=0)
+
+        return torch.cat([z1, z2, z3], dim=2)
+
+    def forward(
+        self,
+        X: dict[str, tuple[torch.Tensor, torch.Tensor] | torch.Tensor],
+        cur_data_fidelity: DataFidelity,
+        cur_prior: Prior,
+        cur_params: dict,
+        y: torch.Tensor,
+        physics: Physics,
+    ) -> dict[str, tuple[torch.Tensor, torch.Tensor] | torch.Tensor]:
+        r"""
+        Single iteration of the PIDAL algorithm.
+
+        :param dict X: Dictionary containing the current iterate and the estimated cost.
+        :param deepinv.optim.DataFidelity cur_data_fidelity: Instance of the DataFidelity class defining the current data_fidelity.
+        :param deepinv.optim.Prior cur_prior: Instance of the Prior class defining the current prior.
+        :param dict cur_params: Dictionary containing the current parameters of the algorithm.
+        :param torch.Tensor y: Input data.
+        :param deepinv.physics.Physics physics: Instance of the physics modeling the observation.
+        :return: Dictionary `{"est": (x, z, u), "cost": F}` containing the updated current iterate and the estimated current cost.
+        """
+
+        x, z, u = X["est"]
+
+        x = self.f_step(z, u, cur_params, physics)
+        z = self.g_step(x, u, cur_prior, cur_params, cur_data_fidelity, y, physics)
+        u = u + self.M(x, physics) - z
+
+        F = (
+            self.cost_fn(x, cur_data_fidelity, cur_prior, cur_params, y, physics)
+            if self.has_cost
+            and self.cost_fn is not None
+            and cur_data_fidelity is not None
+            and cur_prior is not None
+            else None
+        )
+        return {"est": (x, z, u), "cost": F}

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -1093,7 +1093,7 @@ class ADMM(BaseOptim):
     If the model is used for inference only, use the ``with torch.no_grad():`` context when calling the model in order to avoid unnecessary gradient computations.
 
     .. :hint:
-    If you are willing to solve Poisson inverse problems, you can use the :class:`deepinv.optim.PoissonADMM` class, which is better suited for this type of problem as the regular ADMM is not guaranteed to converge in this case.
+    If you are willing to solve Poisson inverse problems, you can use the :class:`deepinv.optim.PIDAL` class, which is better suited for this type of problem as the regular ADMM is not guaranteed to converge in this case.
 
     :param list, deepinv.optim.DataFidelity data_fidelity: data-fidelity term :math:`\datafid{x}{y}`.
         Either a single instance (same data-fidelity for each iteration) or a list of instances of
@@ -2697,12 +2697,52 @@ class PIDAL(BaseOptim):
 
     .. math::
         x_{k+1} &= \underset{x}{\text{argmin}}\lbrace \frac{1}{2\gamma}\left\Vert Mx - z_{k} + u_{k}\right\Vert^2\rbrace \\
-        z_{k+1}^1 &= \operatorname{prox}_{\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\
+        z_{k+1}^1 &= \operatorname{prox}_{\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\AF
         z_{k+1}^2 &=  \operatorname{prox}_{\gamma \lambda \regname}(x_{k+1} + u_{k}^2) \\
         z_{k+1}^3 &= \text{max}(0, x_{k+1} + u_{k}^3) \\
         u_{k+1} &= u_{k} + Mx_{k+1} - z_{k+1}
     
     where :math:`\gamma>0` is a stepsize, :math:`M=\begin{bmatrix}A\\I\\I\end{bmatrix}` and :math:`z_{k} = \begin{bmatrix}z_{k}^1\\z_{k}^2\\z_{k}^3\end{bmatrix}`.
+
+    :param list, deepinv.optim.DataFidelity data_fidelity: data-fidelity term :math:`\datafid{x}{y}`.
+        Either a single instance (same data-fidelity for each iteration) or a list of instances of
+        :class:`deepinv.optim.DataFidelity` (distinct data fidelity for each iteration). Default: ``None`` corresponding to :math:`\datafid{x}{y} = 0`.
+    :param list, deepinv.optim.Prior prior: regularization prior :math:`\reg{x}`.
+        Either a single instance (same prior for each iteration) or a list of instances of
+        :class:`deepinv.optim.Prior` (distinct prior for each iteration). Default: ``None`` corresponding to :math:`\reg{x} = 0`.
+    :param float lambda_reg: regularization parameter :math:`\lambda`. Default: ``1.0``.
+    :param float stepsize: stepsize parameter :math:`\gamma`. Default: ``1.0``.
+    :param float beta: ADMM relaxation parameter :math:`\beta`. Default: ``1.0``.
+    :param float g_param: parameter of the prior function. For example the noise level for a denoising prior. Default: ``None``.
+    :param list x_solver: list of solvers to be used for the primal variable update. Default: ``["CG"]``.
+    :param int x_max_iter: maximum number of iterations for the primal variable update. Default: ``100``.
+    :param float x_tol: tolerance for the primal variable update. Default: ``1e-5``.
+    :param float sigma_denoiser: same as ``g_param``. If both ``g_param`` and ``sigma_denoiser`` are provided, ``g_param`` is used. Default: ``None``.
+    :param int max_iter: maximum number of iterations of the optimization algorithm. Default: ``100``.
+    :param str crit_conv: convergence criterion to be used for claiming convergence, either ``"residual"`` (residual
+        of the iterate norm) or ``"cost"`` (on the cost function). Default: ``"residual"``
+    :param float thres_conv: convergence threshold for the chosen convergence criterion. Default: ``1e-5``.
+    :param bool early_stop: whether to stop the algorithm as soon as the convergence criterion is met. Default: ``False``.
+    :param dict custom_metrics: dictionary of custom metric functions to be computed along the iterations. The keys of the dictionary are the names of the metrics, and the values are functions that take as input the current and previous iterates, and return a scalar value. Default: ``None``.
+    :param Callable custom_init:  Custom initialization of the algorithm.
+        The callable function ``custom_init(y, physics)`` takes as input the measurement :math:`y` and the physics ``physics`` and returns the initialization in the form of either:
+        
+        - a tuple :math:`(x_0, z_0)` (where ``x_0`` and ``z_0`` are the initial primal and dual variables),
+        - a torch.Tensor :math:`x_0` (if no dual variables :math:`z_0` are used), or
+        - a dictionary of the form ``X = {'est': (x_0, z_0)}``.
+        
+        Note that custom initialization can also be directly defined via the ``init`` argument in the ``forward`` method. 
+        
+        If ``None`` (default value), the algorithm is initialized with the adjoint :math:`A^{\top}y` when the adjoint is defined,
+        and with the observation `y` if the adjoint is not defined. Default: ``None``.
+    :param bool unfold: whether to unfold the algorithm or not. Default: ``False``.
+    :param list trainable_params: list of ADMM parameters to be trained if ``unfold`` is True. To choose between ``["lambda", "stepsize", "g_param", "beta"]``. Default: None, which means that all parameters are trainable if ``unfold`` is True. For no trainable parameters, set to an empty list.
+    :param Callable cost_fn: Custom user input cost function.    
+            ``cost_fn(x, data_fidelity, prior, cur_params, y, physics)`` takes as input 
+            the current primal variable (:class:`torch.Tensor`), the current data-fidelity (:class:`deepinv.optim.DataFidelity`), 
+            the current prior (:class:`deepinv.optim.Prior`), the current parameters (dict), and the measurement (:class:`torch.Tensor`).
+            Default: ``None``.
+    :param dict params_algo: optionally, directly provide the ADMM parameters in a dictionary. This will overwrite the parameters in the arguments `stepsize`, `lambda_reg`, `g_param` and `beta`.
 
     """
 
@@ -2713,9 +2753,9 @@ class PIDAL(BaseOptim):
         lambda_reg: float = 1.0,
         stepsize: float = 1.0,
         g_param: float = None,
-        f_solver: str = ["CG"],
-        f_max_iter: int = 100,
-        f_tol: float = 1e-5,
+        x_solver: list[str] = ["CG"],
+        x_max_iter: int = 100,
+        x_tol: float = 1e-5,
         sigma_denoiser: float = None,
         max_iter: int = 100,
         crit_conv: str = "residual",
@@ -2748,9 +2788,9 @@ class PIDAL(BaseOptim):
                 "lambda": lambda_reg,
                 "stepsize": stepsize,
                 "g_param": g_param,
-                "f_solver": f_solver,
-                "f_max_iter": f_max_iter,
-                "f_tol": f_tol,
+                "x_solver": x_solver,
+                "x_max_iter": x_max_iter,
+                "x_tol": x_tol,
             }
 
         if custom_init is None:
@@ -2759,18 +2799,12 @@ class PIDAL(BaseOptim):
 
                 x_init = physics.A_adjoint(y)
                 x_init = torch.ones_like(x_init)
-                # z_init_1 = torch.zeros_like(y)
-                # z_init_2 = torch.zeros_like(x_init)
-                # z_init_3 = torch.zeros_like(x_init)
-                # u_init_1 = torch.zeros_like(y)
-                # u_init_2 = torch.zeros_like(x_init)
-                # u_init_3 = torch.zeros_like(x_init)
-                z_init_1 = torch.ones_like(y)
-                z_init_2 = torch.ones_like(x_init)
-                z_init_3 = torch.ones_like(x_init)
-                u_init_1 = torch.ones_like(y)
-                u_init_2 = torch.ones_like(x_init)
-                u_init_3 = torch.ones_like(x_init)
+                z_init_1 = torch.zeros_like(y)
+                z_init_2 = torch.zeros_like(x_init)
+                z_init_3 = torch.zeros_like(x_init)
+                u_init_1 = torch.zeros_like(y)
+                u_init_2 = torch.zeros_like(x_init)
+                u_init_3 = torch.zeros_like(x_init)
 
                 return {"est": (x_init, (z_init_1, z_init_2, z_init_3), (u_init_1, u_init_2, u_init_3))}
 

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -1194,6 +1194,7 @@ class ADMM(BaseOptim):
             **kwargs,
         )
 
+
 class DRS(BaseOptim):
     r"""
     DRS module for solving the problem
@@ -2681,8 +2682,8 @@ class SIRT(BaseOptim):
             **kwargs,
         )
 
-class PIDAL(BaseOptim):
 
+class PIDAL(BaseOptim):
     r"""
     PIDAL (Poisson image deconvolution by augmented Lagrangian) module for solving the problem
 
@@ -2697,7 +2698,7 @@ class PIDAL(BaseOptim):
 
     .. math::
         x_{k+1} &= \underset{x}{\text{argmin}}\lbrace \frac{1}{2\gamma}\left\Vert Mx - z_{k} + u_{k}\right\Vert^2\rbrace \\
-        z_{k+1}^1 &= \operatorname{prox}_{\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\
+        z_{k+1}^1 &= \operatorname{prox}_{\gamma\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\
         z_{k+1}^2 &=  \operatorname{prox}_{\gamma \lambda \regname}(x_{k+1} + u_{k}^2) \\
         z_{k+1}^3 &= \text{max}(0, x_{k+1} + u_{k}^3) \\
         u_{k+1} &= u_{k} + Mx_{k+1} - z_{k+1}
@@ -2713,7 +2714,7 @@ class PIDAL(BaseOptim):
         lambda_reg: float = 1.0,
         stepsize: float = 1.0,
         g_param: float = None,
-        f_solver: str = ["CG"],
+        f_solver: str = "CG",
         f_max_iter: int = 100,
         f_tol: float = 1e-5,
         sigma_denoiser: float = None,
@@ -2748,7 +2749,7 @@ class PIDAL(BaseOptim):
                 "lambda": lambda_reg,
                 "stepsize": stepsize,
                 "g_param": g_param,
-                "f_solver": f_solver,
+                "f_solver": [f_solver],
                 "f_max_iter": f_max_iter,
                 "f_tol": f_tol,
             }
@@ -2758,21 +2759,14 @@ class PIDAL(BaseOptim):
             def custom_init(y, physics):
 
                 x_init = physics.A_adjoint(y)
-                x_init = torch.ones_like(x_init)
-                # z_init_1 = torch.zeros_like(y)
-                # z_init_2 = torch.zeros_like(x_init)
-                # z_init_3 = torch.zeros_like(x_init)
-                # u_init_1 = torch.zeros_like(y)
-                # u_init_2 = torch.zeros_like(x_init)
-                # u_init_3 = torch.zeros_like(x_init)
-                z_init_1 = torch.ones_like(y)
-                z_init_2 = torch.ones_like(x_init)
-                z_init_3 = torch.ones_like(x_init)
-                u_init_1 = torch.ones_like(y)
-                u_init_2 = torch.ones_like(x_init)
-                u_init_3 = torch.ones_like(x_init)
+                z_init = (y.clone(), x_init.clone(), x_init.clone())
+                u_init = (
+                    torch.zeros_like(y),
+                    torch.zeros_like(x_init),
+                    torch.zeros_like(x_init),
+                )
 
-                return {"est": (x_init, (z_init_1, z_init_2, z_init_3), (u_init_1, u_init_2, u_init_3))}
+                return {"est": (x_init, z_init, u_init)}
 
         super(PIDAL, self).__init__(
             PIDALIteration(cost_fn=cost_fn),

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -1194,107 +1194,6 @@ class ADMM(BaseOptim):
             **kwargs,
         )
 
-class PIDAL(BaseOptim):
-
-    r"""
-    PIDAL (Poisson image deconvolution by augmented Lagrangian) module for solving the problem
-
-    .. math::
-        \begin{equation}
-        \label{eq:min_prob}
-        \tag{1}
-        \underset{x}{\arg\min} \quad  \datafid{x}{y} + \lambda \reg{x},
-        \end{equation}
-
-    where :math:`\datafid{x}{y}` is A Poisson data-fidelity term and :math:`\reg{x}` is the regularization term. The iterations (see :footcite:t:`figueiredo_restoration_2010` for more details) are given by
-
-    .. math::
-        x_{k+1} &= \underset{x}{\text{argmin}}\lbrace \frac{1}{2\gamma}\left\Vert Mx - z_{k} + u_{k}\right\Vert^2\rbrace \\
-        z_{k+1}^1 &= \operatorname{prox}_{\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\
-        z_{k+1}^2 &=  \operatorname{prox}_{\gamma \lambda \regname}(x_{k+1} + u_{k}^2) \\
-        z_{k+1}^3 &= \text{max}(0, x_{k+1} + u_{k}^3) \\
-        u_{k+1} &= u_{k} + Mx_{k+1} - z_{k+1}
-    
-    where :math:`\gamma>0` is a stepsize, :math:`M=\begin{bmatrix}A\\I\\I\end{bmatrix}` and :math:`z_{k} = \begin{bmatrix}z_{k}^1\\z_{k}^2\\z_{k}^3\end{bmatrix}`.
-
-    """
-
-    def __init__(
-        self,
-        data_fidelity: PoissonLikelihood | list[PoissonLikelihood] = None,
-        prior: Prior | list[Prior] = None,
-        lambda_reg: float = 1.0,
-        stepsize: float = 1.0,
-        g_param: float = None,
-        f_solver: str = "CG",
-        f_solver_kwargs: dict = {},
-        f_max_iter: int = 100,
-        f_tol: float = 1e-5,
-        sigma_denoiser: float = None,
-        max_iter: int = 100,
-        crit_conv: str = "residual",
-        thres_conv: float = 1e-5,
-        early_stop: bool = False,
-        custom_metrics: dict[str, Metric] = None,
-        custom_init: Callable[[torch.Tensor, Physics], dict] = None,
-        unfold: bool = False,
-        trainable_params: list[str] = None,
-        cost_fn: Callable[
-            [
-                torch.Tensor,
-                DataFidelity,
-                Prior,
-                dict[str, float],
-                torch.Tensor,
-                Physics,
-            ],
-            torch.Tensor,
-        ] = None,
-        params_algo: dict[str, float] = None,
-        **kwargs,
-    ):
-
-        if g_param is None and sigma_denoiser is not None:
-            g_param = sigma_denoiser
-
-        if params_algo is None:
-            params_algo = {
-                "lambda": lambda_reg,
-                "stepsize": stepsize,
-                "g_param": g_param,
-                "f_solver": f_solver,
-                "f_solver_kwargs": f_solver_kwargs,
-                "f_max_iter": f_max_iter,
-                "f_tol": f_tol,
-            }
-
-        if custom_init is None:
-
-            def custom_init(y, physics):
-
-                x_init = physics.A_adjoint(y)
-                z_init = torch.cat([x_init, torch.zeros_like(x_init), torch.zeros_like(x_init)], dim=2)
-                u_init = torch.zeros_like(z_init)
-
-                return {"est": (x_init, z_init, u_init)}
-
-
-        super(PIDAL, self).__init__(
-            PIDALIteration(cost_fn=cost_fn),
-            data_fidelity=data_fidelity,
-            prior=prior,
-            params_algo=params_algo,
-            max_iter=max_iter,
-            crit_conv=crit_conv,
-            thres_conv=thres_conv,
-            early_stop=early_stop,
-            custom_metrics=custom_metrics,
-            custom_init=custom_init,
-            unfold=unfold,
-            trainable_params=trainable_params,
-            **kwargs,
-        )
-
 class DRS(BaseOptim):
     r"""
     DRS module for solving the problem
@@ -2779,5 +2678,114 @@ class SIRT(BaseOptim):
             early_stop=early_stop,
             custom_metrics=custom_metrics,
             custom_init=custom_init,
+            **kwargs,
+        )
+
+class PIDAL(BaseOptim):
+
+    r"""
+    PIDAL (Poisson image deconvolution by augmented Lagrangian) module for solving the problem
+
+    .. math::
+        \begin{equation}
+        \label{eq:min_prob}
+        \tag{1}
+        \underset{x}{\arg\min} \quad  \datafid{x}{y} + \lambda \reg{x},
+        \end{equation}
+
+    where :math:`\datafid{x}{y}` is A Poisson data-fidelity term and :math:`\reg{x}` is the regularization term. The iterations (see :footcite:t:`figueiredo_restoration_2010` for more details) are given by
+
+    .. math::
+        x_{k+1} &= \underset{x}{\text{argmin}}\lbrace \frac{1}{2\gamma}\left\Vert Mx - z_{k} + u_{k}\right\Vert^2\rbrace \\
+        z_{k+1}^1 &= \operatorname{prox}_{\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\
+        z_{k+1}^2 &=  \operatorname{prox}_{\gamma \lambda \regname}(x_{k+1} + u_{k}^2) \\
+        z_{k+1}^3 &= \text{max}(0, x_{k+1} + u_{k}^3) \\
+        u_{k+1} &= u_{k} + Mx_{k+1} - z_{k+1}
+    
+    where :math:`\gamma>0` is a stepsize, :math:`M=\begin{bmatrix}A\\I\\I\end{bmatrix}` and :math:`z_{k} = \begin{bmatrix}z_{k}^1\\z_{k}^2\\z_{k}^3\end{bmatrix}`.
+
+    """
+
+    def __init__(
+        self,
+        data_fidelity: PoissonLikelihood | list[PoissonLikelihood] = None,
+        prior: Prior | list[Prior] = None,
+        lambda_reg: float = 1.0,
+        stepsize: float = 1.0,
+        g_param: float = None,
+        f_solver: str = ["CG"],
+        f_max_iter: int = 100,
+        f_tol: float = 1e-5,
+        sigma_denoiser: float = None,
+        max_iter: int = 100,
+        crit_conv: str = "residual",
+        thres_conv: float = 1e-5,
+        early_stop: bool = False,
+        custom_metrics: dict[str, Metric] = None,
+        custom_init: Callable[[torch.Tensor, Physics], dict] = None,
+        unfold: bool = False,
+        trainable_params: list[str] = None,
+        cost_fn: Callable[
+            [
+                torch.Tensor,
+                DataFidelity,
+                Prior,
+                dict[str, float],
+                torch.Tensor,
+                Physics,
+            ],
+            torch.Tensor,
+        ] = None,
+        params_algo: dict[str, float] = None,
+        **kwargs,
+    ):
+
+        if g_param is None and sigma_denoiser is not None:
+            g_param = sigma_denoiser
+
+        if params_algo is None:
+            params_algo = {
+                "lambda": lambda_reg,
+                "stepsize": stepsize,
+                "g_param": g_param,
+                "f_solver": f_solver,
+                "f_max_iter": f_max_iter,
+                "f_tol": f_tol,
+            }
+
+        if custom_init is None:
+
+            def custom_init(y, physics):
+
+                x_init = physics.A_adjoint(y)
+                x_init = torch.ones_like(x_init)
+                # z_init_1 = torch.zeros_like(y)
+                # z_init_2 = torch.zeros_like(x_init)
+                # z_init_3 = torch.zeros_like(x_init)
+                # u_init_1 = torch.zeros_like(y)
+                # u_init_2 = torch.zeros_like(x_init)
+                # u_init_3 = torch.zeros_like(x_init)
+                z_init_1 = torch.ones_like(y)
+                z_init_2 = torch.ones_like(x_init)
+                z_init_3 = torch.ones_like(x_init)
+                u_init_1 = torch.ones_like(y)
+                u_init_2 = torch.ones_like(x_init)
+                u_init_3 = torch.ones_like(x_init)
+
+                return {"est": (x_init, (z_init_1, z_init_2, z_init_3), (u_init_1, u_init_2, u_init_3))}
+
+        super(PIDAL, self).__init__(
+            PIDALIteration(cost_fn=cost_fn),
+            data_fidelity=data_fidelity,
+            prior=prior,
+            params_algo=params_algo,
+            max_iter=max_iter,
+            crit_conv=crit_conv,
+            thres_conv=thres_conv,
+            early_stop=early_stop,
+            custom_metrics=custom_metrics,
+            custom_init=custom_init,
+            unfold=unfold,
+            trainable_params=trainable_params,
             **kwargs,
         )

--- a/deepinv/optim/optimizers.py
+++ b/deepinv/optim/optimizers.py
@@ -4,6 +4,7 @@ import warnings
 from collections.abc import Iterable
 from types import MappingProxyType
 import torch
+from deepinv.optim.optim_iterators.pidal import PIDALIteration
 from deepinv.optim import optim_iterators as _optim_iterators
 from deepinv.optim.optim_iterators import (
     OptimIterator,
@@ -1091,6 +1092,9 @@ class ADMM(BaseOptim):
     Note also that by default, if the prior has trainable parameters (e.g. a neural network denoiser), these parameters are learnable by default. 
     If the model is used for inference only, use the ``with torch.no_grad():`` context when calling the model in order to avoid unnecessary gradient computations.
 
+    .. :hint:
+    If you are willing to solve Poisson inverse problems, you can use the :class:`deepinv.optim.PoissonADMM` class, which is better suited for this type of problem as the regular ADMM is not guaranteed to converge in this case.
+
     :param list, deepinv.optim.DataFidelity data_fidelity: data-fidelity term :math:`\datafid{x}{y}`.
         Either a single instance (same data-fidelity for each iteration) or a list of instances of
         :class:`deepinv.optim.DataFidelity` (distinct data fidelity for each iteration). Default: ``None`` corresponding to :math:`\datafid{x}{y} = 0`.
@@ -1190,6 +1194,106 @@ class ADMM(BaseOptim):
             **kwargs,
         )
 
+class PIDAL(BaseOptim):
+
+    r"""
+    PIDAL (Poisson image deconvolution by augmented Lagrangian) module for solving the problem
+
+    .. math::
+        \begin{equation}
+        \label{eq:min_prob}
+        \tag{1}
+        \underset{x}{\arg\min} \quad  \datafid{x}{y} + \lambda \reg{x},
+        \end{equation}
+
+    where :math:`\datafid{x}{y}` is A Poisson data-fidelity term and :math:`\reg{x}` is the regularization term. The iterations (see :footcite:t:`figueiredo_restoration_2010` for more details) are given by
+
+    .. math::
+        x_{k+1} &= \underset{x}{\text{argmin}}\lbrace \frac{1}{2\gamma}\left\Vert Mx - z_{k} + u_{k}\right\Vert^2\rbrace \\
+        z_{k+1}^1 &= \operatorname{prox}_{\text{KL}(. | y)}(Ax_{k+1} + u_{k}^1) \\
+        z_{k+1}^2 &=  \operatorname{prox}_{\gamma \lambda \regname}(x_{k+1} + u_{k}^2) \\
+        z_{k+1}^3 &= \text{max}(0, x_{k+1} + u_{k}^3) \\
+        u_{k+1} &= u_{k} + Mx_{k+1} - z_{k+1}
+    
+    where :math:`\gamma>0` is a stepsize, :math:`M=\begin{bmatrix}A\\I\\I\end{bmatrix}` and :math:`z_{k} = \begin{bmatrix}z_{k}^1\\z_{k}^2\\z_{k}^3\end{bmatrix}`.
+
+    """
+
+    def __init__(
+        self,
+        data_fidelity: PoissonLikelihood | list[PoissonLikelihood] = None,
+        prior: Prior | list[Prior] = None,
+        lambda_reg: float = 1.0,
+        stepsize: float = 1.0,
+        g_param: float = None,
+        f_solver: str = "CG",
+        f_solver_kwargs: dict = {},
+        f_max_iter: int = 100,
+        f_tol: float = 1e-5,
+        sigma_denoiser: float = None,
+        max_iter: int = 100,
+        crit_conv: str = "residual",
+        thres_conv: float = 1e-5,
+        early_stop: bool = False,
+        custom_metrics: dict[str, Metric] = None,
+        custom_init: Callable[[torch.Tensor, Physics], dict] = None,
+        unfold: bool = False,
+        trainable_params: list[str] = None,
+        cost_fn: Callable[
+            [
+                torch.Tensor,
+                DataFidelity,
+                Prior,
+                dict[str, float],
+                torch.Tensor,
+                Physics,
+            ],
+            torch.Tensor,
+        ] = None,
+        params_algo: dict[str, float] = None,
+        **kwargs,
+    ):
+
+        if g_param is None and sigma_denoiser is not None:
+            g_param = sigma_denoiser
+
+        if params_algo is None:
+            params_algo = {
+                "lambda": lambda_reg,
+                "stepsize": stepsize,
+                "g_param": g_param,
+                "f_solver": f_solver,
+                "f_solver_kwargs": f_solver_kwargs,
+                "f_max_iter": f_max_iter,
+                "f_tol": f_tol,
+            }
+
+        if custom_init is None:
+
+            def custom_init(y, physics):
+
+                x_init = physics.A_adjoint(y)
+                z_init = torch.cat([x_init, torch.zeros_like(x_init), torch.zeros_like(x_init)], dim=2)
+                u_init = torch.zeros_like(z_init)
+
+                return {"est": (x_init, z_init, u_init)}
+
+
+        super(PIDAL, self).__init__(
+            PIDALIteration(cost_fn=cost_fn),
+            data_fidelity=data_fidelity,
+            prior=prior,
+            params_algo=params_algo,
+            max_iter=max_iter,
+            crit_conv=crit_conv,
+            thres_conv=thres_conv,
+            early_stop=early_stop,
+            custom_metrics=custom_metrics,
+            custom_init=custom_init,
+            unfold=unfold,
+            trainable_params=trainable_params,
+            **kwargs,
+        )
 
 class DRS(BaseOptim):
     r"""

--- a/deepinv/tests/test_optim.py
+++ b/deepinv/tests/test_optim.py
@@ -212,6 +212,46 @@ def test_data_fidelity_l1(device):
     )
 
 
+@pytest.mark.parametrize("denormalize", [False, True])
+def test_data_fidelity_poisson(device, denormalize):
+    gain = 0.2
+    bkg = 0.4
+    gamma = 0.7
+    x = torch.tensor(
+        [[[[0.2, 0.5], [0.8, 1.1]]], [[[0.3, 0.6], [0.9, 1.2]]]],
+        device=device,
+        requires_grad=True,
+    )
+    counts = torch.tensor(
+        [[[[1.0, 2.0], [3.0, 4.0]]], [[[2.0, 3.0], [4.0, 5.0]]]],
+        device=device,
+    )
+    y = counts * gain if denormalize else counts
+    data_fidelity = dinv.optim.PoissonLikelihood(
+        gain=gain, bkg=bkg, denormalize=denormalize
+    )
+
+    loss = data_fidelity.d(x, y)
+    scaled_x = x / gain + bkg
+    expected_loss = (
+        (-counts * torch.log(scaled_x) + scaled_x - counts)
+        .reshape(x.shape[0], -1)
+        .sum(dim=1)
+    )
+    assert torch.allclose(loss, expected_loss)
+
+    expected_grad = (1 - counts / scaled_x) / gain
+    assert torch.allclose(data_fidelity.grad_d(x, y), expected_grad)
+    assert torch.allclose(torch.autograd.grad(loss.sum(), x)[0], expected_grad)
+
+    prox = data_fidelity.prox_d(x.detach(), y, gamma=gamma)
+    assert torch.allclose(
+        prox - x.detach() + gamma * data_fidelity.grad_d(prox, y),
+        torch.zeros_like(x),
+        atol=1e-5,
+    )
+
+
 def test_data_fidelity_zero(device):
     # Define two points
     x = torch.Tensor([[[1], [4], [-0.5]]]).to(device)
@@ -249,6 +289,27 @@ def test_data_fidelity_zero(device):
             y,
         ),
     )
+
+
+def test_pidal_closed_form_solution(device):
+    y = torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]], device=device)
+    physics = dinv.physics.Denoising()
+    lambda_reg = 0.2
+    model = dinv.optim.PIDAL(
+        data_fidelity=dinv.optim.PoissonLikelihood(denormalize=False),
+        prior=dinv.optim.prior.Tikhonov(),
+        lambda_reg=lambda_reg,
+        stepsize=0.7,
+        f_max_iter=5,
+        f_tol=1e-10,
+        max_iter=200,
+    )
+
+    x_hat = model(y, physics)
+    expected = (-1 + torch.sqrt(1 + 4 * lambda_reg * y)) / (2 * lambda_reg)
+
+    assert torch.all(x_hat >= 0)
+    assert torch.allclose(x_hat, expected, atol=1e-4, rtol=1e-4)
 
 
 def test_zero_prior():

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1640,3 +1640,15 @@ journal = {ACM Trans. Graph.}
   doi = {10.1109/42.712135},
   pmid = {9735909}
 }
+
+@article{figueiredo_restoration_2010,
+	title = {Restoration of {Poissonian} {Images} {Using} {Alternating} {Direction} {Optimization}},
+	volume = {19},
+	doi = {10.1109/TIP.2010.2053941},
+	number = {12},
+	journal = {IEEE Transactions on Image Processing},
+	author = {Figueiredo, Mário A. T. and Bioucas-Dias, José M.},
+	month = dec,
+	year = {2010},
+	pages = {3133--3145},
+}

--- a/examples/optimization/demo_PIDAL_PET.py
+++ b/examples/optimization/demo_PIDAL_PET.py
@@ -29,19 +29,26 @@ data_fidelity = dinv.optim.PoissonLikelihood(
     gain=gain
 )
 
-def custom_init(y, physics):
-    osem = dinv.optim.OSEM(
-        num_subsets=16,
-        max_iter=3
-    )
-    x0 = osem.forward(y=y, physics=physics)
-    z0 = torch.zeros_like(x0)
-    return x0, z0
+# def custom_init(y, physics):
+
+#     x_init = x
+#     z_init_1 = torch.clone(y)
+#     z_init_2 = torch.clone(x_init)
+#     z_init_3 = torch.clone(x_init)
+#     u_init_1 = torch.clone(y)
+#     u_init_2 = torch.clone(x_init)
+#     u_init_3 = torch.clone(x_init)
+
+#     return {"est": (x_init, (z_init_1, z_init_2, z_init_3), (u_init_1, u_init_2, u_init_3))}
 
 
 pidal = dinv.optim.PIDAL(
     data_fidelity=data_fidelity,
     prior=prior,
+    max_iter=10,
+    stepsize=0.5,
+    # custom_init=custom_init,
+    # g_param=0.0
 )
 
 x_pidal = pidal.forward(
@@ -52,5 +59,7 @@ x_pidal = pidal.forward(
 dinv.utils.plot(
     [x, x_pidal],
     titles=["Ground truth", "PIDAL reconstruction"],
-    figsize=(8, 4)
+    figsize=(8, 4),
+    rescale_mode="clip",
+    vmin=0,vmax=1
 )

--- a/examples/optimization/demo_PIDAL_PET.py
+++ b/examples/optimization/demo_PIDAL_PET.py
@@ -1,3 +1,4 @@
+# %%
 import deepinv as dinv
 from deepinv.utils.phantoms import generate_pet_phantom
 import torch
@@ -15,6 +16,7 @@ physics = dinv.physics.PET(
     device=device,
     gain=gain,
     normalize=True,
+    normalize_counts=True,
 )
 
 x, attenuation = generate_pet_phantom(img_size, device=device)
@@ -23,43 +25,26 @@ background = None
 physics.update(attenuation=attenuation, background=background)
 y = physics(x)
 
-prior = dinv.optim.prior.Tikhonov()
+prior = dinv.optim.prior.TVPrior(n_it_max=200)
 
-data_fidelity = dinv.optim.PoissonLikelihood(
-    gain=gain
-)
-
-# def custom_init(y, physics):
-
-#     x_init = x
-#     z_init_1 = torch.clone(y)
-#     z_init_2 = torch.clone(x_init)
-#     z_init_3 = torch.clone(x_init)
-#     u_init_1 = torch.clone(y)
-#     u_init_2 = torch.clone(x_init)
-#     u_init_3 = torch.clone(x_init)
-
-#     return {"est": (x_init, (z_init_1, z_init_2, z_init_3), (u_init_1, u_init_2, u_init_3))}
+data_fidelity = dinv.optim.PoissonLikelihood(gain=gain)
 
 
 pidal = dinv.optim.PIDAL(
     data_fidelity=data_fidelity,
     prior=prior,
-    max_iter=10,
+    max_iter=100,
     stepsize=0.5,
-    # custom_init=custom_init,
-    # g_param=0.0
+    f_max_iter=10,
+    lambda_reg=0.03
 )
 
-x_pidal = pidal.forward(
-    y=y,
-    physics=physics
-)
+x_pidal = pidal.forward(y=y, physics=physics)
 
 dinv.utils.plot(
     [x, x_pidal],
     titles=["Ground truth", "PIDAL reconstruction"],
     figsize=(8, 4),
-    rescale_mode="clip",
-    vmin=0,vmax=1
 )
+
+# %%

--- a/examples/optimization/demo_PIDAL_PET.py
+++ b/examples/optimization/demo_PIDAL_PET.py
@@ -1,0 +1,56 @@
+import deepinv as dinv
+from deepinv.utils.phantoms import generate_pet_phantom
+import torch
+
+img_size = (160, 160)
+voxel_size = (2.0, 2.0)
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+gain = 0.01
+
+physics = dinv.physics.PET(
+    img_size=img_size,
+    voxel_size=voxel_size,
+    device=device,
+    gain=gain,
+    normalize=True,
+)
+
+x, attenuation = generate_pet_phantom(img_size, device=device)
+
+background = None
+physics.update(attenuation=attenuation, background=background)
+y = physics(x)
+
+prior = dinv.optim.prior.Tikhonov()
+
+data_fidelity = dinv.optim.PoissonLikelihood(
+    gain=gain
+)
+
+def custom_init(y, physics):
+    osem = dinv.optim.OSEM(
+        num_subsets=16,
+        max_iter=3
+    )
+    x0 = osem.forward(y=y, physics=physics)
+    z0 = torch.zeros_like(x0)
+    return x0, z0
+
+
+pidal = dinv.optim.PIDAL(
+    data_fidelity=data_fidelity,
+    prior=prior,
+)
+
+x_pidal = pidal.forward(
+    y=y,
+    physics=physics
+)
+
+dinv.utils.plot(
+    [x, x_pidal],
+    titles=["Ground truth", "PIDAL reconstruction"],
+    figsize=(8, 4)
+)

--- a/examples/optimization/demo_PIDAL_PET.py
+++ b/examples/optimization/demo_PIDAL_PET.py
@@ -1,65 +1,73 @@
+r"""
+PIDAL + TV prior for PET reconstruction
+======================================
+
+Demonstrates using the PIDAL (see :footcite:t:`figueiredo_restoration_2010`) scheme with a total-variation (TV) prior
+for positron emission tomography (PET) reconstruction on a simulated phantom.
+
+This method is an alternative to ADMM for non-denoising Poisson inverse problems as it provides a splitting procedure.
+
+
+"""
+
+# %%
 import deepinv as dinv
 from deepinv.utils.phantoms import generate_pet_phantom
 import torch
 
+# %%
+# Load PET phantom and attenuation map
+#
+
 img_size = (160, 160)
-voxel_size = (2.0, 2.0)
-
 device = "cuda" if torch.cuda.is_available() else "cpu"
+x, attenuation = generate_pet_phantom(img_size, device=device)
 
-gain = 0.01
+# %%
+# Create PET physics and simulate sinogram data
+#
 
+voxel_size = (2.0, 2.0)
+gain = 1.0
 physics = dinv.physics.PET(
     img_size=img_size,
     voxel_size=voxel_size,
     device=device,
     gain=gain,
-    normalize=True,
+    normalize=False,
 )
-
-x, attenuation = generate_pet_phantom(img_size, device=device)
 
 background = None
 physics.update(attenuation=attenuation, background=background)
 y = physics(x)
 
-prior = dinv.optim.prior.Tikhonov()
-
+# %%
+# Define PIDAL optimizer with TV prior
+pet_prior = dinv.optim.prior.TVPrior()
 data_fidelity = dinv.optim.PoissonLikelihood(
     gain=gain
 )
-
-# def custom_init(y, physics):
-
-#     x_init = x
-#     z_init_1 = torch.clone(y)
-#     z_init_2 = torch.clone(x_init)
-#     z_init_3 = torch.clone(x_init)
-#     u_init_1 = torch.clone(y)
-#     u_init_2 = torch.clone(x_init)
-#     u_init_3 = torch.clone(x_init)
-
-#     return {"est": (x_init, (z_init_1, z_init_2, z_init_3), (u_init_1, u_init_2, u_init_3))}
-
-
 pidal = dinv.optim.PIDAL(
     data_fidelity=data_fidelity,
-    prior=prior,
-    max_iter=10,
+    prior=pet_prior,
+    max_iter=50,
     stepsize=0.5,
-    # custom_init=custom_init,
-    # g_param=0.0
+    lambda_reg=1.0
 )
+
+# %%
+# Run PIDAL reconstruction
 
 x_pidal = pidal.forward(
     y=y,
     physics=physics
 )
 
+# %%
+# Display results
+
 dinv.utils.plot(
     [x, x_pidal],
     titles=["Ground truth", "PIDAL reconstruction"],
-    figsize=(8, 4),
-    rescale_mode="clip",
-    vmin=0,vmax=1
+    figsize=(8, 4)
 )


### PR DESCRIPTION
The current ADMM algorithm is not guaranteed to work when the proximal operator of the data fidelity term doesn't have a closed-form solution. By default, deepinv will fall back to gradient descent algorithm to solve the ADMM data fidelity proximal step, which is not guaranteed to work with functions such as Kullback-Leibler divergence. This is the case for Poisson inverse problems.

We propose to implement a splitting strategy that aims to remove $A$ from the proximal operator in order to have a closed-form solution for the latter. We introduce the following scheme proposed in [1]:

$$x^{k+1} = \underset{x}{\text{argmin}}\lbrace \frac{1}{2\gamma}\left\Vert Mx - z^k + u^k\right\Vert^2\rbrace$$
$$z_1^{k+1} = \text{prox}_{\text{KL}(. | y)}(Ax^{k+1} + u_1^k)$$
$$z_2^{k+1} = \text{prox}_{\gamma \lambda g}(x^{k+1} + u_2^k)$$
$$z_3^{k+1} = \text{max}(0, x^{k+1} + u_3^k)$$
$$u^{k+1} = u^k + Mx^{k+1} - z^{k+1}$$

with $M = [A^T, Id, Id]^T$ and $z = [z_1, z_2, z_3]^T$.

We want to add an example with PET.


[1] Figueiredo, M. A. T., & Bioucas-Dias, J. M. (2010). Restoration of Poissonian Images Using Alternating Direction Optimization. IEEE Transactions on Image Processing, 19(12), 3133–3145. https://doi.org/10.1109/tip.2010.2053941