### PR TITLE
fix(models): keep the offending mode char in conv()'s error message

### DIFF
--- a/deepinv/models/drunet.py
+++ b/deepinv/models/drunet.py
@@ -387,7 +387,7 @@ def conv(
         elif t == "A":
             L.append(avgpool_nd(dim)(kernel_size=kernel_size, stride=stride, padding=0))
         else:  # pragma: no cover
-            raise NotImplementedError("Undefined type: ".format(t))
+            raise NotImplementedError(f"Undefined type: {t}")
     return sequential(*L)
 
 

--- a/deepinv/models/ram.py
+++ b/deepinv/models/ram.py
@@ -1206,7 +1206,7 @@ def conv(
         elif t == "R":
             L.append(nn.ReLU(inplace=True))
         else:
-            raise NotImplementedError("Undefined type: ".format(t))
+            raise NotImplementedError(f"Undefined type: {t}")
     return sequential(*L)
 
 


### PR DESCRIPTION
### Problem

`deepinv/models/drunet.py:390` and `deepinv/models/ram.py:1209` both reject an unsupported `mode` character with

```python
raise NotImplementedError("Undefined type: ".format(t))
```

The literal has no `{}` placeholder, so `str.format` silently discards `t`. Passing a bad `mode` string to either `conv()` therefore produces an error message that does not say *which* character was rejected:

```
NotImplementedError: Undefined type:
```

pyflakes flags both as `'...'.format(...) has unused arguments at position(s): 0`.

### Fix

Use an f-string, matching the style of the neighbouring error messages in the same modules — e.g. `ram.py:1239`:

```python
raise ValueError(f"got mode {mode}, mode examples: 2, 2R, 2R, 3, ..., 4R.")
```

```diff
-            raise NotImplementedError("Undefined type: ".format(t))
+            raise NotImplementedError(f"Undefined type: {t}")
```

(The two sibling `NotImplementedError`s in `drunet.py` — `"downsample mode [{:s}] is not found".format(...)` at L98 and `"upsample mode [{:s}] is not found".format(...)` at L139 — show the intended shape; happy to switch to `"Undefined type: {:s}".format(t)` instead if you prefer to keep `.format` here.)

### Verification

`conv()` was AST-extracted from each source file and called with an unsupported mode character, before and after the patch:

```
[BEFORE] deepinv/models/drunet.py
[BEFORE]   NotImplementedError('Undefined type: ')
[BEFORE]   offending mode char present in message: False
[AFTER]    NotImplementedError('Undefined type: Z')
[AFTER]    offending mode char present in message: True

[BEFORE] deepinv/models/ram.py
[BEFORE]   NotImplementedError('Undefined type: ')
[BEFORE]   offending mode char present in message: False
[AFTER]    NotImplementedError('Undefined type: Z')
[AFTER]    offending mode char present in message: True
```

`black --check` and `ruff check` are clean on both files, before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
