### PR TITLE
Simplify PET physics adjoint using `.H` property

### DIFF
--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -7,8 +7,7 @@ import contextlib
 import io
 
 if TYPE_CHECKING:
-    import parallelproj
-
+    from parallelproj import pet_scanners, pet_lors, projectors, operators
 
 class PET(LinearPhysics):
     r"""
@@ -115,7 +114,7 @@ class PET(LinearPhysics):
         img_size: tuple,
         voxel_size: tuple = (2, 2, 2),
         fwhm_data_mm: float | tuple = 4.0,
-        scanner: None | parallelproj.pet_scanners.ModularizedPETScannerGeometry = None,
+        scanner: None | pet_scanners.ModularizedPETScannerGeometry = None,
         radial_trim: int = 3,
         gain: float = 1.0,
         normalize: bool = False,
@@ -138,7 +137,7 @@ class PET(LinearPhysics):
 
         try:  # avoids doctest failing when parallelproj prints banner
             with contextlib.redirect_stdout(io.StringIO()):
-                import parallelproj
+                from parallelproj import pet_scanners, pet_lors, projectors, operators
                 from array_api_compat import torch as torch_compat
         except ImportError:
             raise ImportError(
@@ -164,22 +163,22 @@ class PET(LinearPhysics):
             self.is_2d = False
 
         if scanner is None:
-            scanner = parallelproj.pet_scanners.DemoPETScannerGeometry(
+            scanner = pet_scanners.DemoPETScannerGeometry(
                 torch_compat, dev=device, num_rings=1 if self.is_2d else 16
             )
         self.scanner = scanner
 
         # setup the LOR descriptor that defines the sinogram
-        lor_desc = parallelproj.RegularPolygonPETLORDescriptor(
+        lor_desc = pet_lors.RegularPolygonPETLORDescriptor(
             scanner,
             radial_trim=radial_trim,
-            sinogram_order=parallelproj.SinogramSpatialAxisOrder.RVP,
+            sinogram_order=pet_lors.SinogramSpatialAxisOrder.RVP,
         )
 
         if views is not None:
             views = torch.as_tensor(views, device=device, dtype=torch.int64)
 
-        self.proj = parallelproj.RegularPolygonPETProjector(
+        self.proj = projectors.RegularPolygonPETProjector(
             lor_desc, img_shape=img_size, voxel_size=voxel_size, views=views
         )
         # store the views as a buffer but does not add it to state dict since its part
@@ -205,10 +204,10 @@ class PET(LinearPhysics):
         fwhm_data_mm = torch.as_tensor(
             fwhm_data_mm, device=device, dtype=self.proj.voxel_size.dtype
         )
-        self.res_model = parallelproj.GaussianFilterOperator(
+        self.res_model = operators.GaussianFilterOperator(
             img_size, sigma=fwhm_data_mm / (2.35 * self.proj.voxel_size)
         )
-        self.pet_lin_op = parallelproj.CompositeLinearOperator(
+        self.pet_lin_op = operators.CompositeLinearOperator(
             (self.proj, self.res_model)
         )
 
@@ -249,7 +248,6 @@ class PET(LinearPhysics):
         if self.is_2d:
             x = x.unsqueeze(-1)
             attenuation = attenuation.unsqueeze(-1)
-
         out = LinearSingleChannelOperator.apply(x, self.pet_lin_op) * attenuation
         if self.is_2d:
             out = out.squeeze(-1)
@@ -353,7 +351,8 @@ class PET(LinearPhysics):
                     attenuation = attenuation.unsqueeze(0)
                 if self.is_2d:
                     attenuation = attenuation.unsqueeze(-1)
-
+                
+                attenuation = attenuation.contiguous() # paralleproj_core requires contiguous tensors
                 proj_att = LinearSingleChannelOperator.apply(attenuation, self.proj)
                 if self.is_2d:
                     proj_att = proj_att.squeeze(-1)
@@ -379,7 +378,7 @@ class LinearSingleChannelOperator(torch.autograd.Function):
 
     @staticmethod
     def forward(
-        ctx, x: torch.Tensor, operator: parallelproj.LinearOperator
+        ctx, x: torch.Tensor, operator: operators.LinearOperator
     ) -> torch.Tensor:
         r"""
         Forward pass for a mini-batch of 3D images using a linear operator.

--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -7,7 +7,8 @@ import contextlib
 import io
 
 if TYPE_CHECKING:
