### PR TITLE
Transforms sandbox

### DIFF
--- a/deepinv/transform/augmentation.py
+++ b/deepinv/transform/augmentation.py
@@ -37,6 +37,10 @@ class RandomNoise(Transform):
         else:
             raise ValueError(f"Noise type {noise_type} not supported.")
 
+    @property
+    def order(self) -> float:
+        return float("inf")
+
     def _get_params(self, *args) -> dict:
         if isinstance(sr := self.sigma, tuple):
             sigma = (
@@ -80,6 +84,10 @@ class RandomPhaseError(Transform):
         super().__init__(*args, **kwargs)
         self.scale = scale
         self.flatten_video_input = False
+
+    @property
+    def order(self) -> float:
+        return float("inf")
 
     def _get_params(self, *args) -> dict:
         if isinstance(s := self.scale, tuple):

--- a/deepinv/transform/augmentation.py
+++ b/deepinv/transform/augmentation.py
@@ -41,6 +41,10 @@ class RandomNoise(Transform):
     def order(self) -> float:
         return float("inf")
 
+    @property
+    def sampling_kind(self) -> str:
+        return "with_replacement"
+
     def _get_params(self, *args) -> dict:
         if isinstance(sr := self.sigma, tuple):
             sigma = (
@@ -88,6 +92,10 @@ class RandomPhaseError(Transform):
     @property
     def order(self) -> float:
         return float("inf")
+
+    @property
+    def sampling_kind(self) -> str:
+        return "with_replacement"
 
     def _get_params(self, *args) -> dict:
         if isinstance(s := self.scale, tuple):

--- a/deepinv/transform/base.py
+++ b/deepinv/transform/base.py
@@ -169,9 +169,9 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
 
     def _check_x_5D(self, x: torch.Tensor) -> bool:
         """If x 4D (i.e. 2D image), return False, if 5D (e.g. with a time dim), return True, else raise Error"""
-        if len(x.shape) == 4:
+        if x.ndim == 4:
             return False
-        elif len(x.shape) == 5:
+        elif x.ndim == 5:
             return True
         else:
             raise ValueError("x must be either 4D or 5D.")

--- a/deepinv/transform/base.py
+++ b/deepinv/transform/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from functools import wraps
 from itertools import product
 from typing import Callable, Any
 import torch
@@ -167,15 +168,50 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
         :return str, None: ``"with_replacement"``, ``"without_replacement"``, or ``None``.
         """
 
-    def _check_x_5D(self, x: torch.Tensor) -> bool:
-        """If x 4D (i.e. 2D image), return False, if 5D (e.g. with a time dim), return True, else raise Error"""
-        if x.ndim == 4:
-            return False
-        elif x.ndim == 5:
-            return True
-        else:
-            raise ValueError("x must be either 4D or 5D.")
+    @staticmethod
+    def _handle_video_input(
+        video_output: bool,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Decorate a ``Transform`` method to transparently accept video (5D) input.
 
+        If ``x`` is a 5D tensor ``(B,C,T,H,W)`` and ``self.flatten_video_input`` is ``True``,
+        flattens the time dim into the channel dim before calling the decorated method. If
+        ``out``, the method's tensor output is then reshaped back to the original 5D shape
+        (use this when the method returns an image-shaped tensor, e.g. ``transform``; use
+        ``out=False`` when it returns something else, e.g. a params dict, as in ``get_params``).
+        Otherwise (4D input, or ``self.flatten_video_input=False``), the method is called unchanged.
+
+        :param bool out: whether to unflatten the decorated method's tensor output back to 5D.
+        :return Callable: decorator for a ``Transform`` method.
+        """
+
+        def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
+            @wraps(f)
+            def wrapped(self: Transform, x: torch.Tensor, *args, **kwargs):
+                if x.ndim == 4:
+                    video_input = False
+                elif x.ndim == 5:
+                    video_input = True
+                else:
+                    raise ValueError("Input must be either 4D or 5D.")
+
+                if self.flatten_video_input and video_input:
+                    shape = x.shape
+                    x = self.flatten_C(x)
+                    out = f(self, x, *args, **kwargs)
+                    if video_output:
+                        # The batch size might increase.
+                        out = out.reshape(-1, *shape[1:])
+                else:
+                    out = f(self, x, *args, **kwargs)
+
+                return out
+
+            return wrapped
+
+        return decorator
+
+    @_handle_video_input(video_output=False)
     def get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate transform parameters, one set per n_trans.
 
@@ -189,11 +225,7 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
         :param torch.Tensor x: input image
         :return dict: keyword args of transform parameters e.g. ``{'theta': 30}``
         """
-        return (
-            self._get_params(self.flatten_C(x))
-            if self._check_x_5D(x) and self.flatten_video_input
-            else self._get_params(x)
-        )
+        return self._get_params(x)
 
     def invert_params(self, params: dict) -> dict:
         """Invert transformation parameters. Pass variable of type ``TransformParam`` to override negation (e.g. to take reciprocal).
@@ -203,6 +235,7 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
         """
         return {k: -v for k, v in params.items()}
 
+    @_handle_video_input(video_output=True)
     def transform(self, x: torch.Tensor, **params) -> torch.Tensor:
         """Transform image given transform parameters.
 
@@ -212,12 +245,7 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
         :param params: parameters e.g. degrees or shifts provided as keyword args.
         :return: torch.Tensor: transformed image.
         """
-        transform = (
-            self.wrap_flatten_C(self._transform)
-            if self._check_x_5D(x) and self.flatten_video_input
-            else self._transform
-        )
-        return transform(x, **params)
+        return self._transform(x, **params)
 
     def forward(self, x: torch.Tensor, **params) -> torch.Tensor:
         """Perform random transformation on image.
@@ -316,7 +344,8 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
         :return Callable[[torch.Tensor, Any], torch.Tensor]: decorated function.
         """
 
-        def symmetrized(x, *args, **kwargs):
+        @self._handle_video_input(video_output=True)
+        def symmetrized(self, x, *args, **kwargs):
             params = self.get_params(x)
             if self.constant_shape and collate_batch:
                 # Collect over n_trans
@@ -339,11 +368,8 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
                     torch.stack(out, dim=1).mean(dim=1) if average else torch.cat(out)
                 )
 
-        return lambda x, *args, **kwargs: (
-            self.wrap_flatten_C(symmetrized)(x, *args, **kwargs)
-            if self._check_x_5D(x) and self.flatten_video_input
-            else symmetrized(x, *args, **kwargs)
-        )
+        # Bind self
+        return lambda *args, **kwargs: symmetrized(self, *args, **kwargs)
 
     def __mul__(self, other: Transform):
         """

--- a/deepinv/transform/base.py
+++ b/deepinv/transform/base.py
@@ -272,29 +272,43 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
             If False, params will attempt to match each image in batch to keep constant ``len(out)=len(x)``. No effect when ``n_trans==1``
         :return torch.Tensor: randomly transformed images
         """
-        inv_params = self.invert_params(self.get_params(x) if not params else params)
+        if not params:
+            params = self.get_params(x)
+
+        params = self.invert_params(params)
 
         if batchwise:
-            return self.transform(x, **inv_params)
+            out = self.transform(x, **params)
+        else:
+            B = x.shape[0]
 
-        if len(x) % self.n_trans != 0:  # pragma: no cover
-            raise ValueError(
-                f"batchwise=False requires len(x) to be divisible by n_trans, but got len(x)={len(x)} and n_trans={self.n_trans}. Set batchwise=True or adjust the batch size."
-            )
-        B = len(x) // self.n_trans
-        return torch.cat(
-            [
-                self.transform(
-                    x[i].unsqueeze(0),
-                    **{
-                        k: p[[i // B]]
-                        for k, p in inv_params.items()
-                        if len(p) == self.n_trans
-                    },
+            # Repeat params
+            n_trans = self.n_trans
+            if B % n_trans == 0:
+                n_reps = B // n_trans
+                params = {
+                    key: param.repeat_interleave(n_reps, dim=0)
+                    for key, param in params.items()
+                    if len(param) == n_trans
+                }
+            else:
+                raise ValueError(
+                    f"batchwise=False requires the batch size to be divisible by n_trans, but got {B} and n_trans={n_trans}. Set batchwise=True or adjust the batch size."
                 )
-                for i in range(len(x))
+
+            params_list = [
+                {key: param[i].unsqueeze(0) for key, param in params.items()}
+                for i in range(B)
             ]
-        )
+            out = torch.cat(
+                [
+                    self.transform(xi, **params_xi)
+                    for xi, params_xi in zip(
+                        x.split(1, dim=0), params_list, strict=True
+                    )
+                ]
+            )
+        return out
 
     def identity(self, x: torch.Tensor, average: bool = False) -> torch.Tensor:
         """Sanity check function that should do nothing.

--- a/deepinv/transform/base.py
+++ b/deepinv/transform/base.py
@@ -257,7 +257,10 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
         :param torch.Tensor x: input image of shape (B,C,H,W)
         :return torch.Tensor: randomly transformed images concatenated along the first dimension
         """
-        return self.transform(x, **(self.get_params(x) if not params else params))
+        if not params:
+            params = self.get_params(x)
+
+        return self.transform(x, **params)
 
     def inverse(self, x: torch.Tensor, batchwise=True, **params) -> torch.Tensor:
         """Perform random inverse transformation on image (i.e. when not a group).

--- a/deepinv/transform/base.py
+++ b/deepinv/transform/base.py
@@ -125,6 +125,20 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
         self.constant_shape = constant_shape
         self.flatten_video_input = flatten_video_input
 
+    @abstractmethod
+    def _get_params(self, x: torch.Tensor) -> dict:
+        """
+        Override this to implement a custom transform.
+        See ``get_params`` for details.
+        """
+
+    @abstractmethod
+    def _transform(self, x: torch.Tensor, **params) -> torch.Tensor:
+        """
+        Override this to implement a custom transform.
+        See ``transform`` for details.
+        """
+
     def _check_x_5D(self, x: torch.Tensor) -> bool:
         """If x 4D (i.e. 2D image), return False, if 5D (e.g. with a time dim), return True, else raise Error"""
         if len(x.shape) == 4:
@@ -133,13 +147,6 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
             return True
         else:
             raise ValueError("x must be either 4D or 5D.")
-
-    @abstractmethod
-    def _get_params(self, x: torch.Tensor) -> dict:
-        """
-        Override this to implement a custom transform.
-        See ``get_params`` for details.
-        """
 
     def get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate transform parameters, one set per n_trans.
@@ -167,13 +174,6 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
         :return dict: inverted parameters.
         """
         return {k: -v for k, v in params.items()}
-
-    @abstractmethod
-    def _transform(self, x: torch.Tensor, **params) -> torch.Tensor:
-        """
-        Override this to implement a custom transform.
-        See ``transform`` for details.
-        """
 
     def transform(self, x: torch.Tensor, **params) -> torch.Tensor:
         """Transform image given transform parameters.

--- a/deepinv/transform/base.py
+++ b/deepinv/transform/base.py
@@ -139,6 +139,21 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
         See ``transform`` for details.
         """
 
+    @property
+    @abstractmethod
+    def order(self) -> int | float | None:
+        """
+        Cardinal of the parameter space
+
+        Override this to declare the size of the parameter space that ``_get_params`` samples from.
+        Return ``float("inf")`` if the parameter space is infinite (e.g. continuous), or ``None`` if
+        the cardinal is unknown (e.g. it depends on quantities, such as the input shape, that aren't
+        available to this property).
+
+        :return int, float, None: cardinal of the parameter space, ``float("inf")`` if infinite,
+            or ``None`` if unknown.
+        """
+
     def _check_x_5D(self, x: torch.Tensor) -> bool:
         """If x 4D (i.e. 2D image), return False, if 5D (e.g. with a time dim), return True, else raise Error"""
         if len(x.shape) == 4:
@@ -335,6 +350,12 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
                 self.t2 = t2
                 self.constant_shape = t1.constant_shape and t2.constant_shape
 
+            @property
+            def order(self) -> int | float | None:
+                if self.t1.order is None or self.t2.order is None:
+                    return None
+                return self.t1.order * self.t2.order
+
             def _get_params(self, x: torch.Tensor) -> dict:
                 return self.t1._get_params(x) | self.t2._get_params(x)
 
@@ -380,6 +401,12 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
                 self.t1 = t1
                 self.t2 = t2
 
+            @property
+            def order(self) -> int | float | None:
+                if self.t1.order is None or self.t2.order is None:
+                    return None
+                return self.t1.order * self.t2.order
+
             def _get_params(self, x: torch.Tensor) -> dict:
                 return self.t1._get_params(x) | self.t2._get_params(x)
 
@@ -413,6 +440,12 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
                 self.t1 = t1
                 self.t2 = t2
                 self.recent_choice = None
+
+            @property
+            def order(self) -> int | float | None:
+                if self.t1.order is None or self.t2.order is None:
+                    return None
+                return self.t1.order + self.t2.order
 
             def _get_params(self, x: torch.Tensor) -> dict:
                 return self.t1._get_params(x) | self.t2._get_params(x)
@@ -450,6 +483,10 @@ class Identity(Transform):
     """
     Identity transform i.e. trivial group.
     """
+
+    @property
+    def order(self) -> int:
+        return 1
 
     def _get_params(self, *args):
         return {}

--- a/deepinv/transform/base.py
+++ b/deepinv/transform/base.py
@@ -154,6 +154,19 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
             or ``None`` if unknown.
         """
 
+    @property
+    @abstractmethod
+    def sampling_kind(self) -> str | None:
+        """
+         Sampling kind (with or without replacement)
+
+         Depending whether sampling on the parameter space is done with (iid)
+         or without replacement, the property takes the value ``"with_replacement"`` or
+         ``"without_replacement"``, and ``None`` if neither applies.
+
+        :return str, None: ``"with_replacement"``, ``"without_replacement"``, or ``None``.
+        """
+
     def _check_x_5D(self, x: torch.Tensor) -> bool:
         """If x 4D (i.e. 2D image), return False, if 5D (e.g. with a time dim), return True, else raise Error"""
         if len(x.shape) == 4:
@@ -356,6 +369,14 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
                     return None
                 return self.t1.order * self.t2.order
 
+            @property
+            def sampling_kind(self) -> str | None:
+                if self.t1.sampling_kind == self.t2.sampling_kind == "with_replacement":
+                    kind = "with_replacement"
+                else:
+                    kind = None
+                return kind
+
             def _get_params(self, x: torch.Tensor) -> dict:
                 return self.t1._get_params(x) | self.t2._get_params(x)
 
@@ -407,6 +428,14 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
                     return None
                 return self.t1.order * self.t2.order
 
+            @property
+            def sampling_kind(self) -> str | None:
+                if self.t1.sampling_kind == self.t2.sampling_kind == "with_replacement":
+                    kind = "with_replacement"
+                else:
+                    kind = None
+                return kind
+
             def _get_params(self, x: torch.Tensor) -> dict:
                 return self.t1._get_params(x) | self.t2._get_params(x)
 
@@ -446,6 +475,14 @@ class Transform(torch.nn.Module, TimeMixin, ABC):
                 if self.t1.order is None or self.t2.order is None:
                     return None
                 return self.t1.order + self.t2.order
+
+            @property
+            def sampling_kind(self) -> str | None:
+                if self.t1.sampling_kind == self.t2.sampling_kind == "with_replacement":
+                    kind = "with_replacement"
+                else:
+                    kind = None
+                return kind
 
             def _get_params(self, x: torch.Tensor) -> dict:
                 return self.t1._get_params(x) | self.t2._get_params(x)
@@ -487,6 +524,10 @@ class Identity(Transform):
     @property
     def order(self) -> int:
         return 1
+
+    @property
+    def sampling_kind(self) -> str:
+        return "with_replacement"
 
     def _get_params(self, *args):
         return {}

--- a/deepinv/transform/base.py
+++ b/deepinv/transform/base.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from abc import ABC, abstractmethod
 from itertools import product
 from typing import Callable, Any
 import torch
@@ -26,7 +27,7 @@ class TransformParam(torch.Tensor):
         return TransformParam(xi, neg=self._neg) if hasattr(self, "_neg") else xi
 
 
-class Transform(torch.nn.Module, TimeMixin):
+class Transform(torch.nn.Module, TimeMixin, ABC):
     r"""
     Base class for image transforms.
 
@@ -133,12 +134,12 @@ class Transform(torch.nn.Module, TimeMixin):
         else:
             raise ValueError("x must be either 4D or 5D.")
 
+    @abstractmethod
     def _get_params(self, x: torch.Tensor) -> dict:
         """
         Override this to implement a custom transform.
         See ``get_params`` for details.
         """
-        return NotImplementedError()
 
     def get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate transform parameters, one set per n_trans.
@@ -167,12 +168,12 @@ class Transform(torch.nn.Module, TimeMixin):
         """
         return {k: -v for k, v in params.items()}
 
+    @abstractmethod
     def _transform(self, x: torch.Tensor, **params) -> torch.Tensor:
         """
         Override this to implement a custom transform.
         See ``transform`` for details.
         """
-        return NotImplementedError()
 
     def transform(self, x: torch.Tensor, **params) -> torch.Tensor:
         """Transform image given transform parameters.

--- a/deepinv/transform/diffeomorphism.py
+++ b/deepinv/transform/diffeomorphism.py
@@ -67,6 +67,10 @@ class CPABDiffeomorphism(Transform):
             override=override,
         )
 
+    @property
+    def order(self) -> float:
+        return float("inf")
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Generate random diffeomorphism parameters.
 

--- a/deepinv/transform/diffeomorphism.py
+++ b/deepinv/transform/diffeomorphism.py
@@ -71,6 +71,10 @@ class CPABDiffeomorphism(Transform):
     def order(self) -> float:
         return float("inf")
 
+    @property
+    def sampling_kind(self) -> str:
+        return "with_replacement"
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Generate random diffeomorphism parameters.
 

--- a/deepinv/transform/projective.py
+++ b/deepinv/transform/projective.py
@@ -244,6 +244,10 @@ class Homography(Transform):
     def order(self) -> float:
         return float("inf")
 
+    @property
+    def sampling_kind(self) -> str:
+        return "with_replacement"
+
     def rand(self, maxi: float, mini: float = None) -> torch.Tensor:
         if mini is None:
             mini = -maxi

--- a/deepinv/transform/projective.py
+++ b/deepinv/transform/projective.py
@@ -240,6 +240,10 @@ class Homography(Transform):
     def __post_init__(self, *args, **kwargs):
         super().__init__(*args, n_trans=self.n_trans, rng=self.rng, **kwargs)
 
+    @property
+    def order(self) -> float:
+        return float("inf")
+
     def rand(self, maxi: float, mini: float = None) -> torch.Tensor:
         if mini is None:
             mini = -maxi

--- a/deepinv/transform/reflect.py
+++ b/deepinv/transform/reflect.py
@@ -32,6 +32,10 @@ class Reflect(Transform):
     def order(self) -> int:
         return 2 ** len(self.dim)
 
+    @property
+    def sampling_kind(self) -> str:
+        return "without_replacement"
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate sets of reflection axes without replacement.
 

--- a/deepinv/transform/reflect.py
+++ b/deepinv/transform/reflect.py
@@ -28,6 +28,10 @@ class Reflect(Transform):
         super().__init__(*args, **kwargs)
         self.dim = dim
 
+    @property
+    def order(self) -> int:
+        return 2 ** len(self.dim)
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate sets of reflection axes without replacement.
 

--- a/deepinv/transform/rotate.py
+++ b/deepinv/transform/rotate.py
@@ -57,6 +57,11 @@ class Rotate(Transform):
             else interpolation_mode
         )
 
+    @property
+    def order(self) -> int:
+        n = len(torch.arange(0, self.limits, self.multiples))
+        return n if self.positive else 2 * n
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate rotation parameters.
 

--- a/deepinv/transform/rotate.py
+++ b/deepinv/transform/rotate.py
@@ -62,6 +62,10 @@ class Rotate(Transform):
         n = len(torch.arange(0, self.limits, self.multiples))
         return n if self.positive else 2 * n
 
+    @property
+    def sampling_kind(self) -> str:
+        return "without_replacement"
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate rotation parameters.
 

--- a/deepinv/transform/scale.py
+++ b/deepinv/transform/scale.py
@@ -65,6 +65,10 @@ class Scale(Transform):
     def order(self) -> float:
         return float("inf")
 
+    @property
+    def sampling_kind(self) -> str:
+        return "with_replacement"
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate scale factor parameters.
 

--- a/deepinv/transform/scale.py
+++ b/deepinv/transform/scale.py
@@ -61,6 +61,10 @@ class Scale(Transform):
         self.padding_mode = padding_mode
         self.mode = mode
 
+    @property
+    def order(self) -> float:
+        return float("inf")
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate scale factor parameters.
 

--- a/deepinv/transform/shift.py
+++ b/deepinv/transform/shift.py
@@ -27,6 +27,10 @@ class Shift(Transform):
         # It depends on the input size.
         return None
 
+    @property
+    def sampling_kind(self) -> str:
+        return "without_replacement"
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate shift parameters.
 

--- a/deepinv/transform/shift.py
+++ b/deepinv/transform/shift.py
@@ -22,6 +22,11 @@ class Shift(Transform):
         super().__init__(*args, **kwargs)
         self.shift_max = shift_max
 
+    @property
+    def order(self) -> None:
+        # It depends on the input size.
+        return None
+
     def _get_params(self, x: torch.Tensor) -> dict:
         """Randomly generate shift parameters.
 

--- a/deepinv/transform/temporal.py
+++ b/deepinv/transform/temporal.py
@@ -26,6 +26,11 @@ class ShiftTime(Transform):
                 f"padding must be one of ('reflect', 'wrap'), got {padding}"
             )
 
+    @property
+    def order(self) -> None:
+        # Depends on the number of input frames.
+        return None
+
     def roll_reflect_1d(self, x: torch.Tensor, by: int = 0, dim: int = 0):
         """Roll in one dimension with reflect padding.
 

--- a/deepinv/transform/temporal.py
+++ b/deepinv/transform/temporal.py
@@ -31,6 +31,10 @@ class ShiftTime(Transform):
         # Depends on the number of input frames.
         return None
 
+    @property
+    def sampling_kind(self) -> str:
+        return "without_replacement"
+
     def roll_reflect_1d(self, x: torch.Tensor, by: int = 0, dim: int = 0):
         """Roll in one dimension with reflect padding.
 


### PR DESCRIPTION
This PR is a sandbox for prototyping & discussing potential changes to the transforms module - in particular towards #973 

**Goal**

Improve the structure of the transforms module without adding, removing or altering features

**Core design principles**

An instance of Transform is associated with a family of functions indexed by a parameter space along with a sampling function

The parameter space sometimes has a semigroup or group structure _approximately_ compatible with composition

The sampling function is associated with a preferred distribution on the parameter space and is always either sampling with or without replacement of multiple random parameters

**Possible changes**

- ab547257ab43660e946a74c4d79d534ef092c1a1 Make Transform an abstract base class (see #373)
- 3c6831faf8ffd804e62984812002671979617959 Add a property order for the cardinal of the parameter space if known
- fa0b483b37545c5205ec25b809a5ba889bcef743 Add a property sampling kind for whether sampling is with (iid) or without replacement
- fa13812e0216cf3e6d7536c2a4ea22df52edcca9 Have a single decorator for everything related to video inputs