### PR TITLE
Make `relu` act inplace

### DIFF
--- a/deepinv/models/ae.py
+++ b/deepinv/models/ae.py
@@ -28,12 +28,12 @@ class AutoEncoder(Denoiser):
 
         self.encoder = torch.nn.Sequential(
             torch.nn.Linear(dim_input, dim_mid),
-            torch.nn.ReLU(),
+            torch.nn.ReLU(inplace=True),
             torch.nn.Linear(dim_mid, dim_hid),
         )
         self.decoder = torch.nn.Sequential(
             torch.nn.Linear(dim_hid, dim_mid),
-            torch.nn.ReLU(),
+            torch.nn.ReLU(inplace=True),
             torch.nn.Linear(dim_mid, dim_input),
         )
 

--- a/deepinv/models/dip.py
+++ b/deepinv/models/dip.py
@@ -77,7 +77,7 @@ class ConvDecoder(nn.Module):
                     bias=True,
                 )
             )
-            self.net.append(nn.ReLU())
+            self.net.append(nn.ReLU(inplace=True))
             self.net.append(batchnorm(channels, affine=True))
         # final layer
         self.net.append(
@@ -90,7 +90,7 @@ class ConvDecoder(nn.Module):
                 bias=True,
             )
         )
-        self.net.append(nn.ReLU())
+        self.net.append(nn.ReLU(inplace=True))
         self.net.append(batchnorm(channels, affine=True))
         self.net.append(conv(channels, output_channels, 1, 1, padding=0, bias=True))
 

--- a/deepinv/models/dncnn.py
+++ b/deepinv/models/dncnn.py
@@ -72,7 +72,9 @@ class DnCNN(Denoiser):
             nf, out_channels, kernel_size=3, stride=1, padding=1, bias=bias
         )
 
-        self.nl_list = nn.ModuleList([nn.ReLU() for _ in range(self.depth - 1)])
+        self.nl_list = nn.ModuleList(
+            [nn.ReLU(inplace=True) for _ in range(self.depth - 1)]
+        )
 
         if pretrained is not None:
             if pretrained.startswith("download"):

--- a/deepinv/models/multispectral.py
+++ b/deepinv/models/multispectral.py
@@ -41,7 +41,7 @@ class ResNet(nn.Module):
                 padding=1,
             ),
             nn.BatchNorm2d(hidden_channels) if self.batch_norm else nn.Identity(),
-            nn.ReLU(),
+            nn.ReLU(inplace=True),
             nn.Conv2d(
                 in_channels=hidden_channels,
                 out_channels=hidden_channels,
@@ -50,13 +50,13 @@ class ResNet(nn.Module):
                 padding=1,
             ),
             nn.BatchNorm2d(hidden_channels) if self.batch_norm else nn.Identity(),
-            nn.ReLU() if self.relu_before_addition else nn.Identity(),
+            nn.ReLU(inplace=True) if self.relu_before_addition else nn.Identity(),
         )
 
     def forward(self, x):
         for block in self.blocks:
             x = x + block(x)
-            x = nn.ReLU()(x) if not self.relu_before_addition else x
+            x = nn.ReLU(inplace=True)(x) if not self.relu_before_addition else x
         return x
 
 

--- a/deepinv/models/srresnet.py
+++ b/deepinv/models/srresnet.py
@@ -112,7 +112,7 @@ class SRResNet(Reconstructor):
         self.final_conv = nn.Sequential(
             *(
                 [nn.Conv2d(feats, im_c, final_kernel_size, 1, p)]
-                + ([nn.ReLU()] if final_relu else [])
+                + ([nn.ReLU(inplace=True)] if final_relu else [])
             )
         )
         if device is not None:

--- a/deepinv/optim/prior.py
+++ b/deepinv/optim/prior.py
@@ -913,9 +913,9 @@ class PatchNR(Prior):
             def subnet_fc(c_in, c_out):
                 return nn.Sequential(
                     nn.Linear(c_in, sub_net_size),
-                    nn.ReLU(),
+                    nn.ReLU(inplace=True),
                     nn.Linear(sub_net_size, sub_net_size),
-                    nn.ReLU(),
+                    nn.ReLU(inplace=True),
                     nn.Linear(sub_net_size, c_out),
                 )
 

