### PR TITLE
Fix inverse Homography

### DIFF
--- a/deepinv/transform/projective.py
+++ b/deepinv/transform/projective.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 from typing import Iterable
 
+import warnings
 import numpy as np
 import torch
 from PIL import Image
@@ -10,7 +11,7 @@ from PIL import Image
 from deepinv.transform.base import Transform, TransformParam
 
 
-def rotation_matrix(tx: float, ty: float, tz: float) -> np.ndarray:
+def rotation_matrix(tx: float, ty: float, tz: float, inverse: bool = False) -> np.ndarray:
     """Numpy implementation of ``scipy`` rotation matrix from Euler angles.
 
     Construct 3D extrinsic rotation matrix from x, y and z angles. This is equivalent of using the ``scipy`` function:
@@ -20,6 +21,7 @@ def rotation_matrix(tx: float, ty: float, tz: float) -> np.ndarray:
     :param float tx: x rotation in degrees
     :param float ty: y rotation in degrees
     :param float tz: z rotation in degrees
+    :param bool inverse: if True, return the inverse rotation matrix, defaults to False
     :return np.ndarray: 3D rotation matrix.
 
     .. note::
@@ -27,6 +29,9 @@ def rotation_matrix(tx: float, ty: float, tz: float) -> np.ndarray:
         This class requires the ``astra-toolbox`` package to be installed. Install with ``pip install astra-toolbox``.
     """
     tx, ty, tz = np.radians((tx, ty, tz))
+
+    if inverse:
+        tx, ty, tz = -tx, -ty, -tz
 
     # fmt: off
     Rx = np.array([
@@ -48,7 +53,12 @@ def rotation_matrix(tx: float, ty: float, tz: float) -> np.ndarray:
     ])
     # fmt: on
 
