### PR TITLE
Misc docs and example fixes

### DIFF
--- a/deepinv/physics/wrappers.py
+++ b/deepinv/physics/wrappers.py
@@ -107,7 +107,7 @@ class PhysicsMultiScaler(Physics):
         :param int, None scale: target scale in which to express `y`, if None, uses the value of the attribute `scale`, default: None
         """
         raise NotImplementedError(
-            f"The method 'downsample_measurement' should be overidden in subclasses of PhysicsMultiScaler to be used, but it is not implemented for {self.__class__.__name__}."
+            f"The method 'downsample_measurement' should be overridden in subclasses of PhysicsMultiScaler to be used, but it is not implemented for {self.__class__.__name__}."
         )
 
     def update_parameters(self, **kwargs):

--- a/deepinv/utils/io.py
+++ b/deepinv/utils/io.py
@@ -40,7 +40,8 @@ def load_tiff(fname: str | Path, dtype: torch.dtype | None = None) -> torch.Tens
 
     Integer images are normalized to the range ``[0, 1]`` by dividing by the
     maximum value representable by their dtype; floating point images are
-    loaded as-is. 2D images of shape `(H, W)` are loaded with a single channel,
+    cast as-is (values are preserved, but the dtype is recast to float64).
+    2D images of shape `(H, W)` are loaded with a single channel,
     and 3D arrays of shape `(H, W, C)` are converted to channel-first `(C, H, W)`.
     In both cases a leading batch dimension is added.
 
@@ -48,8 +49,12 @@ def load_tiff(fname: str | Path, dtype: torch.dtype | None = None) -> torch.Tens
         Requires `tifffile` to be installed. Install it with `pip install tifffile`.
 
     :param str, pathlib.Path fname: path to TIFF file or buffer.
-    :param torch.dtype dtype: if not ``None``, cast the output tensor to this dtype.
-    :return: :class:`torch.Tensor` of shape `(1, C, H, W)`.
+    :param torch.dtype dtype: if not ``None``, cast the output tensor to this dtype. If ``None``
+        (default), the tensor is returned as ``torch.float64`` regardless of the TIFF's
+        original dtype (e.g. a ``float32`` TIFF is upcast); pass ``dtype=torch.float32``
+        to match the dtype commonly used in the library and PyTorch.
+    :return: :class:`torch.Tensor` of shape `(1, C, H, W)` and dtype ``torch.float64`` unless
+        `dtype` is specified.
     """
     try:
         import tifffile

--- a/docs/source/_templates/benchmark_template.rst
+++ b/docs/source/_templates/benchmark_template.rst
@@ -22,11 +22,6 @@ Run this benchmark with
    results = run_benchmark(my_solver, "%%LABEL%%")
 
 
-.. warning::
-
-    Runtimes are only indicative and may vary depending on various factors which are not controlled in the benchmark.
-
-
 .. list-table::
    :class: sortable-table
    :header-rows: 1

--- a/docs/source/_templates/benchmark_template.rst
+++ b/docs/source/_templates/benchmark_template.rst
@@ -22,6 +22,11 @@ Run this benchmark with
    results = run_benchmark(my_solver, "%%LABEL%%")
 
 
+.. warning::
+
+    Runtimes are only indicative and may vary depending on various factors which are not controlled in the benchmark.
+
+
 .. list-table::
    :class: sortable-table
    :header-rows: 1

--- a/examples/optimization/demo_3D_denoising.py
+++ b/examples/optimization/demo_3D_denoising.py
@@ -1,5 +1,5 @@
 """
-3D denoising of a brain MRI volume with wavelet and TV priors
+3D denoising of brain MRI with wavelet and TV priors
 =============================================================
 
 This example shows how to use variational 3D denoisers for denoising a 3D image. We first apply a standard soft-thresholding

--- a/examples/optimization/demo_3D_denoising.py
+++ b/examples/optimization/demo_3D_denoising.py
@@ -1,6 +1,6 @@
 """
-3D denoising
-====================================================================================================
+3D denoising of a brain MRI volume with wavelet and TV priors
+=============================================================
 
 This example shows how to use variational 3D denoisers for denoising a 3D image. We first apply a standard soft-thresholding
 wavelet denoiser to a 3D brain MRI volume, as well as a 3D TV denoiser.

--- a/examples/optimization/demo_dip.py
+++ b/examples/optimization/demo_dip.py
@@ -102,18 +102,24 @@ dip = f(y, physics)
 x_lin = physics.A_adjoint(y)
 
 # compute PSNR
+psnr_measurement = dinv.metric.PSNR()(x, y).item()
 psnr_linear = dinv.metric.PSNR()(x, x_lin).item()
 psnr_dip = dinv.metric.PSNR()(x, dip).item()
 
 # plot results
 plot(
     {
+        "Ground Truth": x,
         "Measurement": y,
         "Linear": x_lin,
-        "Ground Truth": x,
         "DIP": dip,
     },
-    subtitles=["PSNR", f"{psnr_linear:.2f} dB", "", f"{psnr_dip:.2f} dB"],
+    subtitles=[
+        "PSNR",
+        f"{psnr_measurement:.2f} dB",
+        f"{psnr_linear:.2f} dB",
+        f"{psnr_dip:.2f} dB",
+    ],
 )
 
 # %%

--- a/examples/optimization/demo_dip.py
+++ b/examples/optimization/demo_dip.py
@@ -109,10 +109,11 @@ psnr_dip = dinv.metric.PSNR()(x, dip).item()
 plot(
     {
         "Measurement": y,
+        "Linear": x_lin,
         "Ground Truth": x,
         "DIP": dip,
     },
-    subtitles=["PSNR", f"{psnr_linear:.2f} dB", f"{psnr_dip:.2f} dB"],
+    subtitles=["PSNR", f"{psnr_linear:.2f} dB", "", f"{psnr_dip:.2f} dB"],
 )
 
 # %%


### PR DESCRIPTION
This PR:

- Addresses docs concerns in #1366
- Renames 3D denoising example to be less generic
- Fixes an issue with a plot in examples described [here](https://github.com/deepinv/deepinv/issues/431#issuecomment-5575549559)
- Fix random typo

<img width="1200" height="762" alt="image" src="https://github.com/user-attachments/assets/33e19bde-91ec-4974-bbdc-d2be29b50bf8" />


### Checks to be done before submitting your PR

- [ ] `python3 -m pytest deepinv/tests` runs successfully.
- [ ] `black .` and `ruff check .` run successfully.
- [ ] `make html` runs successfully (in the `docs/` directory).
- [ ] Updated docstrings related to the changes (as applicable).
- [ ] Added an entry to the [changelog.rst](https://github.com/deepinv/deepinv/blob/main/docs/source/changelog.rst).

### LLM policy

LLM usage is ok, but not PRs generated 100% by AI. See our [LLM policy](https://deepinv.org/contributing.html#llm-policy) Tick below as appropriate:

- [x] I did not use LLM tools to write the code
- [ ] I, a human, wrote code, and LLM tools helped me to write part of the code.
- [ ] An LLM tool wrote all of the code.
- [ ] An agent submitted the PR and wrote the description.