--- a/docs/source/api/deepinv.distributed.rst
+++ b/docs/source/api/deepinv.distributed.rst
@@ -6,7 +6,7 @@ multiple devices and processes. The core function :func:`~deepinv.distributed.di
 wraps your objects (stacked physics, denoisers, data fidelity) into their
 distributed counterparts, handling all the boilerplate for you.
 
-See the :ref:`user guide on distributed reconstruction<distributed>` for more information.
+See the :ref:`user guide on distributed reconstruction<distributed-reconstruction>` for more information.
 
 Main API
 --------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -113,7 +113,7 @@ Changed
 
 Fixed
 ^^^^^
-- Add warning when options `reduce="mean"` and `reduce="none"` are used in :class:`deepinv.physics.StackedLinearPhysics`. Remove `reduction` argument from :class:`deepinv.distributed.DistributedStackedLinearPhysics` (:gh:`1071` by `Romain Vo`_)
+- Add warning when options `reduce="mean"` and `reduce="none"` are used in :class:`deepinv.physics.StackedLinearPhysics`. Remove `reduction` argument from :class:`deepinv.distributed.framework.DistributedStackedLinearPhysics` (:gh:`1071` by `Romain Vo`_)
 - Correct the value of ``Transform.n_trans`` in composed transformations (:gh:`881` by `Jérémy Scanvic`_)
 - Add support for computing the evaluation loss for splitting losses like :class:`deepinv.loss.SplittingLoss` in the trainer (:gh:`881` by `Jérémy Scanvic`_)
 - Add a deprecation warning in :func:`deepinv.utils.plot_inset` in favor of :func:`deepinv.utils.plot` with `plot_inset=True` (:gh:`1148` by `Paul Bernard`_).
@@ -134,7 +134,7 @@ New Features
 - Add :class:`deepinv.physics.Scattering` physics for non-linear inverse scattering problems (:gh:`1020` by `Julian Tachella`_)
 - Add :meth:`deepinv.physics.Physics.compute_norm` local operator norm computation for non-linear physics (:gh:`1020` by `Julian Tachella`_)
 - Add :class:`deepinv.models.BilateralFilter` model (:gh:`997` by `Thomas Boulanger`_)
-- Add distributed computing framework with :class:`deepinv.distributed.DistributedContext`, :class:`deepinv.distributed.DistributedStackedPhysics`, :class:`deepinv.distributed.DistributedProcessing`, :class:`deepinv.distributed.DistributedDataFidelity` and :func:`deepinv.distributed.distribute` factory function. Supports multi-GPU/multi-process execution with physics-based and spatial tiling distribution strategies (:gh:`790`` by `Benoît Malézieux`_)
+- Add distributed computing framework with :class:`deepinv.distributed.DistributedContext`, :class:`deepinv.distributed.framework.DistributedStackedPhysics`, :class:`deepinv.distributed.framework.DistributedProcessing`, :class:`deepinv.distributed.framework.DistributedDataFidelity` and :func:`deepinv.distributed.distribute` factory function. Supports multi-GPU/multi-process execution with physics-based and spatial tiling distribution strategies (:gh:`790`` by `Benoît Malézieux`_)
 - Add :class:`deepinv.loss.metric.CosineSimilarity` to the metrics (:gh:`944` by `Avithal Lautman`_)
 - New option to initialize 3D networks (DRUNet, DnCNN, DScCP) from pretrained 2D weights (:gh:`958` by `Romain Vo`_)
 - Add option to pass a noise level map to DRUNet and RAM (:gh:`1056` by `Thomas Boulanger`_)

--- a/docs/source/user_guide/distributed/reconstruction.rst
+++ b/docs/source/user_guide/distributed/reconstruction.rst
@@ -468,13 +468,13 @@ Key Classes
      - Description
    * - :class:`deepinv.distributed.DistributedContext`
      - Manages distributed execution, process groups, and devices
-   * - :class:`deepinv.distributed.DistributedStackedPhysics`
+   * - :class:`deepinv.distributed.framework.DistributedStackedPhysics`
      - Distributes physics operators across processes (auto-created by ``distribute()``)
-   * - :class:`deepinv.distributed.DistributedStackedLinearPhysics`
+   * - :class:`deepinv.distributed.framework.DistributedStackedLinearPhysics`
      - Extends DistributedStackedPhysics for linear operators with adjoint operations
-   * - :class:`deepinv.distributed.DistributedProcessing`
+   * - :class:`deepinv.distributed.framework.DistributedProcessing`
      - Distributes denoisers/priors using spatial tiling (auto-created by ``distribute()``)
-   * - :class:`deepinv.distributed.DistributedDataFidelity`
+   * - :class:`deepinv.distributed.framework.DistributedDataFidelity`
      - Distributes data fidelity `fn` and `grad`` (if needed, auto-created by ``distribute()``)
 
 **You typically won't need to instantiate these classes directly.** Use the :func:`deepinv.distributed.distribute()` function instead.

--- a/docs/source/user_guide/training/multigpu.rst
+++ b/docs/source/user_guide/training/multigpu.rst
@@ -32,4 +32,4 @@ Distributed Reconstruction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 DeepInverse also provides a simplified API for distributing DeepInverse objects across multiple devices and processes for reconstruction.
-See the :ref:`user guide on distributed reconstruction<distributed>` for more information.
+See the :ref:`user guide on distributed reconstruction<distributed-reconstruction>` for more information.


### PR DESCRIPTION
Prompted by #1289 , let's make relu's act in-place. Some nets (e.g. `scunet.py`) already did this. All of these `relu`s should be safe to make in-place.

Likely not a major impact on memory / compute, but every small part helps :)

Not sure if this needs an entry in changelog?

+ Fix the docs build error in ci right now

### Checks to be done before submitting your PR

- [x] `python3 -m pytest deepinv/tests` runs successfully.
- [x] `black .` and `ruff check .` run successfully.
- [x] `make html` runs successfully (in the `docs/` directory).
- [x] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.