### PR TITLE
Make shifts implementation parallel

### DIFF
--- a/deepinv/transform/shift.py
+++ b/deepinv/transform/shift.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from typing import Iterable
-from itertools import zip_longest
 import torch
 from deepinv.transform.base import Transform, TransformParam
 
@@ -38,14 +37,14 @@ class Shift(Transform):
                 torch.randperm(2 * W_max, generator=self.rng, device=self.rng.device)
             ][: self.n_trans]
             if W_max > 0
-            else torch.zeros(self.n_trans, device=x.device)
+            else torch.zeros(self.n_trans, device=x.device, dtype=torch.long)
         )
         y_shift = (
             torch.arange(-H_max, H_max, device=self.rng.device)[
                 torch.randperm(2 * H_max, generator=self.rng, device=self.rng.device)
             ][: self.n_trans]
             if H_max > 0
-            else torch.zeros(self.n_trans, device=x.device)
+            else torch.zeros(self.n_trans, device=x.device, dtype=torch.long)
         )
 
         return {"x_shift": x_shift, "y_shift": y_shift}
@@ -64,10 +63,40 @@ class Shift(Transform):
         :param torch.Tensor, list y_shift: iterable of shifts in y direction, one per ``n_trans``.
         :return: torch.Tensor: transformed image.
         """
-        return torch.cat(
-            [
-                torch.roll(x, [sy, sx], [-2, -1])
-                for sy, sx in zip_longest(y_shift, x_shift, fillvalue=0)
-            ],
-            dim=0,
-        )
+        # Convert input and params to tensors
+        x_shift = torch.as_tensor(x_shift, device=x.device)
+        y_shift = torch.as_tensor(y_shift, device=x.device)
+
+        # Pad x_shift and y_shift in case they're not the same length
+        N_y = y_shift.shape[0]
+        N_x = x_shift.shape[0]
+        N = max(N_y, N_x)
+        _y_shift = torch.zeros(N, device=x.device, dtype=y_shift.dtype)
+        _x_shift = torch.zeros(N, device=x.device, dtype=x_shift.dtype)
+        _y_shift[:N_y] = y_shift
+        _x_shift[:N_x] = x_shift
+        y_shift = _y_shift
+        x_shift = _x_shift
+
+        # Prepare input and params for batch-wise transform
+        B = x.shape[0]
+        x = x.repeat(N, *((x.ndim - 1) * [1]))
+        y_shift = y_shift.repeat_interleave(B, dim=0)
+        x_shift = x_shift.repeat_interleave(B, dim=0)
+
+        # Build the indices for torch.gather
+        shape = x.shape
+        B, H, W = shape[0], shape[-2], shape[-1]
+        index_y = torch.arange(H, device=x.device)
+        index_x = torch.arange(W, device=x.device)
+        index_y = index_y.view(1, -1).repeat(B, 1)
+        index_x = index_x.view(1, -1).repeat(B, 1)
+        y_shift = y_shift.view(-1, 1).repeat(1, H)
+        x_shift = x_shift.view(-1, 1).repeat(1, W)
+        index_y = (index_y - y_shift) % H
+        index_x = (index_x - x_shift) % W
+        index_y = index_y.view(B, *((x.ndim - 3) * [1]), H, 1).expand(shape)
+        index_x = index_x.view(B, *((x.ndim - 3) * [1]), 1, W).expand(shape)
+
+        # Apply the shifts
+        return x.gather(dim=-2, index=index_y).gather(dim=-1, index=index_x)

--- a/deepinv/transform/shift.py
+++ b/deepinv/transform/shift.py
@@ -64,8 +64,8 @@ class Shift(Transform):
         :return: torch.Tensor: transformed image.
         """
         # Convert input and params to tensors
-        x_shift = torch.as_tensor(x_shift, device=x.device)
-        y_shift = torch.as_tensor(y_shift, device=x.device)
+        x_shift = torch.as_tensor(x_shift, device=x.device, dtype=torch.long)
+        y_shift = torch.as_tensor(y_shift, device=x.device, dtype=torch.long)
 
         # Pad x_shift and y_shift in case they're not the same length
         N_y = y_shift.shape[0]

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -21,6 +21,7 @@ New Features
 Changed
 ^^^^^^^
 - Remove dependency on timm for SwinIR and SCUNet (:gh:`1304` by `Vicky De Ridder`_)
+- Make the implementation of :class:`deepinv.transform.Shift` parallel with respect to the number of transforms (:gh:`1408` by `Jérémy Scanvic`_)
 
 Fixed
 ^^^^^


### PR DESCRIPTION
The current implementation of Shift is sequential in the number of transformations. I suggest to make it parallel

I do so by swapping the more specific torch.roll for the more general torch.gather

I also fix a negligible bug flagged by Claude when shift_max = 0.0 - in that case, we end up with float tensors instead of int tensors due to torch.zeros defaulting to floats (very unlikely to be ever triggered)

**Backwards compatibility**

I made sure the change is backwards compatible - notably:
-  I made sure that it is the params that are interleaved instead of the input (transformations of the same image end up far away from each other in memory) which is the current behavior
- I made sure the zip_longest quirk is preserved