-    return Rz @ Ry @ Rx
+    if not inverse:
+        P = Rz @ Ry @ Rx
+    else:
+        P = Rx @ Ry @ Rz
+
+    return P
 
 
 def apply_homography(
@@ -62,6 +72,7 @@ def apply_homography(
     y_stretch_factor: float = 1.0,
     x_t: float = 0.0,
     y_t: float = 0.0,
+    inverse: bool = False,
     padding: str = "reflection",
     interpolation: str = "bilinear",
     verbose: bool = False,
@@ -123,12 +134,15 @@ def apply_homography(
     ])
     # fmt: on
 
-    R_dash = rotation_matrix(theta_x, theta_y, theta_z)
+    R_dash = rotation_matrix(theta_x, theta_y, theta_z, inverse=inverse)
 
     if isinstance(im, torch.Tensor):
         # note thetas defined in the opposite direction here, but it doesn't matter
         # for random transformations which have symmetric ranges about 0.
-        H_inverse = K @ R_dash @ np.linalg.inv(K_dash)
+        if not inverse:
+            H_inverse = K @ R_dash @ np.linalg.inv(K_dash)
+        else:
+            H_inverse = K_dash @ R_dash @ np.linalg.inv(K)
 
         if verbose:
             with np.printoptions(precision=2, suppress=True):
@@ -149,7 +163,10 @@ def apply_homography(
         elif interpolation == "nearest":
             pil_interp = Image.Resampling.NEAREST
 
-        H = K_dash @ R_dash @ np.linalg.inv(K)
+        if not inverse:
+            H = K_dash @ R_dash @ np.linalg.inv(K)
+        else:
+            H = K @ R_dash @ np.linalg.inv(K_dash)
 
         return im.transform(
             size=(im.size[0], im.size[1]),
@@ -273,6 +290,7 @@ class Homography(Transform):
                     skew=sk,
                     x_stretch_factor=xsf,
                     y_stretch_factor=ysf,
+                    inverse=False,
                     padding=self.padding,
                     interpolation=self.interpolation,
                     device=self.device,
@@ -292,6 +310,63 @@ class Homography(Transform):
             ],
             dim=0,
         ).float()
+
+    def invert_params(self, params: dict) -> dict:
+        warnings.warn(
+            f"Inverting f{self.__class__.__name__} parameters is not fully supported. Unlike other transforms, passing the inverted parameters to `transform` is (erroneously) not equivalent to passing the initial parameters to `inverse`.",
+            UserWarning,
+            stacklevel=1
+        )
+        return super().invert_params(params)
+
+    def inverse(self,
+                x: torch.Tensor,
+                batchwise: bool = True,
+                theta_x: torch.Tensor | Iterable | TransformParam = tuple(),
+                theta_y: torch.Tensor | Iterable | TransformParam = tuple(),
+                theta_z: torch.Tensor | Iterable | TransformParam = tuple(),
+                zoom_f: torch.Tensor | Iterable | TransformParam = tuple(),
+                shift_x: torch.Tensor | Iterable | TransformParam = tuple(),
+                shift_y: torch.Tensor | Iterable | TransformParam = tuple(),
+                skew: torch.Tensor | Iterable | TransformParam = tuple(),
+                stretch_x: torch.Tensor | Iterable | TransformParam = tuple(),
+                stretch_y: torch.Tensor | Iterable | TransformParam = tuple(),
+                **params,
+    ) -> torch.Tensor:
+        return torch.cat(
+            [
+                apply_homography(
+                    x.double(),
+                    theta_x=tx,
+                    theta_y=ty,
+                    theta_z=tz,
+                    zoom_factor=zf,
+                    x_t=xt,
+                    y_t=yt,
+                    skew=sk,
+                    x_stretch_factor=xsf,
+                    y_stretch_factor=ysf,
+                    inverse=True,
+                    padding=self.padding,
+                    interpolation=self.interpolation,
+                    device=self.device,
+                )
+                for tx, ty, tz, zf, xt, yt, sk, xsf, ysf in zip(
+                    theta_x,
+                    theta_y,
+                    theta_z,
+                    zoom_f,
+                    shift_x,
+                    shift_y,
+                    skew,
+                    stretch_x,
+                    stretch_y,
+                    strict=True,
+                )
+            ],
+            dim=0,
+        ).float()
+
 
 
 class Affine(Homography):

--- a/deepinv/transform/projective.py
+++ b/deepinv/transform/projective.py
@@ -11,7 +11,9 @@ from PIL import Image
 from deepinv.transform.base import Transform, TransformParam
 
 
-def rotation_matrix(tx: float, ty: float, tz: float, inverse: bool = False) -> np.ndarray:
+def rotation_matrix(
+    tx: float, ty: float, tz: float, inverse: bool = False
+) -> np.ndarray:
     """Numpy implementation of ``scipy`` rotation matrix from Euler angles.
 
     Construct 3D extrinsic rotation matrix from x, y and z angles. This is equivalent of using the ``scipy`` function:
@@ -315,23 +317,24 @@ class Homography(Transform):
         warnings.warn(
             f"Inverting f{self.__class__.__name__} parameters is not fully supported. Unlike other transforms, passing the inverted parameters to `transform` is (erroneously) not equivalent to passing the initial parameters to `inverse`.",
             UserWarning,
-            stacklevel=1
+            stacklevel=1,
         )
         return super().invert_params(params)
 
-    def inverse(self,
-                x: torch.Tensor,
-                batchwise: bool = True,
-                theta_x: torch.Tensor | Iterable | TransformParam = tuple(),
-                theta_y: torch.Tensor | Iterable | TransformParam = tuple(),
-                theta_z: torch.Tensor | Iterable | TransformParam = tuple(),
-                zoom_f: torch.Tensor | Iterable | TransformParam = tuple(),
-                shift_x: torch.Tensor | Iterable | TransformParam = tuple(),
-                shift_y: torch.Tensor | Iterable | TransformParam = tuple(),
-                skew: torch.Tensor | Iterable | TransformParam = tuple(),
-                stretch_x: torch.Tensor | Iterable | TransformParam = tuple(),
-                stretch_y: torch.Tensor | Iterable | TransformParam = tuple(),
-                **params,
+    def inverse(
+        self,
+        x: torch.Tensor,
+        batchwise: bool = True,
+        theta_x: torch.Tensor | Iterable | TransformParam = tuple(),
+        theta_y: torch.Tensor | Iterable | TransformParam = tuple(),
+        theta_z: torch.Tensor | Iterable | TransformParam = tuple(),
+        zoom_f: torch.Tensor | Iterable | TransformParam = tuple(),
+        shift_x: torch.Tensor | Iterable | TransformParam = tuple(),
+        shift_y: torch.Tensor | Iterable | TransformParam = tuple(),
+        skew: torch.Tensor | Iterable | TransformParam = tuple(),
+        stretch_x: torch.Tensor | Iterable | TransformParam = tuple(),
+        stretch_y: torch.Tensor | Iterable | TransformParam = tuple(),
+        **params,
     ) -> torch.Tensor:
         return torch.cat(
             [
@@ -366,7 +369,6 @@ class Homography(Transform):
             ],
             dim=0,
         ).float()
-
 
 
 class Affine(Homography):

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,6 +22,7 @@ Changed
 Fixed
 ^^^^^
 - Fix description of channels in documentation of :class:`deepinv.datasets.NBUDataset` and provide link for more information on the dataset (:gh:`1348` by `Delphine Doutsas`_)
+- Fix inversion in :class:`deepinv.transform.Homography` transforms (:gh:`1395` by `Jérémy Scanvic`_)
 
 
 v0.4.2


### PR DESCRIPTION
Fixes #1391 

- Override `inverse` similarly to `ChainTransform` to have the right inverse
- Add a warning that `invert_params` can't be used as is with `transform`

I checked that it makes the example from the issue work and also that it partially fixes the instability of `test_transform_identity` (there's another separate issue and I'll wrap this up in a separate PR)