### PR TITLE
Minor deprecation warnings clean-up

### DIFF
--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -1173,17 +1173,18 @@ def test_restoration_models(
 
     sigma = 0.02
 
-    # Recursively set the noise model sigma in the physics (and sub-physics)
-    for p in physics.modules():
-        if not isinstance(p, dinv.physics.Physics) or not hasattr(p, "noise_model"):
-            continue
+    if physics is not None:
+        # Recursively set the noise model sigma in the physics (and sub-physics)
+        for p in physics.modules():
+            if not isinstance(p, dinv.physics.Physics) or not hasattr(p, "noise_model"):
+                continue
 
-        if hasattr(p.noise_model, "sigma"):
-            p.noise_model.sigma = torch.tensor(
-                [max(p.noise_model.sigma, sigma)], device=device, dtype=dtype
-            )
-        else:
-            p.noise_model = dinv.physics.GaussianNoise(sigma)
+            if hasattr(p.noise_model, "sigma"):
+                p.noise_model.sigma = torch.tensor(
+                    [max(p.noise_model.sigma, sigma)], device=device, dtype=dtype
+                )
+            else:
+                p.noise_model = dinv.physics.GaussianNoise(sigma)
 
     x = DummyCircles(imsize=imsize, samples=2)
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -1171,27 +1171,21 @@ def test_restoration_models(
     else:
         physics = None
 
-    # A helper function to set sigma in physics noise models
-    def _set_sigma_physics(physics, sigma):
-        if hasattr(physics, "noise_model"):
-            if hasattr(physics.noise_model, "sigma"):
-                physics.noise_model.sigma = torch.tensor(
-                    [max(physics.noise_model.sigma, sigma)], device=device, dtype=dtype
-                )
-            else:
-                physics.noise_model = dinv.physics.GaussianNoise(sigma)
-
-        if physics is not None:
-            # recursively set sigma for noise models in composite physics
-            for attr in dir(physics):
-                sub_physics = getattr(physics, attr)
-                if isinstance(sub_physics, dinv.physics.Physics):
-                    _set_sigma_physics(sub_physics, sigma)
-        else:
-            pass
-
     sigma = 0.02
-    _set_sigma_physics(physics, sigma)
+
+    # Recursively set the noise model sigma in the physics (and sub-physics)
+    for p in physics.modules():
+        # Filter out sub-modules that are not sub-physics and sub-physics
+        # without a noise model
+        if not isinstance(p, dinv.physics.Physics) or not hasattr(p, "noise_model"):
+            continue
+
+        if hasattr(p.noise_model, "sigma"):
+            p.noise_model.sigma = torch.tensor(
+                [max(p.noise_model.sigma, sigma)], device=device, dtype=dtype
+            )
+        else:
+            p.noise_model = dinv.physics.GaussianNoise(sigma)
 
     x = DummyCircles(imsize=imsize, samples=2)
 

--- a/deepinv/tests/test_models.py
+++ b/deepinv/tests/test_models.py
@@ -1175,8 +1175,6 @@ def test_restoration_models(
 
     # Recursively set the noise model sigma in the physics (and sub-physics)
     for p in physics.modules():
-        # Filter out sub-modules that are not sub-physics and sub-physics
-        # without a noise model
         if not isinstance(p, dinv.physics.Physics) or not hasattr(p, "noise_model"):
             continue
 

--- a/deepinv/tests/test_physics.py
+++ b/deepinv/tests/test_physics.py
@@ -2496,7 +2496,7 @@ def test_multiscale_A_adjoint_A(name, device):
         img_size=imsize, A=op_cmp, A_adjoint=op_cmp
     )
 
-    error = physics_cmp.compute_norm(x_coarse).abs()
+    error = physics_cmp.compute_sqnorm(x_coarse).abs()
     assert error < 0.2
 
 


### PR DESCRIPTION
1. I use `compute_sqnorm` instead of the deprecated `compute_norm` with default `squared=True`
2. Rewrite sigma setting without traversing dir(physics) to avoid traversing `physics.device` which causes warnings

Towards #1007 