-    from parallelproj import pet_scanners, pet_lors, projectors, operators
+    from parallelproj import pet_scanners, operators
+
 
 class PET(LinearPhysics):
     r"""
@@ -207,9 +208,7 @@ class PET(LinearPhysics):
         self.res_model = operators.GaussianFilterOperator(
             img_size, sigma=fwhm_data_mm / (2.35 * self.proj.voxel_size)
         )
-        self.pet_lin_op = operators.CompositeLinearOperator(
-            (self.proj, self.res_model)
-        )
+        self.pet_lin_op = operators.CompositeLinearOperator((self.proj, self.res_model))
 
         self.normalize = normalize
 
@@ -277,8 +276,10 @@ class PET(LinearPhysics):
         if self.is_2d:
             y = y.unsqueeze(-1)
             attenuation = attenuation.unsqueeze(-1)
+
+        # operator.H returns an instance of AdjointLinearOperator with appropriate attributes.
         out = (
-            LinearSingleChannelOperator.apply(y * attenuation, self.pet_lin_op.H)  # operator.H returns an instance of AdjointLinearOperator with appropriate attributes.
+            LinearSingleChannelOperator.apply(y * attenuation, self.pet_lin_op.H)
             / self.operator_norm
         )
         if self.is_2d:
@@ -351,8 +352,9 @@ class PET(LinearPhysics):
                     attenuation = attenuation.unsqueeze(0)
                 if self.is_2d:
                     attenuation = attenuation.unsqueeze(-1)
-                
-                attenuation = attenuation.contiguous() # paralleproj_core requires contiguous tensors
+
+                # paralleproj_core requires contiguous tensors
+                attenuation = attenuation.contiguous()
                 proj_att = LinearSingleChannelOperator.apply(attenuation, self.proj)
                 if self.is_2d:
                     proj_att = proj_att.squeeze(-1)

--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -280,7 +280,7 @@ class PET(LinearPhysics):
             y = y.unsqueeze(-1)
             attenuation = attenuation.unsqueeze(-1)
         out = (
-            AdjointLinearSingleChannelOperator.apply(y * attenuation, self.pet_lin_op)
+            LinearSingleChannelOperator.apply(y * attenuation, self.pet_lin_op.H)  # operator.H returns an instance of AdjointLinearOperator with appropriate attributes.
             / self.operator_norm
         )
         if self.is_2d:
@@ -440,100 +440,5 @@ class LinearSingleChannelOperator(torch.autograd.Function):
 
             for i in range(batch_size):
                 x[i, 0, ...] = operator.adjoint(grad_output[i, 0, ...].detach())
-
-            return x, None
-
-
-# %%
-# Setup the back projection layer
-# -------------------------------
-#
-# We subclass :class:`torch.autograd.Function` to define a custom pytorch layer
-# that is compatible with pytorch's autograd engine.
-# see also: https://pytorch.org/tutorials/beginner/examples_autograd/two_layer_net_custom_function.html
-
-
-class AdjointLinearSingleChannelOperator(torch.autograd.Function):
-    """
-    Function representing the adjoint of a linear operator acting on a mini batch of single channel images
-    """
-
-    @staticmethod
-    def forward(
-        ctx, x: torch.Tensor, operator: parallelproj.LinearOperator
-    ) -> torch.Tensor:
-        """forward pass of the adjoint of the linear operator
-
-        Parameters
-        ----------
-        ctx : context object
-            that can be used to store information for the backward pass
-        x : torch.Tensor
-            mini batch of 3D images with dimension (batch_size, 1, operator.out_shape)
-        operator : parallelproj.LinearOperator
-            linear operator that can act on a single 3D image
-
-        Returns
-        -------
-        torch.Tensor
-            mini batch of 3D images with dimension (batch_size, 1, operator.img_size)
-        """
-
-        ctx.set_materialize_grads(False)
-        ctx.operator = operator
-
-        batch_size = x.shape[0]
-        y = torch.zeros(
-            (batch_size, 1) + operator.in_shape, dtype=x.dtype, device=x.device
-        )
-
-        # loop over all samples in the batch and apply linear operator
-        # to the first channel
-        for i in range(batch_size):
-            y[i, 0, ...] = operator.adjoint(x[i, 0, ...].detach())
-
-        return y
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        """backward pass of the forward pass
-
-        Parameters
-        ----------
-        ctx : context object
-            that can be used to obtain information from the forward pass
-        grad_output : torch.Tensor
-            mini batch of dimension (batch_size, 1, operator.img_size)
-
-        Returns
-        -------
-        torch.Tensor, None
-            mini batch of 3D images with dimension (batch_size, 1, operator.out_shape)
-        """
-        # For details on how to implement the backward pass, see
-        # https://pytorch.org/docs/stable/notes/extending.html#how-to-use
-
-        # since forward takes two input arguments (x, operator)
-        # we have to return two arguments (the latter is None)
-        if grad_output is None:
-            return None, None
-        else:
-            operator = ctx.operator
-
-            batch_size = grad_output.shape[0]
-            x = torch.zeros(
-                (
-                    batch_size,
-                    1,
-                )
-                + operator.out_shape,
-                dtype=grad_output.dtype,
-                device=grad_output.device,
-            )
-
-            # loop over all samples in the batch and apply linear operator
-            # to the first channel
-            for i in range(batch_size):
-                x[i, 0, ...] = operator(grad_output[i, 0, ...].detach())
 
             return x, None

--- a/deepinv/physics/pet.py
+++ b/deepinv/physics/pet.py
@@ -106,7 +106,7 @@ class PET(LinearPhysics):
     >>> attenuation = torch.rand((1, 1,) + img_size)
     >>> y = physics(x, attenuation=attenuation, background=background)
     >>> y.shape
-    torch.Size([1, 1, 539, 272])
+    torch.Size([1, 1, 537, 272])
 
     """
 

