### PR TITLE
List deepinv-benchmarks in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ examples/*/*.gif
 /docs/source/auto_benchmarks/*
 /docs/source/gen_modules/
 /docs/source/**/stubs/*
+/docs/source/deepinv-benchmarks/
 
 # Miscellaneous
 /experimental/


### PR DESCRIPTION
Fixes #1398

The results of running the benchmarks are stored in `docs/source/deepinv-benchmarks` which is currently not gitignored. In this PR, I remedy that
