### PR TITLE
fix(trainer): don't require check_grad=True to use grad_clip

### DIFF
--- a/deepinv/tests/test_trainer.py
+++ b/deepinv/tests/test_trainer.py
@@ -1072,6 +1072,50 @@ def test_gradient_norm(dummy_dataset, imsize, device, tmpdir, grad_clip):
         assert torch.linalg.vector_norm(torch.cat(grads), ord=2) <= grad_clip + 1e-1
 
 
+# Regression test for the crash reported in
+# https://github.com/deepinv/deepinv/issues/1387: ``check_grad_val`` is only
+# created when ``check_grad`` is True, but ``check_clip_grad`` returns a
+# non-None norm whenever ``grad_clip`` is set. Guarding the log line on the
+# returned norm therefore hit the missing attribute as soon as clipping was
+# requested on its own.
+def test_grad_clip_without_check_grad(dummy_dataset, imsize, device, tmpdir):
+    dataloader = DataLoader(dummy_dataset, batch_size=2)
+    physics = dinv.physics.Inpainting(img_size=imsize, device=device, mask=0.5)
+
+    backbone = dinv.models.UNet(in_channels=3, out_channels=3, scales=2)
+    model = dinv.models.ArtifactRemoval(backbone).to(device)
+
+    grad_clip = 0.5
+    trainer = dinv.Trainer(
+        model,
+        device=device,
+        save_path=tmpdir,
+        verbose=False,
+        show_progress_bar=False,
+        physics=physics,
+        epochs=1,
+        losses=dinv.loss.SupLoss(),
+        optimizer=torch.optim.AdamW(model.parameters(), lr=1e-3),
+        train_dataloader=dataloader,
+        online_measurements=True,
+        grad_clip=grad_clip,
+    )
+
+    # Used to raise AttributeError: 'Trainer' object has no attribute
+    # 'check_grad_val'.
+    trainer.train()
+
+    # The meter is still not created, and the gradient norm is not logged,
+    # since check_grad was left at its default.
+    assert not hasattr(trainer, "check_grad_val")
+
+    grads = [
+        p.grad.detach().flatten() for p in model.parameters() if p.grad is not None
+    ]
+    assert len(grads) > 0
+    assert torch.linalg.vector_norm(torch.cat(grads), ord=2) <= grad_clip + 1e-1
+
+
 # Test output directory collision detection
 # It is difficult to deterministically trigger actual collisions so we mock the
 # get_timestamp function used in the implementation to make it return the same

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -945,8 +945,8 @@ class Trainer:
                 and not step
             )
             if not defer_clip:
-                norm = self.check_clip_grad()
-                if norm is not None:
+                self.check_clip_grad()
+                if self.check_grad:
                     logs["gradient_norm"] = self.check_grad_val.avg
 
             if step:
@@ -1132,8 +1132,8 @@ class Trainer:
         if train and self.optimizer_step_multi_dataset:
             if self.scaler.is_enabled():
                 # Gradients from all datasets have now been accumulated
-                norm = self.check_clip_grad()
-                if norm is not None:
+                self.check_clip_grad()
+                if self.check_grad:
                     logs["gradient_norm"] = self.check_grad_val.avg
             self.scaler.step(self.optimizer)  # Optimizer step
             self.scaler.update()


### PR DESCRIPTION
Fixes #1387.

## The bug

`Trainer.check_clip_grad()` returns a non-`None` norm **whenever `grad_clip` is set**, independently of `check_grad`:

```python
# deepinv/training/trainer.py
def check_clip_grad(self):
    grad_norm = None
    if self.grad_clip is not None:
        self.scaler.unscale_(self.optimizer)
        grad_norm = torch.nn.utils.clip_grad_norm_(...)   # <- not None
    if self.check_grad:
        ...
        self.check_grad_val.update(grad_norm)
    return grad_norm
```

But `check_grad_val` is only created when `check_grad` is `True`:

```python
# setup_train, L527-529
if train and self.check_grad:
    self.check_grad_val = AverageMeter("Gradient norm", ":.2e")
```

Both call sites guarded the log line on the *returned norm* rather than on the flag that gates the meter's existence:

```python
norm = self.check_clip_grad()
if norm is not None:                                  # true just from grad_clip
    logs["gradient_norm"] = self.check_grad_val.avg   # AttributeError
```

so `Trainer(..., grad_clip=0.5)` with `check_grad` left at its default crashes on the first step, exactly as reported.

## The fix

Guard on `self.check_grad` at both call sites (`compute_loss` and the `optimizer_step_multi_dataset` branch of the step loop). The clipping itself still runs unconditionally — only the *logging* is now tied to the flag that creates the meter, which matches the documented meaning of `check_grad` ("Compute and print the gradient norm at each iteration").

`check_grad=True` behaviour is unchanged: when the flag is set, `check_clip_grad` assigns `grad_norm` in **both** of its branches, so the old `norm is not None` guard was already always true there.

Supporting evidence that the attribute is genuinely optional: `reset_metrics()` already defends it with `hasattr(self, "check_grad_val")`.

## Verification

I don't have a GPU box handy, so I replayed the real `check_clip_grad` source (AST-extracted from `trainer.py`) against real `torch`, with the meter created exactly as `setup_train` creates it, and ran the call site before and after the patch across the full 2x2 grid:

```
BEFORE check_grad=False grad_clip=0.5  -> AttributeError: no attribute 'check_grad_val'
BEFORE check_grad=True  grad_clip=0.5  -> logs={'gradient_norm': 5.490318}
BEFORE check_grad=True  grad_clip=None -> logs={'gradient_norm': 5.337699}
BEFORE check_grad=False grad_clip=None -> logs={}

AFTER  check_grad=False grad_clip=0.5  -> logs={}
AFTER  check_grad=True  grad_clip=0.5  -> logs={'gradient_norm': 5.475723}
AFTER  check_grad=True  grad_clip=None -> logs={'gradient_norm': 6.739681}
AFTER  check_grad=False grad_clip=None -> logs={}
```

Only the broken cell changes.

## Test

`test_gradient_norm` parametrizes `grad_clip` over `[None, 0.5]` but always passes `check_grad=True`, so the failing combination had no coverage. Added `test_grad_clip_without_check_grad`, which trains one epoch with `grad_clip=0.5` and the default `check_grad`, asserts it no longer raises, asserts the meter is still not created, and checks the gradients were actually clipped.

`black==26.5.1` and `ruff==0.15.20` (the pinned pre-commit revs, run against the repo's `pyproject.toml`) both pass on the two touched files.

## Alternative

If you would rather have the norm reported whenever it is computed, the other direction is to create `check_grad_val` when `grad_clip is not None` as well. That changes what shows up in the progress bar for existing `grad_clip` users, so I went with the smaller, behaviour-preserving option — happy to switch if you prefer the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