--- a/examples/physics/demo_pet2d.py
+++ b/examples/physics/demo_pet2d.py
@@ -51,7 +51,7 @@ import deepinv as dinv
 from deepinv.physics import PET
 from deepinv.utils.phantoms import generate_pet_phantom
 import torch
-import parallelproj
+from parallelproj import pet_scanners
 from array_api_compat import torch as torch_compat
 
 # %%
@@ -93,7 +93,7 @@ num_lor_endpoints_per_side = 16
 # choose a single ring for 2D
 num_rings = 1
 
-scanner = parallelproj.pet_scanners.DemoPETScannerGeometry(
+scanner = pet_scanners.DemoPETScannerGeometry(
     torch_compat,
     dev=device,
     num_rings=num_rings,

--- a/examples/physics/demo_pet3d.py
+++ b/examples/physics/demo_pet3d.py
@@ -63,7 +63,7 @@ import deepinv as dinv
 from deepinv.physics import PET
 from deepinv.utils.phantoms import generate_pet_phantom
 import torch
-import parallelproj
+from parallelproj import pet_scanners
 from array_api_compat import torch as torch_compat
 
 # %%
@@ -99,7 +99,7 @@ num_lor_endpoints_per_side = 16
 # number of rings of detectors on the depth axes
 num_rings = 8
 
-scanner = parallelproj.pet_scanners.DemoPETScannerGeometry(
+scanner = pet_scanners.DemoPETScannerGeometry(
     torch_compat,
     dev=device,
     num_rings=num_rings,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ transformers = "*"
 torchkbnufft = "*"
 array-api-compat = "*"
 sigpy = "*"
-parallelproj = ">=1.10.0,<2.0.0"
+parallelproj = ">=2.0"
 # spyrit is PyPI-only, stays in optional deps
 
 [tool.pixi.feature.physics-gpu.dependencies]


### PR DESCRIPTION
Refs #1296 

This PR simplifies the PET physics operator by using `.H` property introduced in `parallelproj` V2.0.

### Changes
This PR makes the following changes:

* Refactors [deepinv/physics/pet.py](https://github.com/deepinv/deepinv/blob/main/deepinv/physics/pet.py) to use `self.pet_lin_op.H` directly instead of a separate AdjointLinearSingleChannelOperator. Modifies the import paths to match `parallelproj` V2.0 API.
* Updated the import paths for [examples/physics/demo_pet2d.py](https://github.com/deepinv/deepinv/blob/main/examples/physics/demo_pet2d.py) and [examples/physics/demo_pet3d.py](https://github.com/deepinv/deepinv/blob/main/examples/physics/demo_pet3d.py).
* Bumped `parallelproj` version to `>=2.0` in [pyproject.toml](https://github.com/deepinv/deepinv/blob/main/pyproject.toml)

#### I would like feedback on these:
* I found that `parallelproj`'s underlying projector raises a TypeError for non contiguous tensors, and in example 2d and 3d pet, attenuation is non contiguous and raises the error during physics.update(...). In the change, I have explicitly made the tensor contiguous in `update_parameters`, but this might need to be done at other places as well.
* `parallelproj>=2.0` requires `python>=3.12` but deepinv requires `python>=3.10`, should a version guard be added to `pet.py`? 

### Checks to be done before submitting your PR

- [x] `pixi run -e test pytest deepinv/tests/test_physics.py` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.

