### PR TITLE
Quickfix test_trainer_speed

### DIFF
--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -1157,8 +1157,14 @@ def test_trainer_speed(mixed_precision, device):  # pragma: no cover
             x = batch["x"]
             x = x.to(device)
             y = physics(x)
-            x_hat = model(y, physics=physics)
-            loss = losses(x, x_hat)
+
+            if mixed_precision is not False:
+                with torch.autocast(device.type, dtype=mixed_precision):
+                    x_hat = model(y, physics=physics)
+                    loss = losses(x, x_hat)
+            else:
+                x_hat = model(y, physics=physics)
+                loss = losses(x, x_hat)
             loss.backward()
             optimizer.step()
             optimizer.zero_grad()


### PR DESCRIPTION
A test was regularly failing the CI
test_trainer_speed compares the execution time between the Trainer and a manual "naive" training loop. But the mixed precision was only done by the Trainer, so the execution time was different.

I have tested the fix on multiple GPUs, namely:
- RTX 2080 SUPER
-  RTX 2080 Ti
- RTX A1000

See #1208

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.