### PR TITLE
Fix minor typo in MLEM demo

### DIFF
--- a/examples/optimization/demo_poisson_mlem.py
+++ b/examples/optimization/demo_poisson_mlem.py
@@ -3,14 +3,14 @@ Poisson Inverse Problems with Maximum-Likelihood Expectation-Maximization (MLEM)
 ====================================================================================================
 
 This example demonstrates how to solve Poisson inverse problems using the
-**Maximum-Likelihood Expectation-Maximization (MLEM)** algorithm :footcite:t:`sheppMaximumLikelihoodReconstruction1982`,
-also known as the Richardson-Lucy algorithm in the deconvolution setting :footcite:t:`richardsonBayesianBasedIterativeMethod1972,lucyIterativeTechniqueRectification1974`.
+**Maximum-Likelihood Expectation-Maximization (MLEM)** algorithm :footcite:p:`sheppMaximumLikelihoodReconstruction1982`,
+also known as the Richardson-Lucy algorithm in the deconvolution setting :footcite:p:`richardsonBayesianBasedIterativeMethod1972,lucyIterativeTechniqueRectification1974`.
 
 The Poisson observation model is:
 
 .. math::
 
-    y \sim \mathcal{P}\!\left(\frac{Ax}{\gamma}\right)
+    y \sim \gamma \mathcal{P}\!\left(\frac{Ax}{\gamma}\right)
 
 where :math:`A` is a linear forward operator, :math:`x \geq 0` is the image to recover,
 :math:`\gamma > 0` is the gain parameter, and :math:`\mathcal{P}` denotes the Poisson distribution.


### PR DESCRIPTION
Fixes #1385

Also switches two `:footcite:t:` to `:footcite:p:` for improved readability