### PR TITLE
Fix `PanNet` upsampler

### DIFF
--- a/deepinv/models/multispectral.py
+++ b/deepinv/models/multispectral.py
@@ -161,10 +161,10 @@ class PanNet(nn.Module):
         lr_highpass = self.highpass(lr)
         pan_highpass = self.highpass(pan)
 
-        lr_highpass_up = self.upsampler(lr_highpass)  # note fixed upsampler
+        lr_highpass_up = self.upsampler(lr_highpass) * self.scale_factor**2
 
         ms = torch.cat([pan_highpass, lr_highpass_up], dim=1)
 
-        output = self.net(ms) + self.upsampler(lr)
+        output = self.net(ms) + self.upsampler(lr) * self.scale_factor**2
 
         return output

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ New Features
 Changed
 ^^^^^^^
 - :class:`deepinv.models.FFDNet` default network parameters changed, to allow pretrained weights by default (:gh:`1357` by `Vicky De Ridder`_)
+- :class:`deepinv.models.PanNet` upsampling preserves intensity properly now. Existing PanNet weights may not perform well, but retraining should give improved performance compared to old weights. (:gh:`1371` by `Vicky De Ridder`_)
 
 Fixed
 ^^^^^


### PR DESCRIPTION
Currently, `PanNet` upsamples through `sampler.A_adjoint`.  This lowers the pixel intensities a lot. This makes training worse, especially when not using batchnorm.

4x Pansharpening, final validation loss and best val PSNR:

- before fix: 0.0324, 26.42
- after fix: 0.0231, 28.52




### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.