### PR TITLE
Add Set5, BSD100, McMaster, and Kodak24 datasets

### DIFF
--- a/deepinv/datasets/__init__.py
+++ b/deepinv/datasets/__init__.py
@@ -8,6 +8,7 @@ from .set5 import Set5HR
 from .bsds500 import BSDS500
 from .bsd100 import BSD100HR
 from .mcmaster import McMaster
+from .kodak24 import Kodak24
 from .cbsd68 import CBSD68
 from .fastmri import (
     FastMRISliceDataset,

--- a/deepinv/datasets/__init__.py
+++ b/deepinv/datasets/__init__.py
@@ -4,7 +4,10 @@ from .random_sampler import RandomPatchSampler
 from .div2k import DIV2K
 from .urban100 import Urban100HR
 from .set14 import Set14HR
+from .set5 import Set5HR
 from .bsds500 import BSDS500
+from .bsd100 import BSD100HR
+from .mcmaster import McMaster
 from .cbsd68 import CBSD68
 from .fastmri import (
     FastMRISliceDataset,

--- a/deepinv/datasets/bsd100.py
+++ b/deepinv/datasets/bsd100.py
@@ -29,7 +29,6 @@ class BSD100HR(ImageFolder):
                 |
                 --- xxx
 
-    This dataset wrapper gives access to the 100 high resolution images in the `BSD100_HR` folder.
     Raw dataset source : https://huggingface.co/datasets/eugenesiow/BSD100
 
     :param str root: Root directory of dataset. Directory path from where we load and save the dataset.

--- a/deepinv/datasets/bsd100.py
+++ b/deepinv/datasets/bsd100.py
@@ -1,0 +1,131 @@
+from typing import Callable
+from types import MappingProxyType
+import os
+
+from deepinv.datasets.utils import (
+    calculate_md5_for_folder,
+    download_archive,
+    extract_tarball,
+)
+from deepinv.datasets.base import ImageFolder
+from .utils import resolve_root
+
+
+class BSD100HR(ImageFolder):
+    """Dataset for `BSD100 <https://paperswithcode.com/dataset/bsd100>`_.
+
+    The BSD100 dataset :footcite:p:`martin2001database` is a dataset consisting of 100 images commonly used for testing performance of image reconstruction algorithms.
+    Images have sizes ranging from 240×160 to 480×320 pixels.
+
+    **Raw data file structure:** ::
+
+        self.root --- BSD100_HR.tar.gz
+                |
+                --- BSD100_HR --- 3096.png
+                |               |
+                |               --- 8023.png
+                |               --- 12084.png
+                |               --- ...
+                |
+                --- xxx
+
+    This dataset wrapper gives access to the 100 high resolution images in the `BSD100_HR` folder.
+    Raw dataset source : https://huggingface.co/datasets/eugenesiow/BSD100
+
+    :param str root: Root directory of dataset. Directory path from where we load and save the dataset.
+    :param bool download: If ``True``, downloads the dataset from the internet and puts it in root directory.
+        If dataset is already downloaded, it is not downloaded again. Default at False.
+    :param Callable transform:: (optional)  A function/transform that takes in a PIL image
+        and returns a transformed version. E.g, ``torchvision.transforms.RandomCrop``
+    :param bool verbose: Print a message if the dataset has been correctly downloaded. Default ``True``.
+    :param bool use_dict_output: whether to return output as dict with keys "x", "y", "params" instead of tuple (default `False`).
+
+    |sep|
+
+    :Examples:
+
+        Instantiate dataset and download raw data from the Internet ::
+
+            import shutil
+            from deepinv.datasets import BSD100HR
+            dataset = BSD100HR(root="BSD100", download=True)  # download raw data at root and load dataset
+            Dataset has been successfully downloaded.
+            print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
+            True
+            print(len(dataset))                                  # check that we have 100 images
+            100
+            shutil.rmtree("BSD100")                          # remove raw data from disk
+
+    """
+
+    _archive_urls = MappingProxyType(
+        {
+            "BSD100_HR.tar.gz": "https://huggingface.co/datasets/eugenesiow/BSD100/resolve/main/data/BSD100_HR.tar.gz",
+        }
+    )
+    _checksums = MappingProxyType({"BSD100_HR": "2288d442262c1c26343fda3b36f05b03"})
+    # for integrity of downloaded data
+
+    def __init__(
+        self,
+        root: str = None,
+        download: bool = False,
+        transform: Callable = None,
+        verbose: bool = True,
+        use_dict_output: bool = False,
+    ) -> None:
+        self.root = resolve_root(root, "BSD100")
+        self.img_dir = os.path.join(self.root, "BSD100_HR")
+
+        # download dataset, we check first that dataset isn't already downloaded
+        if not self.check_dataset_exists():
+            if download:
+                if not os.path.isdir(self.root):
+                    os.makedirs(self.root)
+                if os.path.exists(self.img_dir):
+                    raise ValueError(
+                        f"The image folder already exists, thus the download is aborted. Please set `download=False` OR remove `{self.img_dir}`."
+                    )
+
+                for filename, url in self._archive_urls.items():
+                    download_archive(
+                        url=url,
+                        save_path=os.path.join(self.root, filename),
+                    )
+                    extract_tarball(os.path.join(self.root, filename), self.root)
+
+                if self.check_dataset_exists() and verbose:
+                    print("Dataset has been successfully downloaded.")
+                else:
+                    raise ValueError("There is an issue with the data downloaded.")
+            # stop the execution since the dataset is not available and we didn't download it
+            else:
+                raise RuntimeError(
+                    f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
+                )
+
+        # Initialize ImageFolder
+        super().__init__(
+            self.img_dir, transform=transform, use_dict_output=use_dict_output
+        )
+
+    def check_dataset_exists(self) -> bool:
+        """Verify that the image folders exist and contain all the images.
+
+        ``self.root`` should have the following structure: ::
+
+            self.root --- BSD100_HR --- 3096.png
+                    |               |
+                    |               --- 8023.png
+                    |               --- 12084.png
+                    |               --- ...
+                    |
+                    --- xxx
+        """
+        data_dir_exist = os.path.isdir(os.path.join(self.root, "BSD100_HR"))
+        if not data_dir_exist:
+            return False
+        return all(
+            calculate_md5_for_folder(os.path.join(self.root, folder_name)) == checksum
+            for folder_name, checksum in self._checksums.items()
+        )

--- a/deepinv/datasets/bsd100.py
+++ b/deepinv/datasets/bsd100.py
@@ -40,22 +40,6 @@ class BSD100HR(ImageFolder):
     :param bool verbose: Print a message if the dataset has been correctly downloaded. Default ``True``.
     :param bool use_dict_output: whether to return output as dict with keys "x", "y", "params" instead of tuple (default `False`).
 
-    |sep|
-
-    :Examples:
-
-        Instantiate dataset and download raw data from the Internet ::
-
-            import shutil
-            from deepinv.datasets import BSD100HR
-            dataset = BSD100HR(root="BSD100", download=True)  # download raw data at root and load dataset
-            Dataset has been successfully downloaded.
-            print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
-            True
-            print(len(dataset))                                  # check that we have 100 images
-            100
-            shutil.rmtree("BSD100")                          # remove raw data from disk
-
     """
 
     _archive_urls = MappingProxyType(

--- a/deepinv/datasets/bsd100.py
+++ b/deepinv/datasets/bsd100.py
@@ -87,7 +87,6 @@ class BSD100HR(ImageFolder):
                     f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
                 )
 
-        # Initialize ImageFolder
         super().__init__(
             self.img_dir, transform=transform, use_dict_output=use_dict_output
         )

--- a/deepinv/datasets/div2k.py
+++ b/deepinv/datasets/div2k.py
@@ -127,7 +127,6 @@ class DIV2K(ImageFolder):
                     f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`), OR set `download=True` (currently `download={download}`)."
                 )
 
-        # Initialize ImageFolder
         super().__init__(
             self.img_dir, transform=transform, use_dict_output=use_dict_output
         )

--- a/deepinv/datasets/flickr2k.py
+++ b/deepinv/datasets/flickr2k.py
@@ -106,7 +106,6 @@ class Flickr2kHR(ImageFolder):
                     f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
                 )
 
-        # Initialize ImageFolder
         super().__init__(
             self.img_dir, transform=transform, use_dict_output=use_dict_output
         )

--- a/deepinv/datasets/kodak24.py
+++ b/deepinv/datasets/kodak24.py
@@ -40,22 +40,6 @@ class Kodak24(ImageFolder):
     :param bool verbose: Print a message if the dataset has been correctly downloaded. Default ``True``.
     :param bool use_dict_output: whether to return output as dict with keys "x", "y", "params" instead of tuple (default `False`).
 
-    |sep|
-
-    :Examples:
-
-        Instantiate dataset and download raw data from the Internet ::
-
-            import shutil
-            from deepinv.datasets import Kodak24
-            dataset = Kodak24(root="Kodak24", download=True)  # download raw data at root and load dataset
-            Dataset has been successfully downloaded.
-            print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
-            True
-            print(len(dataset))                                  # check that we have 24 images
-            24
-            shutil.rmtree("Kodak24")                          # remove raw data from disk
-
     """
 
     _archive_urls = MappingProxyType(

--- a/deepinv/datasets/kodak24.py
+++ b/deepinv/datasets/kodak24.py
@@ -1,0 +1,138 @@
+from typing import Callable
+from types import MappingProxyType
+import os
+
+from deepinv.datasets.utils import (
+    calculate_md5_for_folder,
+    download_archive,
+    extract_zipfile,
+)
+from deepinv.datasets.base import ImageFolder
+from .utils import resolve_root
+
+
+class Kodak24(ImageFolder):
+    """Dataset for `Kodak24 <http://r0k.us/graphics/kodak/>`_.
+
+    The Kodak24 dataset :footcite:p:`kodak1993` is a dataset consisting of 24 images commonly used for testing performance of
+    image reconstruction algorithms. Images have a fixed size of 768×512 (or 512×768) pixels, with 8 bits per color
+    channel (24 bits per pixel RGB), i.e., the same color depth as a standard 8-bit PNG.
+
+    **Raw data file structure:** ::
+
+        self.root --- Kodak-Lossless-True-Color-Image-Suite-master.zip
+                |
+                --- Kodak-Lossless-True-Color-Image-Suite-master --- PhotoCD_PCD0992 --- 01.png
+                |                                                                     |
+                |                                                                     --- 02.png
+                |                                                                     --- ...
+                |
+                --- xxx
+
+    This dataset wrapper gives access to the 24 images in the `PhotoCD_PCD0992` folder.
+    Raw dataset source : https://github.com/MohamedBakrAli/Kodak-Lossless-True-Color-Image-Suite
+
+    :param str root: Root directory of dataset. Directory path from where we load and save the dataset.
+    :param bool download: If ``True``, downloads the dataset from the internet and puts it in root directory.
+        If dataset is already downloaded, it is not downloaded again. Default at False.
+    :param Callable transform:: (optional)  A function/transform that takes in a PIL image
+        and returns a transformed version. E.g, ``torchvision.transforms.RandomCrop``
+    :param bool verbose: Print a message if the dataset has been correctly downloaded. Default ``True``.
+    :param bool use_dict_output: whether to return output as dict with keys "x", "y", "params" instead of tuple (default `False`).
+
+    |sep|
+
+    :Examples:
+
+        Instantiate dataset and download raw data from the Internet ::
+
+            import shutil
+            from deepinv.datasets import Kodak24
+            dataset = Kodak24(root="Kodak24", download=True)  # download raw data at root and load dataset
+            Dataset has been successfully downloaded.
+            print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
+            True
+            print(len(dataset))                                  # check that we have 24 images
+            24
+            shutil.rmtree("Kodak24")                          # remove raw data from disk
+
+    """
+
+    _archive_urls = MappingProxyType(
+        {
+            "Kodak-Lossless-True-Color-Image-Suite-master.zip": "https://github.com/MohamedBakrAli/Kodak-Lossless-True-Color-Image-Suite/archive/refs/heads/master.zip",
+        }
+    )
+    _checksums = MappingProxyType(
+        {
+            "Kodak-Lossless-True-Color-Image-Suite-master/PhotoCD_PCD0992": "5b16b585b8f20e8ea62af85837d40e40"
+        }
+    )
+    # for integrity of downloaded data
+
+    def __init__(
+        self,
+        root: str = None,
+        download: bool = False,
+        transform: Callable = None,
+        verbose: bool = True,
+        use_dict_output: bool = False,
+    ) -> None:
+        self.root = resolve_root(root, "Kodak24")
+        self.img_dir = os.path.join(
+            self.root,
+            "Kodak-Lossless-True-Color-Image-Suite-master",
+            "PhotoCD_PCD0992",
+        )
+
+        # download dataset, we check first that dataset isn't already downloaded
+        if not self.check_dataset_exists():
+            if download:
+                if not os.path.isdir(self.root):
+                    os.makedirs(self.root)
+                if os.path.exists(self.img_dir):
+                    raise ValueError(
+                        f"The image folder already exists, thus the download is aborted. Please set `download=False` OR remove `{self.img_dir}`."
+                    )
+
+                for filename, url in self._archive_urls.items():
+                    download_archive(
+                        url=url,
+                        save_path=os.path.join(self.root, filename),
+                    )
+                    extract_zipfile(os.path.join(self.root, filename), self.root)
+
+                if self.check_dataset_exists() and verbose:
+                    print("Dataset has been successfully downloaded.")
+                else:
+                    raise ValueError("There is an issue with the data downloaded.")
+            # stop the execution since the dataset is not available and we didn't download it
+            else:
+                raise RuntimeError(
+                    f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
+                )
+
+        # Initialize ImageFolder
+        super().__init__(
+            self.img_dir, transform=transform, use_dict_output=use_dict_output
+        )
+
+    def check_dataset_exists(self) -> bool:
+        """Verify that the image folders exist and contain all the images.
+
+        ``self.root`` should have the following structure: ::
+
+            self.root --- Kodak-Lossless-True-Color-Image-Suite-master --- PhotoCD_PCD0992 --- 01.png
+                    |                                                                        |
+                    |                                                                        --- 02.png
+                    |                                                                        --- ...
+                    |
+                    --- xxx
+        """
+        data_dir_exist = os.path.isdir(self.img_dir)
+        if not data_dir_exist:
+            return False
+        return all(
+            calculate_md5_for_folder(os.path.join(self.root, folder_name)) == checksum
+            for folder_name, checksum in self._checksums.items()
+        )

--- a/deepinv/datasets/kodak24.py
+++ b/deepinv/datasets/kodak24.py
@@ -15,8 +15,7 @@ class Kodak24(ImageFolder):
     """Dataset for `Kodak24 <http://r0k.us/graphics/kodak/>`_.
 
     The Kodak24 dataset :footcite:p:`kodak1993` is a dataset consisting of 24 images commonly used for testing performance of
-    image reconstruction algorithms. Images have a fixed size of 768×512 (or 512×768) pixels, with 8 bits per color
-    channel (24 bits per pixel RGB), i.e., the same color depth as a standard 8-bit PNG.
+    image reconstruction algorithms. Images have a fixed size of 768×512 (or 512×768) pixels.
 
     **Raw data file structure:** ::
 
@@ -29,7 +28,6 @@ class Kodak24(ImageFolder):
                 |
                 --- xxx
 
-    This dataset wrapper gives access to the 24 images in the `PhotoCD_PCD0992` folder.
     Raw dataset source : https://github.com/MohamedBakrAli/Kodak-Lossless-True-Color-Image-Suite
 
     :param str root: Root directory of dataset. Directory path from where we load and save the dataset.

--- a/deepinv/datasets/kodak24.py
+++ b/deepinv/datasets/kodak24.py
@@ -94,7 +94,6 @@ class Kodak24(ImageFolder):
                     f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
                 )
 
-        # Initialize ImageFolder
         super().__init__(
             self.img_dir, transform=transform, use_dict_output=use_dict_output
         )

--- a/deepinv/datasets/lsdir.py
+++ b/deepinv/datasets/lsdir.py
@@ -166,7 +166,6 @@ class LsdirHR(ImageFolder):
         ):  # pragma: no cover
             raise RuntimeError("Data folder doesn't exist, please set `download=True`")
 
-        # Initialize ImageFolder
         if mode == "val":
             super().__init__(
                 self.root,

--- a/deepinv/datasets/lsdir.py
+++ b/deepinv/datasets/lsdir.py
@@ -18,7 +18,7 @@ class LsdirHR(ImageFolder):
     Published in :footcite:t:`li2023lsdir`.
 
     A large-scale dataset for image restoration tasks such as image super-resolution (SR),
-    image denoising, JPEG deblocking, deblurring, and demosaicking, and real-world SR.
+    image denoising, JPEG deblocking, deblurring, and demosaicing, and real-world SR.
 
 
     **Raw data file structure:** ::

--- a/deepinv/datasets/mcmaster.py
+++ b/deepinv/datasets/mcmaster.py
@@ -30,7 +30,6 @@ class McMaster(ImageFolder):
                 |
                 --- xxx
 
-    This dataset wrapper gives access to the 18 high resolution images in the `McM` folder.
     Raw dataset source : https://www4.comp.polyu.edu.hk/~cslzhang/DATA/McM.zip
 
     :param str root: Root directory of dataset. Directory path from where we load and save the dataset.

--- a/deepinv/datasets/mcmaster.py
+++ b/deepinv/datasets/mcmaster.py
@@ -41,22 +41,6 @@ class McMaster(ImageFolder):
     :param bool verbose: Print a message if the dataset has been correctly downloaded. Default ``True``.
     :param bool use_dict_output: whether to return output as dict with keys "x", "y", "params" instead of tuple (default `False`).
 
-    |sep|
-
-    :Examples:
-
-        Instantiate dataset and download raw data from the Internet ::
-
-            import shutil
-            from deepinv.datasets import McMaster
-            dataset = McMaster(root="McMaster", download=True)  # download raw data at root and load dataset
-            Dataset has been successfully downloaded.
-            print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
-            True
-            print(len(dataset))                                  # check that we have 18 images
-            18
-            shutil.rmtree("McMaster")                          # remove raw data from disk
-
     """
 
     _archive_urls = MappingProxyType(

--- a/deepinv/datasets/mcmaster.py
+++ b/deepinv/datasets/mcmaster.py
@@ -1,0 +1,137 @@
+from typing import Callable
+from types import MappingProxyType
+import os
+
+from deepinv.datasets.utils import (
+    calculate_md5_for_folder,
+    download_archive,
+    extract_zipfile,
+)
+from deepinv.datasets.base import ImageFolder
+from .utils import resolve_root
+
+
+class McMaster(ImageFolder):
+    """Dataset for `McMaster <https://www4.comp.polyu.edu.hk/~cslzhang/CDM_Dataset.htm>`_.
+
+    The McMaster dataset :footcite:p:`zhang2011color` is a dataset consisting of 18 images commonly used for testing performance of
+    color demosaicking and image reconstruction algorithms.
+    Images have a fixed size of 500×500 pixels.
+
+    **Raw data file structure:** ::
+
+        self.root --- McM.zip
+                |
+                --- McM --- 1.tif
+                |         |
+                |         --- 2.tif
+                |         --- 3.tif
+                |         --- ...
+                |
+                --- xxx
+
+    This dataset wrapper gives access to the 18 high resolution images in the `McM` folder.
+    Raw dataset source : https://www4.comp.polyu.edu.hk/~cslzhang/DATA/McM.zip
+
+    :param str root: Root directory of dataset. Directory path from where we load and save the dataset.
+    :param bool download: If ``True``, downloads the dataset from the internet and puts it in root directory.
+        If dataset is already downloaded, it is not downloaded again. Default at False.
+    :param Callable transform:: (optional)  A function/transform that takes in a PIL image
+        and returns a transformed version. E.g, ``torchvision.transforms.RandomCrop``
+    :param bool verbose: Print a message if the dataset has been correctly downloaded. Default ``True``.
+    :param bool use_dict_output: whether to return output as dict with keys "x", "y", "params" instead of tuple (default `False`).
+
+    |sep|
+
+    :Examples:
+
+        Instantiate dataset and download raw data from the Internet ::
+
+            import shutil
+            from deepinv.datasets import McMaster
+            dataset = McMaster(root="McMaster", download=True)  # download raw data at root and load dataset
+            Dataset has been successfully downloaded.
+            print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
+            True
+            print(len(dataset))                                  # check that we have 18 images
+            18
+            shutil.rmtree("McMaster")                          # remove raw data from disk
+
+    """
+
+    _archive_urls = MappingProxyType(
+        {
+            "McM.zip": "https://www4.comp.polyu.edu.hk/~cslzhang/DATA/McM.zip",
+        }
+    )
+    _archive_password = "McM_CDM"
+    _checksums = MappingProxyType({"McM": "27d5b588cb81cf7f2ddee6880a5bc2ea"})
+    # for integrity of downloaded data
+
+    def __init__(
+        self,
+        root: str = None,
+        download: bool = False,
+        transform: Callable = None,
+        verbose: bool = True,
+        use_dict_output: bool = False,
+    ) -> None:
+        self.root = resolve_root(root, "McMaster")
+        self.img_dir = os.path.join(self.root, "McM")
+
+        # download dataset, we check first that dataset isn't already downloaded
+        if not self.check_dataset_exists():
+            if download:
+                if not os.path.isdir(self.root):
+                    os.makedirs(self.root)
+                if os.path.exists(self.img_dir):
+                    raise ValueError(
+                        f"The image folder already exists, thus the download is aborted. Please set `download=False` OR remove `{self.img_dir}`."
+                    )
+
+                for filename, url in self._archive_urls.items():
+                    download_archive(
+                        url=url,
+                        save_path=os.path.join(self.root, filename),
+                    )
+                    extract_zipfile(
+                        os.path.join(self.root, filename),
+                        self.root,
+                        password=self._archive_password,
+                    )
+
+                if self.check_dataset_exists() and verbose:
+                    print("Dataset has been successfully downloaded.")
+                else:
+                    raise ValueError("There is an issue with the data downloaded.")
+            # stop the execution since the dataset is not available and we didn't download it
+            else:
+                raise RuntimeError(
+                    f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
+                )
+
+        # Initialize ImageFolder
+        super().__init__(
+            self.img_dir, transform=transform, use_dict_output=use_dict_output
+        )
+
+    def check_dataset_exists(self) -> bool:
+        """Verify that the image folders exist and contain all the images.
+
+        ``self.root`` should have the following structure: ::
+
+            self.root --- McM --- 1.tif
+                    |            |
+                    |            --- 2.tif
+                    |            --- 3.tif
+                    |            --- ...
+                    |
+                    --- xxx
+        """
+        data_dir_exist = os.path.isdir(os.path.join(self.root, "McM"))
+        if not data_dir_exist:
+            return False
+        return all(
+            calculate_md5_for_folder(os.path.join(self.root, folder_name)) == checksum
+            for folder_name, checksum in self._checksums.items()
+        )

--- a/deepinv/datasets/mcmaster.py
+++ b/deepinv/datasets/mcmaster.py
@@ -93,7 +93,6 @@ class McMaster(ImageFolder):
                     f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
                 )
 
-        # Initialize ImageFolder
         super().__init__(
             self.img_dir, transform=transform, use_dict_output=use_dict_output
         )

--- a/deepinv/datasets/mcmaster.py
+++ b/deepinv/datasets/mcmaster.py
@@ -15,7 +15,7 @@ class McMaster(ImageFolder):
     """Dataset for `McMaster <https://www4.comp.polyu.edu.hk/~cslzhang/CDM_Dataset.htm>`_.
 
     The McMaster dataset :footcite:p:`zhang2011color` is a dataset consisting of 18 images commonly used for testing performance of
-    color demosaicking and image reconstruction algorithms.
+    color demosaicing and image reconstruction algorithms.
     Images have a fixed size of 500×500 pixels.
 
     **Raw data file structure:** ::

--- a/deepinv/datasets/set14.py
+++ b/deepinv/datasets/set14.py
@@ -104,7 +104,6 @@ class Set14HR(ImageFolder):
                     f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
                 )
 
-        # Initialize ImageFolder
         super().__init__(
             self.img_dir, transform=transform, use_dict_output=use_dict_output
         )

--- a/deepinv/datasets/set5.py
+++ b/deepinv/datasets/set5.py
@@ -40,22 +40,6 @@ class Set5HR(ImageFolder):
     :param bool verbose: Print a message if the dataset has been correctly downloaded. Default ``True``.
     :param bool use_dict_output: whether to return output as dict with keys "x", "y", "params" instead of tuple (default `False`).
 
-    |sep|
-
-    :Examples:
-
-        Instantiate dataset and download raw data from the Internet ::
-
-            import shutil
-            from deepinv.datasets import Set5HR
-            dataset = Set5HR(root="Set5", download=True)  # download raw data at root and load dataset
-            Dataset has been successfully downloaded.
-            print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
-            True
-            print(len(dataset))                                  # check that we have 5 images
-            5
-            shutil.rmtree("Set5")                          # remove raw data from disk
-
     """
 
     _archive_urls = MappingProxyType(

--- a/deepinv/datasets/set5.py
+++ b/deepinv/datasets/set5.py
@@ -1,0 +1,131 @@
+from typing import Callable
+from types import MappingProxyType
+import os
+
+from deepinv.datasets.utils import (
+    calculate_md5_for_folder,
+    download_archive,
+    extract_tarball,
+)
+from deepinv.datasets.base import ImageFolder
+from .utils import resolve_root
+
+
+class Set5HR(ImageFolder):
+    """Dataset for `Set5 <https://paperswithcode.com/dataset/set5>`_.
+
+    The Set5 dataset :footcite:p:`bevilacqua2012low` is a dataset consisting of 5 images commonly used for testing performance of image reconstruction algorithms.
+    Images have sizes ranging from 256×256 to 512×512 pixels.
+
+    **Raw data file structure:** ::
+
+        self.root --- Set5_HR.tar.gz
+                |
+                --- Set5_HR --- baby.png
+                |             |
+                |             --- bird.png
+                |             --- butterfly.png
+                |             --- ...
+                |
+                --- xxx
+
+    This dataset wrapper gives access to the 5 high resolution images in the `Set5_HR` folder.
+    Raw dataset source : https://huggingface.co/datasets/eugenesiow/Set5
+
+    :param str root: Root directory of dataset. Directory path from where we load and save the dataset.
+    :param bool download: If ``True``, downloads the dataset from the internet and puts it in root directory.
+        If dataset is already downloaded, it is not downloaded again. Default at False.
+    :param Callable transform:: (optional)  A function/transform that takes in a PIL image
+        and returns a transformed version. E.g, ``torchvision.transforms.RandomCrop``
+    :param bool verbose: Print a message if the dataset has been correctly downloaded. Default ``True``.
+    :param bool use_dict_output: whether to return output as dict with keys "x", "y", "params" instead of tuple (default `False`).
+
+    |sep|
+
+    :Examples:
+
+        Instantiate dataset and download raw data from the Internet ::
+
+            import shutil
+            from deepinv.datasets import Set5HR
+            dataset = Set5HR(root="Set5", download=True)  # download raw data at root and load dataset
+            Dataset has been successfully downloaded.
+            print(dataset.check_dataset_exists())                # check that raw data has been downloaded correctly
+            True
+            print(len(dataset))                                  # check that we have 5 images
+            5
+            shutil.rmtree("Set5")                          # remove raw data from disk
+
+    """
+
+    _archive_urls = MappingProxyType(
+        {
+            "Set5_HR.tar.gz": "https://huggingface.co/datasets/eugenesiow/Set5/resolve/main/data/Set5_HR.tar.gz",
+        }
+    )
+    _checksums = MappingProxyType({"Set5_HR": "e128ede786dabb7ebeee99e5fa1ad985"})
+    # for integrity of downloaded data
+
+    def __init__(
+        self,
+        root: str = None,
+        download: bool = False,
+        transform: Callable = None,
+        verbose: bool = True,
+        use_dict_output: bool = False,
+    ) -> None:
+        self.root = resolve_root(root, "Set5")
+        self.img_dir = os.path.join(self.root, "Set5_HR")
+
+        # download dataset, we check first that dataset isn't already downloaded
+        if not self.check_dataset_exists():
+            if download:
+                if not os.path.isdir(self.root):
+                    os.makedirs(self.root)
+                if os.path.exists(self.img_dir):
+                    raise ValueError(
+                        f"The image folder already exists, thus the download is aborted. Please set `download=False` OR remove `{self.img_dir}`."
+                    )
+
+                for filename, url in self._archive_urls.items():
+                    download_archive(
+                        url=url,
+                        save_path=os.path.join(self.root, filename),
+                    )
+                    extract_tarball(os.path.join(self.root, filename), self.root)
+
+                if self.check_dataset_exists() and verbose:
+                    print("Dataset has been successfully downloaded.")
+                else:
+                    raise ValueError("There is an issue with the data downloaded.")
+            # stop the execution since the dataset is not available and we didn't download it
+            else:
+                raise RuntimeError(
+                    f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
+                )
+
+        # Initialize ImageFolder
+        super().__init__(
+            self.img_dir, transform=transform, use_dict_output=use_dict_output
+        )
+
+    def check_dataset_exists(self) -> bool:
+        """Verify that the image folders exist and contain all the images.
+
+        ``self.root`` should have the following structure: ::
+
+            self.root --- Set5_HR --- baby.png
+                    |             |
+                    |             --- bird.png
+                    |             --- butterfly.png
+                    |             --- ...
+                    |
+                    --- xxx
+        """
+        data_dir_exist = os.path.isdir(os.path.join(self.root, "Set5_HR"))
+        if not data_dir_exist:
+            return False
+        return all(
+            calculate_md5_for_folder(os.path.join(self.root, folder_name)) == checksum
+            for folder_name, checksum in self._checksums.items()
+        )

--- a/deepinv/datasets/set5.py
+++ b/deepinv/datasets/set5.py
@@ -29,7 +29,6 @@ class Set5HR(ImageFolder):
                 |
                 --- xxx
 
-    This dataset wrapper gives access to the 5 high resolution images in the `Set5_HR` folder.
     Raw dataset source : https://huggingface.co/datasets/eugenesiow/Set5
 
     :param str root: Root directory of dataset. Directory path from where we load and save the dataset.

--- a/deepinv/datasets/set5.py
+++ b/deepinv/datasets/set5.py
@@ -87,7 +87,6 @@ class Set5HR(ImageFolder):
                     f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
                 )
 
-        # Initialize ImageFolder
         super().__init__(
             self.img_dir, transform=transform, use_dict_output=use_dict_output
         )

--- a/deepinv/datasets/urban100.py
+++ b/deepinv/datasets/urban100.py
@@ -106,7 +106,6 @@ class Urban100HR(ImageFolder):
                     f"Dataset not found at `{self.root}`. Please set `root` correctly (currently `root={self.root}`) OR set `download=True` (currently `download={download}`)."
                 )
 
-        # Initialize ImageFolder
         super().__init__(
             self.root, transform=transform, use_dict_output=use_dict_output
         )

--- a/deepinv/datasets/utils.py
+++ b/deepinv/datasets/utils.py
@@ -109,8 +109,7 @@ def extract_zipfile(
     with zipfile.ZipFile(file_path, "r") as zip_ref:
         pwd = password.encode() if password is not None else None
         # Progress bar on the total number of files to be extracted
-        # Since files may be very huge or very small, the extraction time vary per file
-        # Thus the progress bar will not move linearly with time
+        # Since file size may be variable, the extraction time varies per file
         for file_to_be_extracted in tqdm(zip_ref.infolist(), desc="Extracting"):
             zip_ref.extract(file_to_be_extracted, extract_dir, pwd=pwd)
 
@@ -120,8 +119,7 @@ def extract_tarball(file_path: str | Path, extract_dir: str | Path) -> None:
     # Open the tar file
     with tarfile.open(file_path, "r:*") as tar_ref:
         # Progress bar on the total number of files to be extracted
-        # Since files may be very huge or very small, the extraction time vary per file
-        # Thus the progress bar will not move linearly with time
+        # Since file size may be variable, the extraction time varies per file
         for file_to_be_extracted in tqdm(tar_ref.getmembers(), desc="Extracting"):
             tar_ref.extract(file_to_be_extracted, extract_dir)
 

--- a/deepinv/datasets/utils.py
+++ b/deepinv/datasets/utils.py
@@ -96,15 +96,23 @@ def download_archive(
                 extract_rarfile(save_path, Path(save_path).parent)
 
 
-def extract_zipfile(file_path: str | Path, extract_dir: str | Path) -> None:
-    """Extract a local zip file."""
+def extract_zipfile(
+    file_path: str | Path, extract_dir: str | Path, password: str | None = None
+) -> None:
+    """Extract a local zip file.
+
+    :param str, pathlib.Path file_path: path of the zip file to extract.
+    :param str, pathlib.Path extract_dir: directory where the content should be extracted.
+    :param str password: password to decrypt the archive, if it is password-protected. Default `None`.
+    """
     # Open the zip file
     with zipfile.ZipFile(file_path, "r") as zip_ref:
+        pwd = password.encode() if password is not None else None
         # Progress bar on the total number of files to be extracted
         # Since files may be very huge or very small, the extraction time vary per file
         # Thus the progress bar will not move linearly with time
         for file_to_be_extracted in tqdm(zip_ref.infolist(), desc="Extracting"):
-            zip_ref.extract(file_to_be_extracted, extract_dir)
+            zip_ref.extract(file_to_be_extracted, extract_dir, pwd=pwd)
 
 
 def extract_tarball(file_path: str | Path, extract_dir: str | Path) -> None:

--- a/deepinv/datasets/utils.py
+++ b/deepinv/datasets/utils.py
@@ -99,12 +99,7 @@ def download_archive(
 def extract_zipfile(
     file_path: str | Path, extract_dir: str | Path, password: str | None = None
 ) -> None:
-    """Extract a local zip file.
-
-    :param str, pathlib.Path file_path: path of the zip file to extract.
-    :param str, pathlib.Path extract_dir: directory where the content should be extracted.
-    :param str password: password to decrypt the archive, if it is password-protected. Default `None`.
-    """
+    """Extract a local zip file."""
     # Open the zip file
     with zipfile.ZipFile(file_path, "r") as zip_ref:
         pwd = password.encode() if password is not None else None

--- a/deepinv/tests/test_datasets.py
+++ b/deepinv/tests/test_datasets.py
@@ -22,8 +22,12 @@ from deepinv.datasets import (
     DIV2K,
     Urban100HR,
     Set14HR,
+    Set5HR,
     CBSD68,
     BSDS500,
+    BSD100HR,
+    McMaster,
+    Kodak24,
     LsdirHR,
     FMD,
     Kohler,
@@ -855,6 +859,57 @@ def test_load_set14_dataset(download_set14, use_dict_output):
 
 
 @pytest.fixture
+def download_set5(tmp_path):
+    """Downloads dataset for tests and removes it after test executions."""
+    if not os.environ.get("DEEPINV_MOCK_TESTS", False):
+        tmp_data_dir = str(tmp_path / "Set5")
+
+        # Download Set5 raw dataset
+        with pytest.warns(DeprecationWarning, match="use_dict_output=True"):
+            Set5HR(tmp_data_dir, download=True)
+
+        # This will return control to the test function
+        yield tmp_data_dir
+
+        # After the test function complete, any code after the yield statement will run
+        shutil.rmtree(tmp_data_dir)
+    else:
+        with (
+            patch.object(Set5HR, "check_dataset_exists", return_value=True),
+            patch.object(
+                Path,
+                "glob",
+                side_effect=lambda p: (
+                    [] if p[-3:] != "png" else [f"{i}_HR.png" for i in range(1, 6)]
+                ),
+            ),  # Only patch globbing pngs
+            patch.object(PIL.Image, "open", return_value=get_dummy_pil_png_image()),
+        ):
+            yield "/dummy"
+
+
+@pytest.mark.parametrize("use_dict_output", [True, False])
+def test_load_set5_dataset(download_set5, use_dict_output):
+    """Check that dataset contains 5 PIL images."""
+    for totensor in [ToTensor(), None]:
+        with dataset_output_context(use_dict_output):
+            dtype = image_output_type(
+                use_dict_output, totensor, paired=False, untransformed_type=PIL_Image
+            )
+            check_dataset_format(
+                Set5HR(
+                    download_set5,
+                    download=False,
+                    transform=totensor,
+                    use_dict_output=use_dict_output,
+                ),
+                length=5,
+                dtype=dtype,
+                allow_non_tensor=not totensor,
+            )
+
+
+@pytest.fixture
 def download_flickr2khr(tmp_path):
     """Download or mock Flickr2kHR before testing"""
     if not os.environ.get("DEEPINV_MOCK_TESTS", False):
@@ -998,6 +1053,159 @@ def test_load_bsds500_dataset(
             dtype=dtype,
             allow_non_tensor=not totensor,
         )
+
+
+@pytest.fixture
+def download_bsd100(tmp_path):
+    """Downloads dataset for tests and removes it after test executions."""
+    if not os.environ.get("DEEPINV_MOCK_TESTS", False):
+        tmp_data_dir = str(tmp_path / "BSD100")
+
+        # Download BSD100 raw dataset
+        with pytest.warns(DeprecationWarning, match="use_dict_output=True"):
+            BSD100HR(tmp_data_dir, download=True)
+
+        # This will return control to the test function
+        yield tmp_data_dir
+
+        # After the test function complete, any code after the yield statement will run
+        shutil.rmtree(tmp_data_dir)
+    else:
+        with (
+            patch.object(BSD100HR, "check_dataset_exists", return_value=True),
+            patch.object(
+                Path,
+                "glob",
+                side_effect=lambda p: (
+                    [] if p[-3:] != "png" else [f"{i}_HR.png" for i in range(1, 101)]
+                ),
+            ),  # Only patch globbing pngs
+            patch.object(PIL.Image, "open", return_value=get_dummy_pil_png_image()),
+        ):
+            yield "/dummy"
+
+
+@pytest.mark.parametrize("use_dict_output", [True, False])
+def test_load_bsd100_dataset(download_bsd100, use_dict_output):
+    """Check that dataset contains 100 PIL images."""
+    for totensor in [ToTensor(), None]:
+        with dataset_output_context(use_dict_output):
+            dtype = image_output_type(
+                use_dict_output, totensor, paired=False, untransformed_type=PIL_Image
+            )
+            check_dataset_format(
+                BSD100HR(
+                    download_bsd100,
+                    download=False,
+                    transform=totensor,
+                    use_dict_output=use_dict_output,
+                ),
+                length=100,
+                dtype=dtype,
+                allow_non_tensor=not totensor,
+            )
+
+
+@pytest.fixture
+def download_mcmaster(tmp_path):
+    """Downloads dataset for tests and removes it after test executions."""
+    if not os.environ.get("DEEPINV_MOCK_TESTS", False):
+        tmp_data_dir = str(tmp_path / "McMaster")
+
+        # Download McMaster raw dataset
+        with pytest.warns(DeprecationWarning, match="use_dict_output=True"):
+            McMaster(tmp_data_dir, download=True)
+
+        # This will return control to the test function
+        yield tmp_data_dir
+
+        # After the test function complete, any code after the yield statement will run
+        shutil.rmtree(tmp_data_dir)
+    else:
+        with (
+            patch.object(McMaster, "check_dataset_exists", return_value=True),
+            patch.object(
+                Path,
+                "glob",
+                side_effect=lambda p: (
+                    [] if p[-3:] != "tif" else [f"{i}.tif" for i in range(1, 19)]
+                ),
+            ),  # Only patch globbing tifs
+            patch.object(PIL.Image, "open", return_value=get_dummy_pil_png_image()),
+        ):
+            yield "/dummy"
+
+
+@pytest.mark.parametrize("use_dict_output", [True, False])
+def test_load_mcmaster_dataset(download_mcmaster, use_dict_output):
+    """Check that dataset contains 18 PIL images."""
+    for totensor in [ToTensor(), None]:
+        with dataset_output_context(use_dict_output):
+            dtype = image_output_type(
+                use_dict_output, totensor, paired=False, untransformed_type=PIL_Image
+            )
+            check_dataset_format(
+                McMaster(
+                    download_mcmaster,
+                    download=False,
+                    transform=totensor,
+                    use_dict_output=use_dict_output,
+                ),
+                length=18,
+                dtype=dtype,
+                allow_non_tensor=not totensor,
+            )
+
+
+@pytest.fixture
+def download_kodak24(tmp_path):
+    """Downloads dataset for tests and removes it after test executions."""
+    if not os.environ.get("DEEPINV_MOCK_TESTS", False):
+        tmp_data_dir = str(tmp_path / "Kodak24")
+
+        # Download Kodak24 raw dataset
+        with pytest.warns(DeprecationWarning, match="use_dict_output=True"):
+            Kodak24(tmp_data_dir, download=True)
+
+        # This will return control to the test function
+        yield tmp_data_dir
+
+        # After the test function complete, any code after the yield statement will run
+        shutil.rmtree(tmp_data_dir)
+    else:
+        with (
+            patch.object(Kodak24, "check_dataset_exists", return_value=True),
+            patch.object(
+                Path,
+                "glob",
+                side_effect=lambda p: (
+                    [] if p[-3:] != "png" else [f"{i:02d}.png" for i in range(1, 25)]
+                ),
+            ),  # Only patch globbing pngs
+            patch.object(PIL.Image, "open", return_value=get_dummy_pil_png_image()),
+        ):
+            yield "/dummy"
+
+
+@pytest.mark.parametrize("use_dict_output", [True, False])
+def test_load_kodak24_dataset(download_kodak24, use_dict_output):
+    """Check that dataset contains 24 PIL images."""
+    for totensor in [ToTensor(), None]:
+        with dataset_output_context(use_dict_output):
+            dtype = image_output_type(
+                use_dict_output, totensor, paired=False, untransformed_type=PIL_Image
+            )
+            check_dataset_format(
+                Kodak24(
+                    download_kodak24,
+                    download=False,
+                    transform=totensor,
+                    use_dict_output=use_dict_output,
+                ),
+                length=24,
+                dtype=dtype,
+                allow_non_tensor=not totensor,
+            )
 
 
 @pytest.fixture

--- a/docs/source/api/deepinv.datasets.rst
+++ b/docs/source/api/deepinv.datasets.rst
@@ -56,7 +56,10 @@ Image Datasets
     deepinv.datasets.DIV2K
     deepinv.datasets.Urban100HR
     deepinv.datasets.Set14HR
+    deepinv.datasets.Set5HR
     deepinv.datasets.BSDS500
+    deepinv.datasets.BSD100HR
+    deepinv.datasets.McMaster
     deepinv.datasets.CBSD68
     deepinv.datasets.FastMRISliceDataset
     deepinv.datasets.SimpleFastMRISliceDataset

--- a/docs/source/api/deepinv.datasets.rst
+++ b/docs/source/api/deepinv.datasets.rst
@@ -60,6 +60,7 @@ Image Datasets
     deepinv.datasets.BSDS500
     deepinv.datasets.BSD100HR
     deepinv.datasets.McMaster
+    deepinv.datasets.Kodak24
     deepinv.datasets.CBSD68
     deepinv.datasets.FastMRISliceDataset
     deepinv.datasets.SimpleFastMRISliceDataset

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ New Features
 - Add :func:`deepinv.physics.TomographyWithAstra.from_astra_geometry` to build the operator directly from pre-created ``astra`` geometries (:gh:`1102` by `Margaret Duff`_)
 - Add downloadable pretrained weights to :class:`deepinv.models.FFDNet` (:gh:`1357` by `Vicky De Ridder`_)
 - Add :func:`deepinv.utils.plot` to disable image rescaling with ``rescale_mode=None``. (:gh:`1339` by `Delphine Doutsas`_)
+- Add :class:`deepinv.datasets.Set5HR`, :class:`deepinv.datasets.BSD100HR`, :class:`deepinv.datasets.McMaster` and :class:`deepinv.datasets.Kodak24` datasets (:gh:`1382` by `Vicky De Ridder`_)
 
 Changed
 ^^^^^^^

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -72,6 +72,27 @@
 }
 
 
+@article{zhang2011color,
+    title={Color demosaicking by local directional interpolation and nonlocal adaptive thresholding},
+    author={Zhang, Lei and Wu, Xiaolin and Buades, Antoni and Li, Xin},
+    journal={Journal of Electronic imaging},
+    volume={20},
+    number={2},
+    pages={023016--023016},
+    year={2011},
+    publisher={Society of Photo-Optical Instrumentation Engineers}
+}
+
+
+@inproceedings{bevilacqua2012low,
+    title={Low-Complexity Single-Image Super-Resolution based on Nonnegative Neighbor Embedding},
+    Author = {Bevilacqua, Marco and Roumy, Aline and Guillemot, Christine and Alberi-Morel, Marie-Line},
+    booktitle = {Proceedings of the British Machine Vision Conference (BMVC)},
+    pages={135.1--135.10},
+    Year = {2012}
+}
+
+
 @inproceedings{acar2021self,
   title={Self-supervised dynamic MRI reconstruction},
   author={Acar, Mert and {\c{C}}ukur, Tolga and {\"O}ks{\"u}z, {\.I}lkay},

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -72,6 +72,14 @@
 }
 
 
+@misc{kodak1993,
+    title = {Kodak Lossless True Color Image Suite},
+    author = {{Eastman Kodak Company}},
+    year = {1993},
+    howpublished = {\url{http://r0k.us/graphics/kodak/}},
+}
+
+
 @article{zhang2011color,
     title={Color demosaicking by local directional interpolation and nonlocal adaptive thresholding},
     author={Zhang, Lei and Wu, Xiaolin and Buades, Antoni and Li, Xin},

--- a/docs/source/user_guide/training/datasets.rst
+++ b/docs/source/user_guide/training/datasets.rst
@@ -157,11 +157,29 @@ All these datasets inherit from :class:`deepinv.datasets.ImageDataset`.
      - RGB, 248×248 to 512×768 pixels.
      - A small benchmark dataset for super-resolution tasks, containing a variety of natural images.
 
+   * - :class:`Set5HR <deepinv.datasets.Set5HR>`
+     - `x`
+     - 5 high-resolution images
+     - RGB, 256×256 to 512×512 pixels.
+     - A very small benchmark dataset for super-resolution tasks, containing a variety of natural images.
+
    * - :class:`BSDS500 <deepinv.datasets.BSDS500>`
      - `x`
      - 400 (train) + 100 (test) images
      - RGB, 481x321 or 321x481 pixels
      - Color Berkeley Segmentation Dataset.
+
+   * - :class:`BSD100HR <deepinv.datasets.BSD100HR>`
+     - `x`
+     - 100 high-resolution images
+     - RGB, 240×160 to 480×320 pixels.
+     - A benchmark subset of BSDS300/BSDS500 commonly used for super-resolution tasks.
+
+   * - :class:`McMaster <deepinv.datasets.McMaster>`
+     - `x`
+     - 18 images
+     - RGB, 500×500 pixels.
+     - A small benchmark dataset commonly used for testing color demosaicking algorithms.
 
    * - :class:`CBSD68 <deepinv.datasets.CBSD68>`
      - `x`

--- a/docs/source/user_guide/training/datasets.rst
+++ b/docs/source/user_guide/training/datasets.rst
@@ -161,7 +161,7 @@ All these datasets inherit from :class:`deepinv.datasets.ImageDataset`.
      - `x`
      - 5 high-resolution images
      - RGB, 256×256 to 512×512 pixels.
-     - A very small benchmark dataset for super-resolution tasks, containing a variety of natural images.
+     - A very small benchmark dataset commonly used for super-resolution tasks.
 
    * - :class:`BSDS500 <deepinv.datasets.BSDS500>`
      - `x`

--- a/docs/source/user_guide/training/datasets.rst
+++ b/docs/source/user_guide/training/datasets.rst
@@ -181,6 +181,12 @@ All these datasets inherit from :class:`deepinv.datasets.ImageDataset`.
      - RGB, 500×500 pixels.
      - A small benchmark dataset commonly used for testing color demosaicking algorithms.
 
+   * - :class:`Kodak24 <deepinv.datasets.Kodak24>`
+     - `x`
+     - 24 images
+     - RGB, 768×512 or 512×768 pixels.
+     - A widely-used benchmark dataset for denoising, compression and demosaicking.
+
    * - :class:`CBSD68 <deepinv.datasets.CBSD68>`
      - `x`
      - 68 images

--- a/docs/source/user_guide/training/datasets.rst
+++ b/docs/source/user_guide/training/datasets.rst
@@ -179,13 +179,13 @@ All these datasets inherit from :class:`deepinv.datasets.ImageDataset`.
      - `x`
      - 18 images
      - RGB, 500×500 pixels.
-     - A small benchmark dataset commonly used for testing color demosaicking algorithms.
+     - A small benchmark dataset commonly used for testing color demosaicing algorithms.
 
    * - :class:`Kodak24 <deepinv.datasets.Kodak24>`
      - `x`
      - 24 images
      - RGB, 768×512 or 512×768 pixels.
-     - A widely-used benchmark dataset for denoising, compression and demosaicking.
+     - A widely-used benchmark dataset for denoising, compression and demosaicing.
 
    * - :class:`CBSD68 <deepinv.datasets.CBSD68>`
      - `x`


### PR DESCRIPTION
- Add Set5, BSD100, McMaster, Kodak24
- Add an optional `password` argument to `extract_zipfile`. Some datasets have a password for the zip, even though the password is publicly documented on the source's html (see https://www4.comp.polyu.edu.hk/~cslzhang/CDM_Dataset.htm)

These datasets are all used often as test sets. For instance, `SwinIR` reports performance on all of these in their papers.

Making these available saves users time trying to source them, and makes plugging them into our existing framework zero-cost to them. Additionally, these datasets may be useful to the benchmarks project.

**Questions:**

- *There is a lot of duplicate code between these classes. This was already the case for our other natural imaging datasets, but this PR intensifies the code duplication. A new parent class or some extra functions in `utils.py` to handle e.g. all the downloading and extracting logic after `if not self.check_dataset_exists()` may reduce duplicate code. We can handle this in this PR, or in another one. Thoughts? Same argument can probably be made for tests of these datasets* ==> deferred to a later PR

- We might be able to address #1224 in this PR. Have I interpreted correctly the agreed upon solution is to delete the zip only when we downloaded and extracted the zip in that runtime of the `init`? @jscanvic @Zeppo1994

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [x] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [ ] I did not use LLM tools to write the code
- [x] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.